### PR TITLE
Release 0.1.7

### DIFF
--- a/Bloombox.podspec
+++ b/Bloombox.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "Bloombox"
   s.swift_version = "4.2"
-  s.version       = "0.1.6"
+  s.version       = "0.1.7"
   s.summary       = "Client for Bloombox Cloud APIs"
   s.description   = <<-DESC
 Native Swift client for accessing Bloombox Cloud APIs
@@ -30,8 +30,8 @@ Native Swift client for accessing Bloombox Cloud APIs
   s.source_files = 'Sources/Client/*.swift'
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.dependency 'OpenCannabis', '~> 0.1.6'
-  s.dependency 'BloomboxServices', '~> 0.1.6'
+  s.dependency 'OpenCannabis', '~> 0.1.7'
+  s.dependency 'BloomboxServices', '~> 0.1.7'
   s.dependency 'SwiftProtobuf'
   s.dependency 'SwiftGRPC'
 

--- a/BloomboxServices.podspec
+++ b/BloomboxServices.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "BloomboxServices"
   s.swift_version = "4.2"
-  s.version       = "0.1.6"
+  s.version       = "0.1.7"
   s.summary       = "Service definitions for Bloombox Cloud APIs"
   s.description   = <<-DESC
 Compiled low-level service definitions for Bloombox Cloud APIs. Usually usable with
@@ -31,7 +31,7 @@ the Bloombox client library for Swift.
   s.source_files = 'Sources/Services/*.swift'
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.dependency 'OpenCannabis', '~> 0.1.6'
+  s.dependency 'OpenCannabis', '~> 0.1.7'
   s.dependency 'SwiftProtobuf'
   s.dependency 'SwiftGRPC'
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 
 SCHEMA ?= Schema/
-VERSION ?= 0.1.6
+VERSION ?= 0.1.7
 SCHEMA_BRANCH ?= master
 SWIFT_GRPC ?= SwiftGRPC
 

--- a/OpenCannabis.podspec
+++ b/OpenCannabis.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "OpenCannabis"
   s.swift_version = "4.2"
-  s.version       = "0.1.6"
+  s.version       = "0.1.7"
   s.summary       = "OpenCannabis for Swift"
   s.description   = <<-DESC
 Native Swift codegen and bindings for OpenCannabis

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ inhibit_all_warnings!
 target 'YourProject' do
   use_frameworks!
 
-  pod 'OpenCannabis', '~> 0.1.6'
-  pod 'Bloombox', '~> 0.1.6'
+  pod 'OpenCannabis', '~> 0.1.7'
+  pod 'Bloombox', '~> 0.1.7'
 end
 ```
 
@@ -40,12 +40,12 @@ let package = Package(
     /// ...
 
     dependencies: [
-        .package(url: "https://github.com/bloombox/swift", .upToNextMinor(from: "0.1.6"))])
+        .package(url: "https://github.com/bloombox/swift", .upToNextMinor(from: "0.1.7"))])
 ```
 
 Via **Carthage**:
 ```
-github "bloombox/swift" ~> 0.1.6
+github "bloombox/swift" ~> 0.1.7
 ```
 
 

--- a/Sources/Client/AuthClient.swift
+++ b/Sources/Client/AuthClient.swift
@@ -242,6 +242,7 @@ public final class AuthClient: RemoteService {
   /// - Parameter callback: Callback to dispatch once a nonce or a fatal error is available.
   /// - Returns: RPC call object, which may be used to observe and cancel the underlying RPC call.
   /// - Throws: Client-side errors only, since this method is async. Server side methods occur in the callback.
+  @discardableResult
   public func nonce(apiKey: APIKey? = nil, _ callback: @escaping AuthNonceCallback) throws -> AuthNonceCall {
     let (_, _, apiKey) = try resolveContext(nil, nil, apiKey, enforcePartnerLocation: false)
     return try self.service(apiKey).nonce(Empty()) { response, callResult in
@@ -293,6 +294,7 @@ public final class AuthClient: RemoteService {
   /// - Parameter callback: Response callback to dispatch once a response or error is ready.
   /// - Returns: RPC call object, which can be used
   /// - Throws: Client and server-side errors, since this method is synchronous.
+  @discardableResult
   public func connect(identity: VerifiedIdentityToken,
                       withPublicKey publicKey: UserPublicKey,
                       andNonce nonce: NonceValue,

--- a/Sources/Client/Bindings.swift
+++ b/Sources/Client/Bindings.swift
@@ -373,6 +373,16 @@ public typealias MediaPrivacy = Opencannabis_Media_MediaPrivacy
 public typealias MediaSubject = Opencannabis_Media_MediaSubject
 public typealias MediaReference = Opencannabis_Media_MediaReference
 public typealias MediaOrientation = Opencannabis_Media_MediaOrientation
+public typealias PersonName = Opencannabis_Person_Name
+public typealias PhoneNumber = Opencannabis_Contact_PhoneNumber
+public typealias EmailAddress = Opencannabis_Contact_EmailAddress
+public typealias Passport = Bloombox_Schema_Identity_Ids_Passport
+public typealias ID = Bloombox_Schema_Identity_ID
+public typealias IDType = Bloombox_Schema_Identity_IDType
+public typealias USDL = Bloombox_Schema_Identity_Ids_USDL
+public typealias USDLField = Bloombox_Schema_Identity_Ids_USDLField
+public typealias TemporalDate = Opencannabis_Temporal_Date
+public typealias USDLFieldValue = Bloombox_Schema_Identity_Ids_USDLFieldValue
 
 @available(*, deprecated)
 public typealias PartnerLocationKey = Bloombox_Schema_Partner_LocationKey


### PR DESCRIPTION
This changeset introduces release `0.1.7`, with small bugfix-style changes that clear up warnings.

- [x] Add `discardableResult` to async methods
- [x] Map some type aliases that were missing
- [x] Bump versions all around -> `0.1.7`