### PR TITLE
Release: 0.2.0

### DIFF
--- a/Bloombox.podspec
+++ b/Bloombox.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "Bloombox"
   s.swift_version = "4.2"
-  s.version       = "0.1.10"
+  s.version       = "0.2.0"
   s.summary       = "Client for Bloombox Cloud APIs"
   s.description   = <<-DESC
 Native Swift client for accessing Bloombox Cloud APIs
@@ -30,8 +30,8 @@ Native Swift client for accessing Bloombox Cloud APIs
   s.source_files = 'Sources/Client/*.swift'
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.dependency 'OpenCannabis', '~> 0.1.10'
-  s.dependency 'BloomboxServices', '~> 0.1.10'
+  s.dependency 'OpenCannabis', '~> 0.2.0'
+  s.dependency 'BloomboxServices', '~> 0.2.0'
   s.dependency 'SwiftProtobuf'
   s.dependency 'SwiftGRPC'
 

--- a/Bloombox.xcodeproj/project.pbxproj
+++ b/Bloombox.xcodeproj/project.pbxproj
@@ -1,7274 +1,14952 @@
 // !$*UTF8*$!
 {
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXAggregateTarget section */
-		"Bloombox::BloomboxPackageTests::ProductTarget" /* BloomboxPackageTests */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_1357 /* Build configuration list for PBXAggregateTarget "BloomboxPackageTests" */;
-			buildPhases = (
-			);
-			dependencies = (
-				OBJ_1360 /* PBXTargetDependency */,
-				OBJ_1362 /* PBXTargetDependency */,
-			);
-			name = BloomboxPackageTests;
-			productName = BloomboxPackageTests;
-		};
-/* End PBXAggregateTarget section */
-
-/* Begin PBXBuildFile section */
-		222EF14721C6FBE90008D96B /* IdentityClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222EF14621C6FBE90008D96B /* IdentityClient.swift */; };
-		222EF14C21C7268D0008D96B /* identity_bioprint_Aspects.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222EF14821C7268C0008D96B /* identity_bioprint_Aspects.pb.swift */; };
-		222EF14D21C7268D0008D96B /* identity_bioprint_Weights.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222EF14921C7268C0008D96B /* identity_bioprint_Weights.pb.swift */; };
-		222EF14E21C7268D0008D96B /* identity_bioprint_Affinities.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222EF14A21C7268D0008D96B /* identity_bioprint_Affinities.pb.swift */; };
-		222EF14F21C7268D0008D96B /* identity_bioprint_Bioprint.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222EF14B21C7268D0008D96B /* identity_bioprint_Bioprint.pb.swift */; };
-		OBJ_1312 /* AuthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* AuthClient.swift */; };
-		OBJ_1313 /* Bindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Bindings.swift */; };
-		OBJ_1314 /* Bloombox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Bloombox.swift */; };
-		OBJ_1315 /* DevicesClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* DevicesClient.swift */; };
-		OBJ_1316 /* EventCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* EventCollection.swift */; };
-		OBJ_1317 /* EventContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* EventContext.swift */; };
-		OBJ_1318 /* MenuClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* MenuClient.swift */; };
-		OBJ_1319 /* POSClient+AuthorizeUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* POSClient+AuthorizeUser.swift */; };
-		OBJ_1320 /* POSClient+Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* POSClient+Session.swift */; };
-		OBJ_1321 /* POSClient+VerifyTicketKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* POSClient+VerifyTicketKey.swift */; };
-		OBJ_1322 /* POSClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* POSClient.swift */; };
-		OBJ_1323 /* PlatformClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* PlatformClient.swift */; };
-		OBJ_1324 /* RPCLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* RPCLogic.swift */; };
-		OBJ_1325 /* RemoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* RemoteService.swift */; };
-		OBJ_1326 /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Services.swift */; };
-		OBJ_1327 /* ShopClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* ShopClient.swift */; };
-		OBJ_1328 /* TelemetryClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* TelemetryClient.swift */; };
-		OBJ_1329 /* TelemetryService+Generic.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* TelemetryService+Generic.swift */; };
-		OBJ_1330 /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* Transport.swift */; };
-		OBJ_1332 /* BloomboxServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Bloombox::BloomboxServices::Product" /* BloomboxServices.framework */; };
-		OBJ_1333 /* SwiftGRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::SwiftGRPC::Product" /* SwiftGRPC.framework */; };
-		OBJ_1334 /* CgRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::CgRPC::Product" /* CgRPC.framework */; };
-		OBJ_1335 /* BoringSSL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::BoringSSL::Product" /* BoringSSL.framework */; };
-		OBJ_1336 /* OpenCannabis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Bloombox::OpenCannabis::Product" /* OpenCannabis.framework */; };
-		OBJ_1337 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftProtobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
-		OBJ_1355 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
-		OBJ_1368 /* AuthService_Beta1.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* AuthService_Beta1.grpc.swift */; };
-		OBJ_1369 /* DevicesService_Beta1.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* DevicesService_Beta1.grpc.swift */; };
-		OBJ_1370 /* IdentityService_Beta1.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* IdentityService_Beta1.grpc.swift */; };
-		OBJ_1371 /* MediaService_Beta1.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* MediaService_Beta1.grpc.swift */; };
-		OBJ_1372 /* MenuService_Beta1.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* MenuService_Beta1.grpc.swift */; };
-		OBJ_1373 /* POSService_Beta1.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* POSService_Beta1.grpc.swift */; };
-		OBJ_1374 /* PlatformService_v1.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* PlatformService_v1.grpc.swift */; };
-		OBJ_1375 /* ShopService_v1.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_36 /* ShopService_v1.grpc.swift */; };
-		OBJ_1376 /* TelemetryService_Beta4.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* TelemetryService_Beta4.grpc.swift */; };
-		OBJ_1377 /* WalletService_v1.grpc.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* WalletService_v1.grpc.swift */; };
-		OBJ_1379 /* SwiftGRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::SwiftGRPC::Product" /* SwiftGRPC.framework */; };
-		OBJ_1380 /* CgRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::CgRPC::Product" /* CgRPC.framework */; };
-		OBJ_1381 /* BoringSSL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::BoringSSL::Product" /* BoringSSL.framework */; };
-		OBJ_1382 /* OpenCannabis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Bloombox::OpenCannabis::Product" /* OpenCannabis.framework */; };
-		OBJ_1383 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftProtobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
-		OBJ_1393 /* a_bitstr.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_738 /* a_bitstr.c */; };
-		OBJ_1394 /* a_bool.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_739 /* a_bool.c */; };
-		OBJ_1395 /* a_d2i_fp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_740 /* a_d2i_fp.c */; };
-		OBJ_1396 /* a_dup.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_741 /* a_dup.c */; };
-		OBJ_1397 /* a_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_742 /* a_enum.c */; };
-		OBJ_1398 /* a_gentm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_743 /* a_gentm.c */; };
-		OBJ_1399 /* a_i2d_fp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_744 /* a_i2d_fp.c */; };
-		OBJ_1400 /* a_int.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_745 /* a_int.c */; };
-		OBJ_1401 /* a_mbstr.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_746 /* a_mbstr.c */; };
-		OBJ_1402 /* a_object.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_747 /* a_object.c */; };
-		OBJ_1403 /* a_octet.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_748 /* a_octet.c */; };
-		OBJ_1404 /* a_print.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_749 /* a_print.c */; };
-		OBJ_1405 /* a_strnid.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_750 /* a_strnid.c */; };
-		OBJ_1406 /* a_time.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_751 /* a_time.c */; };
-		OBJ_1407 /* a_type.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_752 /* a_type.c */; };
-		OBJ_1408 /* a_utctm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_753 /* a_utctm.c */; };
-		OBJ_1409 /* a_utf8.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_754 /* a_utf8.c */; };
-		OBJ_1410 /* asn1_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_755 /* asn1_lib.c */; };
-		OBJ_1411 /* asn1_par.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_756 /* asn1_par.c */; };
-		OBJ_1412 /* asn_pack.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_757 /* asn_pack.c */; };
-		OBJ_1413 /* f_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_758 /* f_enum.c */; };
-		OBJ_1414 /* f_int.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_759 /* f_int.c */; };
-		OBJ_1415 /* f_string.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_760 /* f_string.c */; };
-		OBJ_1416 /* tasn_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_761 /* tasn_dec.c */; };
-		OBJ_1417 /* tasn_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_762 /* tasn_enc.c */; };
-		OBJ_1418 /* tasn_fre.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_763 /* tasn_fre.c */; };
-		OBJ_1419 /* tasn_new.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_764 /* tasn_new.c */; };
-		OBJ_1420 /* tasn_typ.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_765 /* tasn_typ.c */; };
-		OBJ_1421 /* tasn_utl.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_766 /* tasn_utl.c */; };
-		OBJ_1422 /* time_support.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_767 /* time_support.c */; };
-		OBJ_1423 /* base64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_769 /* base64.c */; };
-		OBJ_1424 /* bio.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_771 /* bio.c */; };
-		OBJ_1425 /* bio_mem.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_772 /* bio_mem.c */; };
-		OBJ_1426 /* connect.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_773 /* connect.c */; };
-		OBJ_1427 /* fd.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_774 /* fd.c */; };
-		OBJ_1428 /* file.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_775 /* file.c */; };
-		OBJ_1429 /* hexdump.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_776 /* hexdump.c */; };
-		OBJ_1430 /* pair.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_777 /* pair.c */; };
-		OBJ_1431 /* printf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_778 /* printf.c */; };
-		OBJ_1432 /* socket.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_779 /* socket.c */; };
-		OBJ_1433 /* socket_helper.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_780 /* socket_helper.c */; };
-		OBJ_1434 /* bn_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_782 /* bn_asn1.c */; };
-		OBJ_1435 /* convert.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_783 /* convert.c */; };
-		OBJ_1436 /* buf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_785 /* buf.c */; };
-		OBJ_1437 /* asn1_compat.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_787 /* asn1_compat.c */; };
-		OBJ_1438 /* ber.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_788 /* ber.c */; };
-		OBJ_1439 /* cbb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_789 /* cbb.c */; };
-		OBJ_1440 /* cbs.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_790 /* cbs.c */; };
-		OBJ_1441 /* chacha.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_792 /* chacha.c */; };
-		OBJ_1442 /* cipher_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_794 /* cipher_extra.c */; };
-		OBJ_1443 /* derive_key.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_795 /* derive_key.c */; };
-		OBJ_1444 /* e_aesctrhmac.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_796 /* e_aesctrhmac.c */; };
-		OBJ_1445 /* e_aesgcmsiv.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_797 /* e_aesgcmsiv.c */; };
-		OBJ_1446 /* e_chacha20poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_798 /* e_chacha20poly1305.c */; };
-		OBJ_1447 /* e_null.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_799 /* e_null.c */; };
-		OBJ_1448 /* e_rc2.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_800 /* e_rc2.c */; };
-		OBJ_1449 /* e_rc4.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_801 /* e_rc4.c */; };
-		OBJ_1450 /* e_ssl3.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_802 /* e_ssl3.c */; };
-		OBJ_1451 /* e_tls.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_803 /* e_tls.c */; };
-		OBJ_1452 /* tls_cbc.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_804 /* tls_cbc.c */; };
-		OBJ_1453 /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_806 /* cmac.c */; };
-		OBJ_1454 /* conf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_808 /* conf.c */; };
-		OBJ_1455 /* cpu-aarch64-linux.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_809 /* cpu-aarch64-linux.c */; };
-		OBJ_1456 /* cpu-arm-linux.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_810 /* cpu-arm-linux.c */; };
-		OBJ_1457 /* cpu-arm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_811 /* cpu-arm.c */; };
-		OBJ_1458 /* cpu-intel.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_812 /* cpu-intel.c */; };
-		OBJ_1459 /* cpu-ppc64le.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_813 /* cpu-ppc64le.c */; };
-		OBJ_1460 /* crypto.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_814 /* crypto.c */; };
-		OBJ_1461 /* spake25519.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_816 /* spake25519.c */; };
-		OBJ_1462 /* x25519-x86_64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_817 /* x25519-x86_64.c */; };
-		OBJ_1463 /* check.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_819 /* check.c */; };
-		OBJ_1464 /* dh.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_820 /* dh.c */; };
-		OBJ_1465 /* dh_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_821 /* dh_asn1.c */; };
-		OBJ_1466 /* params.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_822 /* params.c */; };
-		OBJ_1467 /* digest_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_824 /* digest_extra.c */; };
-		OBJ_1468 /* dsa.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_826 /* dsa.c */; };
-		OBJ_1469 /* dsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_827 /* dsa_asn1.c */; };
-		OBJ_1470 /* ec_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_829 /* ec_asn1.c */; };
-		OBJ_1471 /* ecdh.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_831 /* ecdh.c */; };
-		OBJ_1472 /* ecdsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_833 /* ecdsa_asn1.c */; };
-		OBJ_1473 /* engine.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_835 /* engine.c */; };
-		OBJ_1474 /* err.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_837 /* err.c */; };
-		OBJ_1475 /* err_data.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_838 /* err_data.c */; };
-		OBJ_1476 /* digestsign.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_840 /* digestsign.c */; };
-		OBJ_1477 /* evp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_841 /* evp.c */; };
-		OBJ_1478 /* evp_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_842 /* evp_asn1.c */; };
-		OBJ_1479 /* evp_ctx.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_843 /* evp_ctx.c */; };
-		OBJ_1480 /* p_dsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_844 /* p_dsa_asn1.c */; };
-		OBJ_1481 /* p_ec.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_845 /* p_ec.c */; };
-		OBJ_1482 /* p_ec_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_846 /* p_ec_asn1.c */; };
-		OBJ_1483 /* p_ed25519.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_847 /* p_ed25519.c */; };
-		OBJ_1484 /* p_ed25519_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_848 /* p_ed25519_asn1.c */; };
-		OBJ_1485 /* p_rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_849 /* p_rsa.c */; };
-		OBJ_1486 /* p_rsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_850 /* p_rsa_asn1.c */; };
-		OBJ_1487 /* pbkdf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_851 /* pbkdf.c */; };
-		OBJ_1488 /* print.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_852 /* print.c */; };
-		OBJ_1489 /* scrypt.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_853 /* scrypt.c */; };
-		OBJ_1490 /* sign.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_854 /* sign.c */; };
-		OBJ_1491 /* ex_data.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_855 /* ex_data.c */; };
-		OBJ_1492 /* aes.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_858 /* aes.c */; };
-		OBJ_1493 /* key_wrap.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_859 /* key_wrap.c */; };
-		OBJ_1494 /* mode_wrappers.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_860 /* mode_wrappers.c */; };
-		OBJ_1495 /* add.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_862 /* add.c */; };
-		OBJ_1496 /* bn.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_863 /* bn.c */; };
-		OBJ_1497 /* bytes.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_864 /* bytes.c */; };
-		OBJ_1498 /* cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_865 /* cmp.c */; };
-		OBJ_1499 /* ctx.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_866 /* ctx.c */; };
-		OBJ_1500 /* div.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_867 /* div.c */; };
-		OBJ_1501 /* exponentiation.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_868 /* exponentiation.c */; };
-		OBJ_1502 /* gcd.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_869 /* gcd.c */; };
-		OBJ_1503 /* generic.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_870 /* generic.c */; };
-		OBJ_1504 /* jacobi.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_871 /* jacobi.c */; };
-		OBJ_1505 /* montgomery.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_872 /* montgomery.c */; };
-		OBJ_1506 /* montgomery_inv.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_873 /* montgomery_inv.c */; };
-		OBJ_1507 /* mul.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_874 /* mul.c */; };
-		OBJ_1508 /* prime.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_875 /* prime.c */; };
-		OBJ_1509 /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_876 /* random.c */; };
-		OBJ_1510 /* rsaz_exp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_877 /* rsaz_exp.c */; };
-		OBJ_1511 /* shift.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_878 /* shift.c */; };
-		OBJ_1512 /* sqrt.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_879 /* sqrt.c */; };
-		OBJ_1513 /* aead.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_881 /* aead.c */; };
-		OBJ_1514 /* cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_882 /* cipher.c */; };
-		OBJ_1515 /* e_aes.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_883 /* e_aes.c */; };
-		OBJ_1516 /* e_des.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_884 /* e_des.c */; };
-		OBJ_1517 /* des.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_886 /* des.c */; };
-		OBJ_1518 /* digest.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_888 /* digest.c */; };
-		OBJ_1519 /* digests.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_889 /* digests.c */; };
-		OBJ_1520 /* ec.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_891 /* ec.c */; };
-		OBJ_1521 /* ec_key.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_892 /* ec_key.c */; };
-		OBJ_1522 /* ec_montgomery.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_893 /* ec_montgomery.c */; };
-		OBJ_1523 /* oct.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_894 /* oct.c */; };
-		OBJ_1524 /* p224-64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_895 /* p224-64.c */; };
-		OBJ_1525 /* p256-64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_896 /* p256-64.c */; };
-		OBJ_1526 /* p256-x86_64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_897 /* p256-x86_64.c */; };
-		OBJ_1527 /* simple.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_898 /* simple.c */; };
-		OBJ_1528 /* util-64.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_899 /* util-64.c */; };
-		OBJ_1529 /* wnaf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_900 /* wnaf.c */; };
-		OBJ_1530 /* ecdsa.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_902 /* ecdsa.c */; };
-		OBJ_1531 /* hmac.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_904 /* hmac.c */; };
-		OBJ_1532 /* is_fips.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_905 /* is_fips.c */; };
-		OBJ_1533 /* md4.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_907 /* md4.c */; };
-		OBJ_1534 /* md5.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_909 /* md5.c */; };
-		OBJ_1535 /* cbc.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_911 /* cbc.c */; };
-		OBJ_1536 /* cfb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_912 /* cfb.c */; };
-		OBJ_1537 /* ctr.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_913 /* ctr.c */; };
-		OBJ_1538 /* gcm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_914 /* gcm.c */; };
-		OBJ_1539 /* ofb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_915 /* ofb.c */; };
-		OBJ_1540 /* polyval.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_916 /* polyval.c */; };
-		OBJ_1541 /* ctrdrbg.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_918 /* ctrdrbg.c */; };
-		OBJ_1542 /* rand.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_919 /* rand.c */; };
-		OBJ_1543 /* urandom.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_920 /* urandom.c */; };
-		OBJ_1544 /* blinding.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_922 /* blinding.c */; };
-		OBJ_1545 /* padding.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_923 /* padding.c */; };
-		OBJ_1546 /* rsa.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_924 /* rsa.c */; };
-		OBJ_1547 /* rsa_impl.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_925 /* rsa_impl.c */; };
-		OBJ_1548 /* sha1-altivec.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_927 /* sha1-altivec.c */; };
-		OBJ_1549 /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_928 /* sha1.c */; };
-		OBJ_1550 /* sha256.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_929 /* sha256.c */; };
-		OBJ_1551 /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_930 /* sha512.c */; };
-		OBJ_1552 /* hkdf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_932 /* hkdf.c */; };
-		OBJ_1553 /* lhash.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_934 /* lhash.c */; };
-		OBJ_1554 /* mem.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_935 /* mem.c */; };
-		OBJ_1555 /* obj.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_937 /* obj.c */; };
-		OBJ_1556 /* obj_xref.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_938 /* obj_xref.c */; };
-		OBJ_1557 /* pem_all.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_940 /* pem_all.c */; };
-		OBJ_1558 /* pem_info.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_941 /* pem_info.c */; };
-		OBJ_1559 /* pem_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_942 /* pem_lib.c */; };
-		OBJ_1560 /* pem_oth.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_943 /* pem_oth.c */; };
-		OBJ_1561 /* pem_pk8.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_944 /* pem_pk8.c */; };
-		OBJ_1562 /* pem_pkey.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_945 /* pem_pkey.c */; };
-		OBJ_1563 /* pem_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_946 /* pem_x509.c */; };
-		OBJ_1564 /* pem_xaux.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_947 /* pem_xaux.c */; };
-		OBJ_1565 /* pkcs7.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_949 /* pkcs7.c */; };
-		OBJ_1566 /* pkcs7_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_950 /* pkcs7_x509.c */; };
-		OBJ_1567 /* p5_pbev2.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_952 /* p5_pbev2.c */; };
-		OBJ_1568 /* pkcs8.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_953 /* pkcs8.c */; };
-		OBJ_1569 /* pkcs8_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_954 /* pkcs8_x509.c */; };
-		OBJ_1570 /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_956 /* poly1305.c */; };
-		OBJ_1571 /* poly1305_arm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_957 /* poly1305_arm.c */; };
-		OBJ_1572 /* poly1305_vec.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_958 /* poly1305_vec.c */; };
-		OBJ_1573 /* pool.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_960 /* pool.c */; };
-		OBJ_1574 /* deterministic.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_962 /* deterministic.c */; };
-		OBJ_1575 /* forkunsafe.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_963 /* forkunsafe.c */; };
-		OBJ_1576 /* fuchsia.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_964 /* fuchsia.c */; };
-		OBJ_1577 /* rand_extra.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_965 /* rand_extra.c */; };
-		OBJ_1578 /* windows.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_966 /* windows.c */; };
-		OBJ_1579 /* rc4.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_968 /* rc4.c */; };
-		OBJ_1580 /* refcount_c11.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_969 /* refcount_c11.c */; };
-		OBJ_1581 /* refcount_lock.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_970 /* refcount_lock.c */; };
-		OBJ_1582 /* rsa_asn1.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_972 /* rsa_asn1.c */; };
-		OBJ_1583 /* stack.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_974 /* stack.c */; };
-		OBJ_1584 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_975 /* thread.c */; };
-		OBJ_1585 /* thread_none.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_976 /* thread_none.c */; };
-		OBJ_1586 /* thread_pthread.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_977 /* thread_pthread.c */; };
-		OBJ_1587 /* thread_win.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_978 /* thread_win.c */; };
-		OBJ_1588 /* a_digest.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_980 /* a_digest.c */; };
-		OBJ_1589 /* a_sign.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_981 /* a_sign.c */; };
-		OBJ_1590 /* a_strex.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_982 /* a_strex.c */; };
-		OBJ_1591 /* a_verify.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_983 /* a_verify.c */; };
-		OBJ_1592 /* algorithm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_984 /* algorithm.c */; };
-		OBJ_1593 /* asn1_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_985 /* asn1_gen.c */; };
-		OBJ_1594 /* by_dir.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_986 /* by_dir.c */; };
-		OBJ_1595 /* by_file.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_987 /* by_file.c */; };
-		OBJ_1596 /* i2d_pr.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_988 /* i2d_pr.c */; };
-		OBJ_1597 /* rsa_pss.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_989 /* rsa_pss.c */; };
-		OBJ_1598 /* t_crl.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_990 /* t_crl.c */; };
-		OBJ_1599 /* t_req.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_991 /* t_req.c */; };
-		OBJ_1600 /* t_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_992 /* t_x509.c */; };
-		OBJ_1601 /* t_x509a.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_993 /* t_x509a.c */; };
-		OBJ_1602 /* x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_994 /* x509.c */; };
-		OBJ_1603 /* x509_att.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_995 /* x509_att.c */; };
-		OBJ_1604 /* x509_cmp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_996 /* x509_cmp.c */; };
-		OBJ_1605 /* x509_d2.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_997 /* x509_d2.c */; };
-		OBJ_1606 /* x509_def.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_998 /* x509_def.c */; };
-		OBJ_1607 /* x509_ext.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_999 /* x509_ext.c */; };
-		OBJ_1608 /* x509_lu.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1000 /* x509_lu.c */; };
-		OBJ_1609 /* x509_obj.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1001 /* x509_obj.c */; };
-		OBJ_1610 /* x509_r2x.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1002 /* x509_r2x.c */; };
-		OBJ_1611 /* x509_req.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1003 /* x509_req.c */; };
-		OBJ_1612 /* x509_set.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1004 /* x509_set.c */; };
-		OBJ_1613 /* x509_trs.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1005 /* x509_trs.c */; };
-		OBJ_1614 /* x509_txt.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1006 /* x509_txt.c */; };
-		OBJ_1615 /* x509_v3.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1007 /* x509_v3.c */; };
-		OBJ_1616 /* x509_vfy.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1008 /* x509_vfy.c */; };
-		OBJ_1617 /* x509_vpm.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1009 /* x509_vpm.c */; };
-		OBJ_1618 /* x509cset.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1010 /* x509cset.c */; };
-		OBJ_1619 /* x509name.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1011 /* x509name.c */; };
-		OBJ_1620 /* x509rset.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1012 /* x509rset.c */; };
-		OBJ_1621 /* x509spki.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1013 /* x509spki.c */; };
-		OBJ_1622 /* x_algor.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1014 /* x_algor.c */; };
-		OBJ_1623 /* x_all.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1015 /* x_all.c */; };
-		OBJ_1624 /* x_attrib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1016 /* x_attrib.c */; };
-		OBJ_1625 /* x_crl.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1017 /* x_crl.c */; };
-		OBJ_1626 /* x_exten.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1018 /* x_exten.c */; };
-		OBJ_1627 /* x_info.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1019 /* x_info.c */; };
-		OBJ_1628 /* x_name.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1020 /* x_name.c */; };
-		OBJ_1629 /* x_pkey.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1021 /* x_pkey.c */; };
-		OBJ_1630 /* x_pubkey.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1022 /* x_pubkey.c */; };
-		OBJ_1631 /* x_req.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1023 /* x_req.c */; };
-		OBJ_1632 /* x_sig.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1024 /* x_sig.c */; };
-		OBJ_1633 /* x_spki.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1025 /* x_spki.c */; };
-		OBJ_1634 /* x_val.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1026 /* x_val.c */; };
-		OBJ_1635 /* x_x509.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1027 /* x_x509.c */; };
-		OBJ_1636 /* x_x509a.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1028 /* x_x509a.c */; };
-		OBJ_1637 /* pcy_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1030 /* pcy_cache.c */; };
-		OBJ_1638 /* pcy_data.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1031 /* pcy_data.c */; };
-		OBJ_1639 /* pcy_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1032 /* pcy_lib.c */; };
-		OBJ_1640 /* pcy_map.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1033 /* pcy_map.c */; };
-		OBJ_1641 /* pcy_node.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1034 /* pcy_node.c */; };
-		OBJ_1642 /* pcy_tree.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1035 /* pcy_tree.c */; };
-		OBJ_1643 /* v3_akey.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1036 /* v3_akey.c */; };
-		OBJ_1644 /* v3_akeya.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1037 /* v3_akeya.c */; };
-		OBJ_1645 /* v3_alt.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1038 /* v3_alt.c */; };
-		OBJ_1646 /* v3_bcons.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1039 /* v3_bcons.c */; };
-		OBJ_1647 /* v3_bitst.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1040 /* v3_bitst.c */; };
-		OBJ_1648 /* v3_conf.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1041 /* v3_conf.c */; };
-		OBJ_1649 /* v3_cpols.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1042 /* v3_cpols.c */; };
-		OBJ_1650 /* v3_crld.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1043 /* v3_crld.c */; };
-		OBJ_1651 /* v3_enum.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1044 /* v3_enum.c */; };
-		OBJ_1652 /* v3_extku.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1045 /* v3_extku.c */; };
-		OBJ_1653 /* v3_genn.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1046 /* v3_genn.c */; };
-		OBJ_1654 /* v3_ia5.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1047 /* v3_ia5.c */; };
-		OBJ_1655 /* v3_info.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1048 /* v3_info.c */; };
-		OBJ_1656 /* v3_int.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1049 /* v3_int.c */; };
-		OBJ_1657 /* v3_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1050 /* v3_lib.c */; };
-		OBJ_1658 /* v3_ncons.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1051 /* v3_ncons.c */; };
-		OBJ_1659 /* v3_pci.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1052 /* v3_pci.c */; };
-		OBJ_1660 /* v3_pcia.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1053 /* v3_pcia.c */; };
-		OBJ_1661 /* v3_pcons.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1054 /* v3_pcons.c */; };
-		OBJ_1662 /* v3_pku.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1055 /* v3_pku.c */; };
-		OBJ_1663 /* v3_pmaps.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1056 /* v3_pmaps.c */; };
-		OBJ_1664 /* v3_prn.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1057 /* v3_prn.c */; };
-		OBJ_1665 /* v3_purp.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1058 /* v3_purp.c */; };
-		OBJ_1666 /* v3_skey.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1059 /* v3_skey.c */; };
-		OBJ_1667 /* v3_sxnet.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1060 /* v3_sxnet.c */; };
-		OBJ_1668 /* v3_utl.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1061 /* v3_utl.c */; };
-		OBJ_1669 /* err_data.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1062 /* err_data.c */; };
-		OBJ_1670 /* bio_ssl.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1064 /* bio_ssl.cc */; };
-		OBJ_1671 /* custom_extensions.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1065 /* custom_extensions.cc */; };
-		OBJ_1672 /* d1_both.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1066 /* d1_both.cc */; };
-		OBJ_1673 /* d1_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1067 /* d1_lib.cc */; };
-		OBJ_1674 /* d1_pkt.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1068 /* d1_pkt.cc */; };
-		OBJ_1675 /* d1_srtp.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1069 /* d1_srtp.cc */; };
-		OBJ_1676 /* dtls_method.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1070 /* dtls_method.cc */; };
-		OBJ_1677 /* dtls_record.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1071 /* dtls_record.cc */; };
-		OBJ_1678 /* handshake.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1072 /* handshake.cc */; };
-		OBJ_1679 /* handshake_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1073 /* handshake_client.cc */; };
-		OBJ_1680 /* handshake_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1074 /* handshake_server.cc */; };
-		OBJ_1681 /* s3_both.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1075 /* s3_both.cc */; };
-		OBJ_1682 /* s3_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1076 /* s3_lib.cc */; };
-		OBJ_1683 /* s3_pkt.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1077 /* s3_pkt.cc */; };
-		OBJ_1684 /* ssl_aead_ctx.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1078 /* ssl_aead_ctx.cc */; };
-		OBJ_1685 /* ssl_asn1.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1079 /* ssl_asn1.cc */; };
-		OBJ_1686 /* ssl_buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1080 /* ssl_buffer.cc */; };
-		OBJ_1687 /* ssl_cert.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1081 /* ssl_cert.cc */; };
-		OBJ_1688 /* ssl_cipher.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1082 /* ssl_cipher.cc */; };
-		OBJ_1689 /* ssl_file.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1083 /* ssl_file.cc */; };
-		OBJ_1690 /* ssl_key_share.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1084 /* ssl_key_share.cc */; };
-		OBJ_1691 /* ssl_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1085 /* ssl_lib.cc */; };
-		OBJ_1692 /* ssl_privkey.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1086 /* ssl_privkey.cc */; };
-		OBJ_1693 /* ssl_session.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1087 /* ssl_session.cc */; };
-		OBJ_1694 /* ssl_stat.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1088 /* ssl_stat.cc */; };
-		OBJ_1695 /* ssl_transcript.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1089 /* ssl_transcript.cc */; };
-		OBJ_1696 /* ssl_versions.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1090 /* ssl_versions.cc */; };
-		OBJ_1697 /* ssl_x509.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1091 /* ssl_x509.cc */; };
-		OBJ_1698 /* t1_enc.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1092 /* t1_enc.cc */; };
-		OBJ_1699 /* t1_lib.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1093 /* t1_lib.cc */; };
-		OBJ_1700 /* tls13_both.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1094 /* tls13_both.cc */; };
-		OBJ_1701 /* tls13_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1095 /* tls13_client.cc */; };
-		OBJ_1702 /* tls13_enc.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1096 /* tls13_enc.cc */; };
-		OBJ_1703 /* tls13_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1097 /* tls13_server.cc */; };
-		OBJ_1704 /* tls_method.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1098 /* tls_method.cc */; };
-		OBJ_1705 /* tls_record.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1099 /* tls_record.cc */; };
-		OBJ_1706 /* curve25519.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1102 /* curve25519.c */; };
-		OBJ_1712 /* byte_buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_240 /* byte_buffer.c */; };
-		OBJ_1713 /* call.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_241 /* call.c */; };
-		OBJ_1714 /* channel.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_242 /* channel.c */; };
-		OBJ_1715 /* completion_queue.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_243 /* completion_queue.c */; };
-		OBJ_1716 /* event.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_244 /* event.c */; };
-		OBJ_1717 /* handler.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_245 /* handler.c */; };
-		OBJ_1718 /* internal.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_246 /* internal.c */; };
-		OBJ_1719 /* metadata.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_247 /* metadata.c */; };
-		OBJ_1720 /* mutex.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_248 /* mutex.c */; };
-		OBJ_1721 /* observers.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_249 /* observers.c */; };
-		OBJ_1722 /* operations.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_250 /* operations.c */; };
-		OBJ_1723 /* server.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_251 /* server.c */; };
-		OBJ_1724 /* grpc_context.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_256 /* grpc_context.cc */; };
-		OBJ_1725 /* backup_poller.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_259 /* backup_poller.cc */; };
-		OBJ_1726 /* channel_connectivity.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_260 /* channel_connectivity.cc */; };
-		OBJ_1727 /* client_channel.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_261 /* client_channel.cc */; };
-		OBJ_1728 /* client_channel_factory.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_262 /* client_channel_factory.cc */; };
-		OBJ_1729 /* client_channel_plugin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_263 /* client_channel_plugin.cc */; };
-		OBJ_1730 /* connector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_264 /* connector.cc */; };
-		OBJ_1731 /* http_connect_handshaker.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_265 /* http_connect_handshaker.cc */; };
-		OBJ_1732 /* http_proxy.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_266 /* http_proxy.cc */; };
-		OBJ_1733 /* lb_policy.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_267 /* lb_policy.cc */; };
-		OBJ_1734 /* client_load_reporting_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_270 /* client_load_reporting_filter.cc */; };
-		OBJ_1735 /* grpclb.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_271 /* grpclb.cc */; };
-		OBJ_1736 /* grpclb_channel_secure.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_272 /* grpclb_channel_secure.cc */; };
-		OBJ_1737 /* grpclb_client_stats.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_273 /* grpclb_client_stats.cc */; };
-		OBJ_1738 /* load_balancer_api.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_274 /* load_balancer_api.cc */; };
-		OBJ_1739 /* load_balancer.pb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_279 /* load_balancer.pb.c */; };
-		OBJ_1740 /* pick_first.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_281 /* pick_first.cc */; };
-		OBJ_1741 /* round_robin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_283 /* round_robin.cc */; };
-		OBJ_1742 /* lb_policy_factory.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_284 /* lb_policy_factory.cc */; };
-		OBJ_1743 /* lb_policy_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_285 /* lb_policy_registry.cc */; };
-		OBJ_1744 /* method_params.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_286 /* method_params.cc */; };
-		OBJ_1745 /* parse_address.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_287 /* parse_address.cc */; };
-		OBJ_1746 /* proxy_mapper.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_288 /* proxy_mapper.cc */; };
-		OBJ_1747 /* proxy_mapper_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_289 /* proxy_mapper_registry.cc */; };
-		OBJ_1748 /* resolver.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_290 /* resolver.cc */; };
-		OBJ_1749 /* dns_resolver_ares.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_294 /* dns_resolver_ares.cc */; };
-		OBJ_1750 /* grpc_ares_ev_driver_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_295 /* grpc_ares_ev_driver_posix.cc */; };
-		OBJ_1751 /* grpc_ares_wrapper.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_296 /* grpc_ares_wrapper.cc */; };
-		OBJ_1752 /* grpc_ares_wrapper_fallback.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_297 /* grpc_ares_wrapper_fallback.cc */; };
-		OBJ_1753 /* dns_resolver.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_299 /* dns_resolver.cc */; };
-		OBJ_1754 /* fake_resolver.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_301 /* fake_resolver.cc */; };
-		OBJ_1755 /* sockaddr_resolver.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_303 /* sockaddr_resolver.cc */; };
-		OBJ_1756 /* resolver_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_304 /* resolver_registry.cc */; };
-		OBJ_1757 /* retry_throttle.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_305 /* retry_throttle.cc */; };
-		OBJ_1758 /* subchannel.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_306 /* subchannel.cc */; };
-		OBJ_1759 /* subchannel_index.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_307 /* subchannel_index.cc */; };
-		OBJ_1760 /* uri_parser.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_308 /* uri_parser.cc */; };
-		OBJ_1761 /* deadline_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_310 /* deadline_filter.cc */; };
-		OBJ_1762 /* http_client_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_313 /* http_client_filter.cc */; };
-		OBJ_1763 /* client_authority_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_314 /* client_authority_filter.cc */; };
-		OBJ_1764 /* http_filters_plugin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_315 /* http_filters_plugin.cc */; };
-		OBJ_1765 /* message_compress_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_317 /* message_compress_filter.cc */; };
-		OBJ_1766 /* http_server_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_319 /* http_server_filter.cc */; };
-		OBJ_1767 /* server_load_reporting_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_321 /* server_load_reporting_filter.cc */; };
-		OBJ_1768 /* server_load_reporting_plugin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_322 /* server_load_reporting_plugin.cc */; };
-		OBJ_1769 /* max_age_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_324 /* max_age_filter.cc */; };
-		OBJ_1770 /* message_size_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_326 /* message_size_filter.cc */; };
-		OBJ_1771 /* workaround_cronet_compression_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_328 /* workaround_cronet_compression_filter.cc */; };
-		OBJ_1772 /* workaround_utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_329 /* workaround_utils.cc */; };
-		OBJ_1773 /* alpn.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_333 /* alpn.cc */; };
-		OBJ_1774 /* authority.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_335 /* authority.cc */; };
-		OBJ_1775 /* chttp2_connector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_336 /* chttp2_connector.cc */; };
-		OBJ_1776 /* channel_create.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_338 /* channel_create.cc */; };
-		OBJ_1777 /* channel_create_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_339 /* channel_create_posix.cc */; };
-		OBJ_1778 /* secure_channel_create.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_341 /* secure_channel_create.cc */; };
-		OBJ_1779 /* chttp2_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_343 /* chttp2_server.cc */; };
-		OBJ_1780 /* server_chttp2.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_345 /* server_chttp2.cc */; };
-		OBJ_1781 /* server_chttp2_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_346 /* server_chttp2_posix.cc */; };
-		OBJ_1782 /* server_secure_chttp2.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_348 /* server_secure_chttp2.cc */; };
-		OBJ_1783 /* bin_decoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_350 /* bin_decoder.cc */; };
-		OBJ_1784 /* bin_encoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_351 /* bin_encoder.cc */; };
-		OBJ_1785 /* chttp2_plugin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_352 /* chttp2_plugin.cc */; };
-		OBJ_1786 /* chttp2_transport.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_353 /* chttp2_transport.cc */; };
-		OBJ_1787 /* flow_control.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_354 /* flow_control.cc */; };
-		OBJ_1788 /* frame_data.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_355 /* frame_data.cc */; };
-		OBJ_1789 /* frame_goaway.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_356 /* frame_goaway.cc */; };
-		OBJ_1790 /* frame_ping.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_357 /* frame_ping.cc */; };
-		OBJ_1791 /* frame_rst_stream.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_358 /* frame_rst_stream.cc */; };
-		OBJ_1792 /* frame_settings.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_359 /* frame_settings.cc */; };
-		OBJ_1793 /* frame_window_update.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_360 /* frame_window_update.cc */; };
-		OBJ_1794 /* hpack_encoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_361 /* hpack_encoder.cc */; };
-		OBJ_1795 /* hpack_parser.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_362 /* hpack_parser.cc */; };
-		OBJ_1796 /* hpack_table.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_363 /* hpack_table.cc */; };
-		OBJ_1797 /* http2_settings.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_364 /* http2_settings.cc */; };
-		OBJ_1798 /* huffsyms.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_365 /* huffsyms.cc */; };
-		OBJ_1799 /* incoming_metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_366 /* incoming_metadata.cc */; };
-		OBJ_1800 /* parsing.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_367 /* parsing.cc */; };
-		OBJ_1801 /* stream_lists.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_368 /* stream_lists.cc */; };
-		OBJ_1802 /* stream_map.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_369 /* stream_map.cc */; };
-		OBJ_1803 /* varint.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_370 /* varint.cc */; };
-		OBJ_1804 /* writing.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_371 /* writing.cc */; };
-		OBJ_1805 /* inproc_plugin.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_373 /* inproc_plugin.cc */; };
-		OBJ_1806 /* inproc_transport.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_374 /* inproc_transport.cc */; };
-		OBJ_1807 /* avl.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_377 /* avl.cc */; };
-		OBJ_1808 /* backoff.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_379 /* backoff.cc */; };
-		OBJ_1809 /* channel_args.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_381 /* channel_args.cc */; };
-		OBJ_1810 /* channel_stack.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_382 /* channel_stack.cc */; };
-		OBJ_1811 /* channel_stack_builder.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_383 /* channel_stack_builder.cc */; };
-		OBJ_1812 /* channel_trace.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_384 /* channel_trace.cc */; };
-		OBJ_1813 /* channel_trace_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_385 /* channel_trace_registry.cc */; };
-		OBJ_1814 /* connected_channel.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_386 /* connected_channel.cc */; };
-		OBJ_1815 /* handshaker.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_387 /* handshaker.cc */; };
-		OBJ_1816 /* handshaker_factory.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_388 /* handshaker_factory.cc */; };
-		OBJ_1817 /* handshaker_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_389 /* handshaker_registry.cc */; };
-		OBJ_1818 /* status_util.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_390 /* status_util.cc */; };
-		OBJ_1819 /* compression.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_392 /* compression.cc */; };
-		OBJ_1820 /* compression_internal.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_393 /* compression_internal.cc */; };
-		OBJ_1821 /* message_compress.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_394 /* message_compress.cc */; };
-		OBJ_1822 /* stream_compression.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_395 /* stream_compression.cc */; };
-		OBJ_1823 /* stream_compression_gzip.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_396 /* stream_compression_gzip.cc */; };
-		OBJ_1824 /* stream_compression_identity.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_397 /* stream_compression_identity.cc */; };
-		OBJ_1825 /* stats.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_399 /* stats.cc */; };
-		OBJ_1826 /* stats_data.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_400 /* stats_data.cc */; };
-		OBJ_1827 /* trace.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_401 /* trace.cc */; };
-		OBJ_1828 /* alloc.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_403 /* alloc.cc */; };
-		OBJ_1829 /* arena.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_404 /* arena.cc */; };
-		OBJ_1830 /* atm.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_405 /* atm.cc */; };
-		OBJ_1831 /* cpu_iphone.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_406 /* cpu_iphone.cc */; };
-		OBJ_1832 /* cpu_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_407 /* cpu_linux.cc */; };
-		OBJ_1833 /* cpu_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_408 /* cpu_posix.cc */; };
-		OBJ_1834 /* cpu_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_409 /* cpu_windows.cc */; };
-		OBJ_1835 /* env_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_410 /* env_linux.cc */; };
-		OBJ_1836 /* env_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_411 /* env_posix.cc */; };
-		OBJ_1837 /* env_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_412 /* env_windows.cc */; };
-		OBJ_1838 /* fork.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_413 /* fork.cc */; };
-		OBJ_1839 /* host_port.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_414 /* host_port.cc */; };
-		OBJ_1840 /* log.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_415 /* log.cc */; };
-		OBJ_1841 /* log_android.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_416 /* log_android.cc */; };
-		OBJ_1842 /* log_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_417 /* log_linux.cc */; };
-		OBJ_1843 /* log_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_418 /* log_posix.cc */; };
-		OBJ_1844 /* log_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_419 /* log_windows.cc */; };
-		OBJ_1845 /* mpscq.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_420 /* mpscq.cc */; };
-		OBJ_1846 /* murmur_hash.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_421 /* murmur_hash.cc */; };
-		OBJ_1847 /* string.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_422 /* string.cc */; };
-		OBJ_1848 /* string_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_423 /* string_posix.cc */; };
-		OBJ_1849 /* string_util_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_424 /* string_util_windows.cc */; };
-		OBJ_1850 /* string_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_425 /* string_windows.cc */; };
-		OBJ_1851 /* sync.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_426 /* sync.cc */; };
-		OBJ_1852 /* sync_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_427 /* sync_posix.cc */; };
-		OBJ_1853 /* sync_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_428 /* sync_windows.cc */; };
-		OBJ_1854 /* time.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_429 /* time.cc */; };
-		OBJ_1855 /* time_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_430 /* time_posix.cc */; };
-		OBJ_1856 /* time_precise.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_431 /* time_precise.cc */; };
-		OBJ_1857 /* time_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_432 /* time_windows.cc */; };
-		OBJ_1858 /* tls_pthread.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_433 /* tls_pthread.cc */; };
-		OBJ_1859 /* tmpfile_msys.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_434 /* tmpfile_msys.cc */; };
-		OBJ_1860 /* tmpfile_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_435 /* tmpfile_posix.cc */; };
-		OBJ_1861 /* tmpfile_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_436 /* tmpfile_windows.cc */; };
-		OBJ_1862 /* wrap_memcpy.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_437 /* wrap_memcpy.cc */; };
-		OBJ_1863 /* thd_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_439 /* thd_posix.cc */; };
-		OBJ_1864 /* thd_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_440 /* thd_windows.cc */; };
-		OBJ_1865 /* format_request.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_442 /* format_request.cc */; };
-		OBJ_1866 /* httpcli.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_443 /* httpcli.cc */; };
-		OBJ_1867 /* httpcli_security_connector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_444 /* httpcli_security_connector.cc */; };
-		OBJ_1868 /* parser.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_445 /* parser.cc */; };
-		OBJ_1869 /* call_combiner.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_447 /* call_combiner.cc */; };
-		OBJ_1870 /* combiner.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_448 /* combiner.cc */; };
-		OBJ_1871 /* endpoint.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_449 /* endpoint.cc */; };
-		OBJ_1872 /* endpoint_pair_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_450 /* endpoint_pair_posix.cc */; };
-		OBJ_1873 /* endpoint_pair_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_451 /* endpoint_pair_uv.cc */; };
-		OBJ_1874 /* endpoint_pair_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_452 /* endpoint_pair_windows.cc */; };
-		OBJ_1875 /* error.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_453 /* error.cc */; };
-		OBJ_1876 /* ev_epoll1_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_454 /* ev_epoll1_linux.cc */; };
-		OBJ_1877 /* ev_epollex_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_455 /* ev_epollex_linux.cc */; };
-		OBJ_1878 /* ev_epollsig_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_456 /* ev_epollsig_linux.cc */; };
-		OBJ_1879 /* ev_poll_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_457 /* ev_poll_posix.cc */; };
-		OBJ_1880 /* ev_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_458 /* ev_posix.cc */; };
-		OBJ_1881 /* ev_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_459 /* ev_windows.cc */; };
-		OBJ_1882 /* exec_ctx.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_460 /* exec_ctx.cc */; };
-		OBJ_1883 /* executor.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_461 /* executor.cc */; };
-		OBJ_1884 /* fork_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_462 /* fork_posix.cc */; };
-		OBJ_1885 /* fork_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_463 /* fork_windows.cc */; };
-		OBJ_1886 /* gethostname_fallback.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_464 /* gethostname_fallback.cc */; };
-		OBJ_1887 /* gethostname_host_name_max.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_465 /* gethostname_host_name_max.cc */; };
-		OBJ_1888 /* gethostname_sysconf.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_466 /* gethostname_sysconf.cc */; };
-		OBJ_1889 /* iocp_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_467 /* iocp_windows.cc */; };
-		OBJ_1890 /* iomgr.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_468 /* iomgr.cc */; };
-		OBJ_1891 /* iomgr_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_469 /* iomgr_custom.cc */; };
-		OBJ_1892 /* iomgr_internal.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_470 /* iomgr_internal.cc */; };
-		OBJ_1893 /* iomgr_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_471 /* iomgr_posix.cc */; };
-		OBJ_1894 /* iomgr_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_472 /* iomgr_uv.cc */; };
-		OBJ_1895 /* iomgr_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_473 /* iomgr_windows.cc */; };
-		OBJ_1896 /* is_epollexclusive_available.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_474 /* is_epollexclusive_available.cc */; };
-		OBJ_1897 /* load_file.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_475 /* load_file.cc */; };
-		OBJ_1898 /* lockfree_event.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_476 /* lockfree_event.cc */; };
-		OBJ_1899 /* network_status_tracker.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_477 /* network_status_tracker.cc */; };
-		OBJ_1900 /* polling_entity.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_478 /* polling_entity.cc */; };
-		OBJ_1901 /* pollset.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_479 /* pollset.cc */; };
-		OBJ_1902 /* pollset_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_480 /* pollset_custom.cc */; };
-		OBJ_1903 /* pollset_set.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_481 /* pollset_set.cc */; };
-		OBJ_1904 /* pollset_set_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_482 /* pollset_set_custom.cc */; };
-		OBJ_1905 /* pollset_set_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_483 /* pollset_set_windows.cc */; };
-		OBJ_1906 /* pollset_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_484 /* pollset_uv.cc */; };
-		OBJ_1907 /* pollset_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_485 /* pollset_windows.cc */; };
-		OBJ_1908 /* resolve_address.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_486 /* resolve_address.cc */; };
-		OBJ_1909 /* resolve_address_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_487 /* resolve_address_custom.cc */; };
-		OBJ_1910 /* resolve_address_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_488 /* resolve_address_posix.cc */; };
-		OBJ_1911 /* resolve_address_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_489 /* resolve_address_windows.cc */; };
-		OBJ_1912 /* resource_quota.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_490 /* resource_quota.cc */; };
-		OBJ_1913 /* sockaddr_utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_491 /* sockaddr_utils.cc */; };
-		OBJ_1914 /* socket_factory_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_492 /* socket_factory_posix.cc */; };
-		OBJ_1915 /* socket_mutator.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_493 /* socket_mutator.cc */; };
-		OBJ_1916 /* socket_utils_common_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_494 /* socket_utils_common_posix.cc */; };
-		OBJ_1917 /* socket_utils_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_495 /* socket_utils_linux.cc */; };
-		OBJ_1918 /* socket_utils_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_496 /* socket_utils_posix.cc */; };
-		OBJ_1919 /* socket_utils_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_497 /* socket_utils_uv.cc */; };
-		OBJ_1920 /* socket_utils_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_498 /* socket_utils_windows.cc */; };
-		OBJ_1921 /* socket_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_499 /* socket_windows.cc */; };
-		OBJ_1922 /* tcp_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_500 /* tcp_client.cc */; };
-		OBJ_1923 /* tcp_client_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_501 /* tcp_client_custom.cc */; };
-		OBJ_1924 /* tcp_client_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_502 /* tcp_client_posix.cc */; };
-		OBJ_1925 /* tcp_client_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_503 /* tcp_client_windows.cc */; };
-		OBJ_1926 /* tcp_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_504 /* tcp_custom.cc */; };
-		OBJ_1927 /* tcp_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_505 /* tcp_posix.cc */; };
-		OBJ_1928 /* tcp_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_506 /* tcp_server.cc */; };
-		OBJ_1929 /* tcp_server_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_507 /* tcp_server_custom.cc */; };
-		OBJ_1930 /* tcp_server_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_508 /* tcp_server_posix.cc */; };
-		OBJ_1931 /* tcp_server_utils_posix_common.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_509 /* tcp_server_utils_posix_common.cc */; };
-		OBJ_1932 /* tcp_server_utils_posix_ifaddrs.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_510 /* tcp_server_utils_posix_ifaddrs.cc */; };
-		OBJ_1933 /* tcp_server_utils_posix_noifaddrs.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_511 /* tcp_server_utils_posix_noifaddrs.cc */; };
-		OBJ_1934 /* tcp_server_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_512 /* tcp_server_windows.cc */; };
-		OBJ_1935 /* tcp_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_513 /* tcp_uv.cc */; };
-		OBJ_1936 /* tcp_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_514 /* tcp_windows.cc */; };
-		OBJ_1937 /* time_averaged_stats.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_515 /* time_averaged_stats.cc */; };
-		OBJ_1938 /* timer.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_516 /* timer.cc */; };
-		OBJ_1939 /* timer_custom.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_517 /* timer_custom.cc */; };
-		OBJ_1940 /* timer_generic.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_518 /* timer_generic.cc */; };
-		OBJ_1941 /* timer_heap.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_519 /* timer_heap.cc */; };
-		OBJ_1942 /* timer_manager.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_520 /* timer_manager.cc */; };
-		OBJ_1943 /* timer_uv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_521 /* timer_uv.cc */; };
-		OBJ_1944 /* udp_server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_522 /* udp_server.cc */; };
-		OBJ_1945 /* unix_sockets_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_523 /* unix_sockets_posix.cc */; };
-		OBJ_1946 /* unix_sockets_posix_noop.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_524 /* unix_sockets_posix_noop.cc */; };
-		OBJ_1947 /* wakeup_fd_cv.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_525 /* wakeup_fd_cv.cc */; };
-		OBJ_1948 /* wakeup_fd_eventfd.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_526 /* wakeup_fd_eventfd.cc */; };
-		OBJ_1949 /* wakeup_fd_nospecial.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_527 /* wakeup_fd_nospecial.cc */; };
-		OBJ_1950 /* wakeup_fd_pipe.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_528 /* wakeup_fd_pipe.cc */; };
-		OBJ_1951 /* wakeup_fd_posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_529 /* wakeup_fd_posix.cc */; };
-		OBJ_1952 /* json.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_531 /* json.cc */; };
-		OBJ_1953 /* json_reader.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_532 /* json_reader.cc */; };
-		OBJ_1954 /* json_string.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_533 /* json_string.cc */; };
-		OBJ_1955 /* json_writer.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_534 /* json_writer.cc */; };
-		OBJ_1956 /* basic_timers.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_536 /* basic_timers.cc */; };
-		OBJ_1957 /* stap_timers.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_537 /* stap_timers.cc */; };
-		OBJ_1958 /* security_context.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_540 /* security_context.cc */; };
-		OBJ_1959 /* alts_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_543 /* alts_credentials.cc */; };
-		OBJ_1960 /* check_gcp_environment.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_544 /* check_gcp_environment.cc */; };
-		OBJ_1961 /* check_gcp_environment_linux.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_545 /* check_gcp_environment_linux.cc */; };
-		OBJ_1962 /* check_gcp_environment_no_op.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_546 /* check_gcp_environment_no_op.cc */; };
-		OBJ_1963 /* check_gcp_environment_windows.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_547 /* check_gcp_environment_windows.cc */; };
-		OBJ_1964 /* grpc_alts_credentials_client_options.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_548 /* grpc_alts_credentials_client_options.cc */; };
-		OBJ_1965 /* grpc_alts_credentials_options.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_549 /* grpc_alts_credentials_options.cc */; };
-		OBJ_1966 /* grpc_alts_credentials_server_options.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_550 /* grpc_alts_credentials_server_options.cc */; };
-		OBJ_1967 /* composite_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_552 /* composite_credentials.cc */; };
-		OBJ_1968 /* credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_553 /* credentials.cc */; };
-		OBJ_1969 /* credentials_metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_554 /* credentials_metadata.cc */; };
-		OBJ_1970 /* fake_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_556 /* fake_credentials.cc */; };
-		OBJ_1971 /* credentials_generic.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_558 /* credentials_generic.cc */; };
-		OBJ_1972 /* google_default_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_559 /* google_default_credentials.cc */; };
-		OBJ_1973 /* iam_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_561 /* iam_credentials.cc */; };
-		OBJ_1974 /* json_token.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_563 /* json_token.cc */; };
-		OBJ_1975 /* jwt_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_564 /* jwt_credentials.cc */; };
-		OBJ_1976 /* jwt_verifier.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_565 /* jwt_verifier.cc */; };
-		OBJ_1977 /* oauth2_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_567 /* oauth2_credentials.cc */; };
-		OBJ_1978 /* plugin_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_569 /* plugin_credentials.cc */; };
-		OBJ_1979 /* ssl_credentials.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_571 /* ssl_credentials.cc */; };
-		OBJ_1980 /* alts_security_connector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_573 /* alts_security_connector.cc */; };
-		OBJ_1981 /* security_connector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_574 /* security_connector.cc */; };
-		OBJ_1982 /* client_auth_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_576 /* client_auth_filter.cc */; };
-		OBJ_1983 /* secure_endpoint.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_577 /* secure_endpoint.cc */; };
-		OBJ_1984 /* security_handshaker.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_578 /* security_handshaker.cc */; };
-		OBJ_1985 /* server_auth_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_579 /* server_auth_filter.cc */; };
-		OBJ_1986 /* target_authority_table.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_580 /* target_authority_table.cc */; };
-		OBJ_1987 /* tsi_error.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_581 /* tsi_error.cc */; };
-		OBJ_1988 /* json_util.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_583 /* json_util.cc */; };
-		OBJ_1989 /* b64.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_585 /* b64.cc */; };
-		OBJ_1990 /* percent_encoding.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_586 /* percent_encoding.cc */; };
-		OBJ_1991 /* slice.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_587 /* slice.cc */; };
-		OBJ_1992 /* slice_buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_588 /* slice_buffer.cc */; };
-		OBJ_1993 /* slice_intern.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_589 /* slice_intern.cc */; };
-		OBJ_1994 /* slice_string_helpers.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_590 /* slice_string_helpers.cc */; };
-		OBJ_1995 /* api_trace.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_592 /* api_trace.cc */; };
-		OBJ_1996 /* byte_buffer.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_593 /* byte_buffer.cc */; };
-		OBJ_1997 /* byte_buffer_reader.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_594 /* byte_buffer_reader.cc */; };
-		OBJ_1998 /* call.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_595 /* call.cc */; };
-		OBJ_1999 /* call_details.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_596 /* call_details.cc */; };
-		OBJ_2000 /* call_log_batch.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_597 /* call_log_batch.cc */; };
-		OBJ_2001 /* channel.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_598 /* channel.cc */; };
-		OBJ_2002 /* channel_init.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_599 /* channel_init.cc */; };
-		OBJ_2003 /* channel_ping.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_600 /* channel_ping.cc */; };
-		OBJ_2004 /* channel_stack_type.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_601 /* channel_stack_type.cc */; };
-		OBJ_2005 /* completion_queue.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_602 /* completion_queue.cc */; };
-		OBJ_2006 /* completion_queue_factory.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_603 /* completion_queue_factory.cc */; };
-		OBJ_2007 /* event_string.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_604 /* event_string.cc */; };
-		OBJ_2008 /* init.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_605 /* init.cc */; };
-		OBJ_2009 /* init_secure.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_606 /* init_secure.cc */; };
-		OBJ_2010 /* lame_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_607 /* lame_client.cc */; };
-		OBJ_2011 /* metadata_array.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_608 /* metadata_array.cc */; };
-		OBJ_2012 /* server.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_609 /* server.cc */; };
-		OBJ_2013 /* validate_metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_610 /* validate_metadata.cc */; };
-		OBJ_2014 /* version.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_611 /* version.cc */; };
-		OBJ_2015 /* bdp_estimator.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_613 /* bdp_estimator.cc */; };
-		OBJ_2016 /* byte_stream.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_614 /* byte_stream.cc */; };
-		OBJ_2017 /* connectivity_state.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_615 /* connectivity_state.cc */; };
-		OBJ_2018 /* error_utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_616 /* error_utils.cc */; };
-		OBJ_2019 /* metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_617 /* metadata.cc */; };
-		OBJ_2020 /* metadata_batch.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_618 /* metadata_batch.cc */; };
-		OBJ_2021 /* pid_controller.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_619 /* pid_controller.cc */; };
-		OBJ_2022 /* service_config.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_620 /* service_config.cc */; };
-		OBJ_2023 /* static_metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_621 /* static_metadata.cc */; };
-		OBJ_2024 /* status_conversion.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_622 /* status_conversion.cc */; };
-		OBJ_2025 /* status_metadata.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_623 /* status_metadata.cc */; };
-		OBJ_2026 /* timeout_encoding.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_624 /* timeout_encoding.cc */; };
-		OBJ_2027 /* transport.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_625 /* transport.cc */; };
-		OBJ_2028 /* transport_op_string.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_626 /* transport_op_string.cc */; };
-		OBJ_2029 /* grpc_plugin_registry.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_628 /* grpc_plugin_registry.cc */; };
-		OBJ_2030 /* aes_gcm.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_632 /* aes_gcm.cc */; };
-		OBJ_2031 /* gsec.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_633 /* gsec.cc */; };
-		OBJ_2032 /* alts_counter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_635 /* alts_counter.cc */; };
-		OBJ_2033 /* alts_crypter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_636 /* alts_crypter.cc */; };
-		OBJ_2034 /* alts_frame_protector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_637 /* alts_frame_protector.cc */; };
-		OBJ_2035 /* alts_record_protocol_crypter_common.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_638 /* alts_record_protocol_crypter_common.cc */; };
-		OBJ_2036 /* alts_seal_privacy_integrity_crypter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_639 /* alts_seal_privacy_integrity_crypter.cc */; };
-		OBJ_2037 /* alts_unseal_privacy_integrity_crypter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_640 /* alts_unseal_privacy_integrity_crypter.cc */; };
-		OBJ_2038 /* frame_handler.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_641 /* frame_handler.cc */; };
-		OBJ_2039 /* alts_handshaker_client.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_643 /* alts_handshaker_client.cc */; };
-		OBJ_2040 /* alts_handshaker_service_api.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_644 /* alts_handshaker_service_api.cc */; };
-		OBJ_2041 /* alts_handshaker_service_api_util.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_645 /* alts_handshaker_service_api_util.cc */; };
-		OBJ_2042 /* alts_tsi_event.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_646 /* alts_tsi_event.cc */; };
-		OBJ_2043 /* alts_tsi_handshaker.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_647 /* alts_tsi_handshaker.cc */; };
-		OBJ_2044 /* alts_tsi_utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_648 /* alts_tsi_utils.cc */; };
-		OBJ_2045 /* altscontext.pb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_649 /* altscontext.pb.c */; };
-		OBJ_2046 /* handshaker.pb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_650 /* handshaker.pb.c */; };
-		OBJ_2047 /* transport_security_common.pb.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_651 /* transport_security_common.pb.c */; };
-		OBJ_2048 /* transport_security_common_api.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_652 /* transport_security_common_api.cc */; };
-		OBJ_2049 /* alts_grpc_integrity_only_record_protocol.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_654 /* alts_grpc_integrity_only_record_protocol.cc */; };
-		OBJ_2050 /* alts_grpc_privacy_integrity_record_protocol.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_655 /* alts_grpc_privacy_integrity_record_protocol.cc */; };
-		OBJ_2051 /* alts_grpc_record_protocol_common.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_656 /* alts_grpc_record_protocol_common.cc */; };
-		OBJ_2052 /* alts_iovec_record_protocol.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_657 /* alts_iovec_record_protocol.cc */; };
-		OBJ_2053 /* alts_zero_copy_grpc_protector.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_658 /* alts_zero_copy_grpc_protector.cc */; };
-		OBJ_2054 /* alts_transport_security.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_659 /* alts_transport_security.cc */; };
-		OBJ_2055 /* fake_transport_security.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_660 /* fake_transport_security.cc */; };
-		OBJ_2056 /* ssl_session_boringssl.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_663 /* ssl_session_boringssl.cc */; };
-		OBJ_2057 /* ssl_session_cache.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_664 /* ssl_session_cache.cc */; };
-		OBJ_2058 /* ssl_session_openssl.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_665 /* ssl_session_openssl.cc */; };
-		OBJ_2059 /* ssl_transport_security.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_666 /* ssl_transport_security.cc */; };
-		OBJ_2060 /* transport_security.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_667 /* transport_security.cc */; };
-		OBJ_2061 /* transport_security_adapter.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_668 /* transport_security_adapter.cc */; };
-		OBJ_2062 /* transport_security_grpc.cc in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_669 /* transport_security_grpc.cc */; };
-		OBJ_2063 /* pb_common.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_672 /* pb_common.c */; };
-		OBJ_2064 /* pb_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_673 /* pb_decode.c */; };
-		OBJ_2065 /* pb_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_674 /* pb_encode.c */; };
-		OBJ_2067 /* BoringSSL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::BoringSSL::Product" /* BoringSSL.framework */; };
-		OBJ_2073 /* AuthClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_221 /* AuthClientTests.swift */; };
-		OBJ_2074 /* ClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_222 /* ClientTests.swift */; };
-		OBJ_2075 /* DeviceClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_223 /* DeviceClientTests.swift */; };
-		OBJ_2076 /* MenuClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_224 /* MenuClientTests.swift */; };
-		OBJ_2077 /* PlatformClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_225 /* PlatformClientTests.swift */; };
-		OBJ_2078 /* ShopClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_226 /* ShopClientTests.swift */; };
-		OBJ_2079 /* TelemetryClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_227 /* TelemetryClientTests.swift */; };
-		OBJ_2081 /* Bloombox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Bloombox::Bloombox::Product" /* Bloombox.framework */; };
-		OBJ_2082 /* BloomboxServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Bloombox::BloomboxServices::Product" /* BloomboxServices.framework */; };
-		OBJ_2083 /* SwiftGRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::SwiftGRPC::Product" /* SwiftGRPC.framework */; };
-		OBJ_2084 /* CgRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::CgRPC::Product" /* CgRPC.framework */; };
-		OBJ_2085 /* BoringSSL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::BoringSSL::Product" /* BoringSSL.framework */; };
-		OBJ_2086 /* OpenCannabis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Bloombox::OpenCannabis::Product" /* OpenCannabis.framework */; };
-		OBJ_2087 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftProtobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
-		OBJ_2099 /* accounting_Taxes.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* accounting_Taxes.pb.swift */; };
-		OBJ_2100 /* analytics_Context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* analytics_Context.pb.swift */; };
-		OBJ_2101 /* analytics_Scope.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* analytics_Scope.pb.swift */; };
-		OBJ_2102 /* analytics_commerce_OrderAnalytics.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* analytics_commerce_OrderAnalytics.pb.swift */; };
-		OBJ_2103 /* analytics_commerce_ProductAnalytics.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* analytics_commerce_ProductAnalytics.pb.swift */; };
-		OBJ_2104 /* analytics_commerce_SectionAnalytics.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* analytics_commerce_SectionAnalytics.pb.swift */; };
-		OBJ_2105 /* analytics_commerce_ShopAnalytics.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* analytics_commerce_ShopAnalytics.pb.swift */; };
-		OBJ_2106 /* analytics_consumption_Biodelivery.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_47 /* analytics_consumption_Biodelivery.pb.swift */; };
-		OBJ_2107 /* analytics_context_Application.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_48 /* analytics_context_Application.pb.swift */; };
-		OBJ_2108 /* analytics_context_Browser.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_49 /* analytics_context_Browser.pb.swift */; };
-		OBJ_2109 /* analytics_context_Collection.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_50 /* analytics_context_Collection.pb.swift */; };
-		OBJ_2110 /* analytics_context_Library.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_51 /* analytics_context_Library.pb.swift */; };
-		OBJ_2111 /* analytics_context_NativeDevice.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_52 /* analytics_context_NativeDevice.pb.swift */; };
-		OBJ_2112 /* analytics_context_OS.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_53 /* analytics_context_OS.pb.swift */; };
-		OBJ_2113 /* analytics_generic_Event.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_54 /* analytics_generic_Event.pb.swift */; };
-		OBJ_2114 /* analytics_generic_Exception.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_55 /* analytics_generic_Exception.pb.swift */; };
-		OBJ_2115 /* analytics_identity_UserAnalytics.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_56 /* analytics_identity_UserAnalytics.pb.swift */; };
-		OBJ_2116 /* analytics_search_SearchProperty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_57 /* analytics_search_SearchProperty.pb.swift */; };
-		OBJ_2117 /* analytics_stats_OrderStats.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_58 /* analytics_stats_OrderStats.pb.swift */; };
-		OBJ_2118 /* analytics_stats_SessionStats.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_59 /* analytics_stats_SessionStats.pb.swift */; };
-		OBJ_2119 /* analytics_stream_Filter.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_60 /* analytics_stream_Filter.pb.swift */; };
-		OBJ_2120 /* auth_v1beta1_AuthService_Beta1.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_61 /* auth_v1beta1_AuthService_Beta1.pb.swift */; };
-		OBJ_2121 /* base_Compression.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_62 /* base_Compression.pb.swift */; };
-		OBJ_2122 /* base_Language.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_63 /* base_Language.pb.swift */; };
-		OBJ_2123 /* base_ProductKey.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_64 /* base_ProductKey.pb.swift */; };
-		OBJ_2124 /* base_ProductKind.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_65 /* base_ProductKind.pb.swift */; };
-		OBJ_2126 /* commerce_Currency.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_67 /* commerce_Currency.pb.swift */; };
-		OBJ_2127 /* commerce_Customer.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_68 /* commerce_Customer.pb.swift */; };
-		OBJ_2128 /* commerce_Delivery.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_69 /* commerce_Delivery.pb.swift */; };
-		OBJ_2129 /* commerce_Discounts.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_70 /* commerce_Discounts.pb.swift */; };
-		OBJ_2130 /* commerce_Item.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* commerce_Item.pb.swift */; };
-		OBJ_2131 /* commerce_Order.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* commerce_Order.pb.swift */; };
-		OBJ_2132 /* commerce_Purchase.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* commerce_Purchase.pb.swift */; };
-		OBJ_2133 /* commerce_payments_Payment.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* commerce_payments_Payment.pb.swift */; };
-		OBJ_2134 /* comms_Comms.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_75 /* comms_Comms.pb.swift */; };
-		OBJ_2135 /* comms_CommsTask.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_76 /* comms_CommsTask.pb.swift */; };
-		OBJ_2136 /* comms_Email.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_77 /* comms_Email.pb.swift */; };
-		OBJ_2137 /* comms_SMS.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_78 /* comms_SMS.pb.swift */; };
-		OBJ_2138 /* contact_ContactInfo.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_79 /* contact_ContactInfo.pb.swift */; };
-		OBJ_2139 /* contact_EmailAddress.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_80 /* contact_EmailAddress.pb.swift */; };
-		OBJ_2140 /* contact_PhoneNumber.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_81 /* contact_PhoneNumber.pb.swift */; };
-		OBJ_2141 /* contact_Website.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_82 /* contact_Website.pb.swift */; };
-		OBJ_2142 /* content_Brand.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_83 /* content_Brand.pb.swift */; };
-		OBJ_2143 /* content_Colors.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_84 /* content_Colors.pb.swift */; };
-		OBJ_2144 /* content_Content.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_85 /* content_Content.pb.swift */; };
-		OBJ_2145 /* content_MaterialsData.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_86 /* content_MaterialsData.pb.swift */; };
-		OBJ_2146 /* content_Name.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_87 /* content_Name.pb.swift */; };
-		OBJ_2147 /* content_ProductContent.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_88 /* content_ProductContent.pb.swift */; };
-		OBJ_2148 /* core_Datamodel.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_89 /* core_Datamodel.pb.swift */; };
-		OBJ_2149 /* crypto_Container.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_90 /* crypto_Container.pb.swift */; };
-		OBJ_2150 /* crypto_Signature.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_91 /* crypto_Signature.pb.swift */; };
-		OBJ_2151 /* crypto_primitives_Integrity.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_92 /* crypto_primitives_Integrity.pb.swift */; };
-		OBJ_2152 /* crypto_primitives_Keys.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_93 /* crypto_primitives_Keys.pb.swift */; };
-		OBJ_2154 /* device_Device.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_95 /* device_Device.pb.swift */; };
-		OBJ_2155 /* devices_v1beta1_DevicesService_Beta1.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_96 /* devices_v1beta1_DevicesService_Beta1.pb.swift */; };
-		OBJ_2156 /* geo_Address.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_97 /* geo_Address.pb.swift */; };
-		OBJ_2157 /* geo_Country.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_98 /* geo_Country.pb.swift */; };
-		OBJ_2158 /* geo_Distance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_99 /* geo_Distance.pb.swift */; };
-		OBJ_2159 /* geo_Geohash.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_100 /* geo_Geohash.pb.swift */; };
-		OBJ_2160 /* geo_Location.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_101 /* geo_Location.pb.swift */; };
-		OBJ_2161 /* geo_Point.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_102 /* geo_Point.pb.swift */; };
-		OBJ_2162 /* geo_Province.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_103 /* geo_Province.pb.swift */; };
-		OBJ_2163 /* geo_USState.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_104 /* geo_USState.pb.swift */; };
-		OBJ_2164 /* geo_usa_ca_CACounty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_105 /* geo_usa_ca_CACounty.pb.swift */; };
-		OBJ_2165 /* google_api_annotations.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_106 /* google_api_annotations.pb.swift */; };
-		OBJ_2166 /* google_api_http.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_107 /* google_api_http.pb.swift */; };
-		OBJ_2167 /* google_protobuf_descriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_108 /* google_protobuf_descriptor.pb.swift */; };
-		OBJ_2168 /* identity_ID.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_109 /* identity_ID.pb.swift */; };
-		OBJ_2169 /* identity_IDMedia.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_110 /* identity_IDMedia.pb.swift */; };
-		OBJ_2170 /* identity_Membership.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_111 /* identity_Membership.pb.swift */; };
-		OBJ_2171 /* identity_MembershipKey.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_112 /* identity_MembershipKey.pb.swift */; };
-		OBJ_2172 /* identity_StaffUser.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_113 /* identity_StaffUser.pb.swift */; };
-		OBJ_2173 /* identity_User.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_114 /* identity_User.pb.swift */; };
-		OBJ_2174 /* identity_UserKey.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_115 /* identity_UserKey.pb.swift */; };
-		OBJ_2179 /* identity_ids_Passport.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_120 /* identity_ids_Passport.pb.swift */; };
-		OBJ_2180 /* identity_ids_USDL.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_121 /* identity_ids_USDL.pb.swift */; };
-		OBJ_2181 /* identity_ids_UserDoctorRec.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_122 /* identity_ids_UserDoctorRec.pb.swift */; };
-		OBJ_2182 /* identity_industry_DashboardStaffSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_123 /* identity_industry_DashboardStaffSettings.pb.swift */; };
-		OBJ_2183 /* identity_industry_POSStaffSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_124 /* identity_industry_POSStaffSettings.pb.swift */; };
-		OBJ_2184 /* identity_industry_StaffSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_125 /* identity_industry_StaffSettings.pb.swift */; };
-		OBJ_2185 /* identity_pass_Pass.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_126 /* identity_pass_Pass.pb.swift */; };
-		OBJ_2186 /* identity_pass_PassKey.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_127 /* identity_pass_PassKey.pb.swift */; };
-		OBJ_2187 /* identity_v1beta1_IdentityService_Beta1.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_128 /* identity_v1beta1_IdentityService_Beta1.pb.swift */; };
-		OBJ_2188 /* inventory_InventoryLocation.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_129 /* inventory_InventoryLocation.pb.swift */; };
-		OBJ_2189 /* inventory_InventoryProduct.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_130 /* inventory_InventoryProduct.pb.swift */; };
-		OBJ_2190 /* ledger_Account.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_131 /* ledger_Account.pb.swift */; };
-		OBJ_2191 /* ledger_Asset.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_132 /* ledger_Asset.pb.swift */; };
-		OBJ_2192 /* ledger_Transaction.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_133 /* ledger_Transaction.pb.swift */; };
-		OBJ_2194 /* licensing_Licensure.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_135 /* licensing_Licensure.pb.swift */; };
-		OBJ_2195 /* marketing_Campaign.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_136 /* marketing_Campaign.pb.swift */; };
-		OBJ_2196 /* marketing_Targeting.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_137 /* marketing_Targeting.pb.swift */; };
-		OBJ_2198 /* media_MediaItem.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_139 /* media_MediaItem.pb.swift */; };
-		OBJ_2199 /* media_MediaKey.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_140 /* media_MediaKey.pb.swift */; };
-		OBJ_2200 /* media_MediaOrientation.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_141 /* media_MediaOrientation.pb.swift */; };
-		OBJ_2201 /* media_MediaType.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_142 /* media_MediaType.pb.swift */; };
-		OBJ_2202 /* media_v1beta1_MediaService_Beta1.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_143 /* media_v1beta1_MediaService_Beta1.pb.swift */; };
-		OBJ_2203 /* media_v1beta1_MediaTask.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_144 /* media_v1beta1_MediaTask.pb.swift */; };
-		OBJ_2204 /* menu_v1beta1_MenuService_Beta1.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_145 /* menu_v1beta1_MenuService_Beta1.pb.swift */; };
-		OBJ_2205 /* oauth_AuthorizationScope.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_146 /* oauth_AuthorizationScope.pb.swift */; };
-		OBJ_2206 /* oauth_Client.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_147 /* oauth_Client.pb.swift */; };
-		OBJ_2207 /* partner_LocationKey.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_148 /* partner_LocationKey.pb.swift */; };
-		OBJ_2208 /* partner_Partner.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_149 /* partner_Partner.pb.swift */; };
-		OBJ_2209 /* partner_PartnerDevice.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_150 /* partner_PartnerDevice.pb.swift */; };
-		OBJ_2210 /* partner_PartnerFlags.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_151 /* partner_PartnerFlags.pb.swift */; };
-		OBJ_2211 /* partner_PartnerKey.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_152 /* partner_PartnerKey.pb.swift */; };
-		OBJ_2212 /* partner_PartnerLocation.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_153 /* partner_PartnerLocation.pb.swift */; };
-		OBJ_2213 /* partner_PartnerScope.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_154 /* partner_PartnerScope.pb.swift */; };
-		OBJ_2214 /* partner_integrations_GSuiteSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_155 /* partner_integrations_GSuiteSettings.pb.swift */; };
-		OBJ_2215 /* partner_integrations_GreenbitsSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_156 /* partner_integrations_GreenbitsSettings.pb.swift */; };
-		OBJ_2216 /* partner_integrations_IntegrationSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_157 /* partner_integrations_IntegrationSettings.pb.swift */; };
-		OBJ_2217 /* partner_integrations_MailchimpSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_158 /* partner_integrations_MailchimpSettings.pb.swift */; };
-		OBJ_2218 /* partner_integrations_OnFleetSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_159 /* partner_integrations_OnFleetSettings.pb.swift */; };
-		OBJ_2219 /* partner_integrations_SendgridSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_160 /* partner_integrations_SendgridSettings.pb.swift */; };
-		OBJ_2220 /* partner_integrations_TreezSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_161 /* partner_integrations_TreezSettings.pb.swift */; };
-		OBJ_2221 /* partner_integrations_TwilioSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_162 /* partner_integrations_TwilioSettings.pb.swift */; };
-		OBJ_2222 /* partner_settings_PartnerLocationSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_163 /* partner_settings_PartnerLocationSettings.pb.swift */; };
-		OBJ_2223 /* partner_settings_PartnerSettings.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_164 /* partner_settings_PartnerSettings.pb.swift */; };
-		OBJ_2225 /* person_Person.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_166 /* person_Person.pb.swift */; };
-		OBJ_2226 /* person_PersonName.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_167 /* person_PersonName.pb.swift */; };
-		OBJ_2227 /* platform_v1_PlatformService_v1.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_168 /* platform_v1_PlatformService_v1.pb.swift */; };
-		OBJ_2228 /* pos_PointOfSale.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_169 /* pos_PointOfSale.pb.swift */; };
-		OBJ_2229 /* pos_v1beta1_POSService_Beta1.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_170 /* pos_v1beta1_POSService_Beta1.pb.swift */; };
-		OBJ_2230 /* products_Apothecary.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_171 /* products_Apothecary.pb.swift */; };
-		OBJ_2231 /* products_Cartridge.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_172 /* products_Cartridge.pb.swift */; };
-		OBJ_2232 /* products_Edible.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_173 /* products_Edible.pb.swift */; };
-		OBJ_2233 /* products_Extract.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_174 /* products_Extract.pb.swift */; };
-		OBJ_2234 /* products_Flower.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_175 /* products_Flower.pb.swift */; };
-		OBJ_2235 /* products_Merchandise.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_176 /* products_Merchandise.pb.swift */; };
-		OBJ_2236 /* products_Plant.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_177 /* products_Plant.pb.swift */; };
-		OBJ_2237 /* products_Preroll.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_178 /* products_Preroll.pb.swift */; };
-		OBJ_2238 /* products_distribution_DistributionChannel.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_179 /* products_distribution_DistributionChannel.pb.swift */; };
-		OBJ_2239 /* products_menu_Menu.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_180 /* products_menu_Menu.pb.swift */; };
-		OBJ_2240 /* products_menu_Section.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_181 /* products_menu_Section.pb.swift */; };
-		OBJ_2241 /* protoc-gen-swagger_options_openapiv2.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_182 /* protoc-gen-swagger_options_openapiv2.pb.swift */; };
-		OBJ_2242 /* protoc-gen-swagger_options_swagger.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_183 /* protoc-gen-swagger_options_swagger.pb.swift */; };
-		OBJ_2243 /* proximity_BluetoothBeacon.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_184 /* proximity_BluetoothBeacon.pb.swift */; };
-		OBJ_2244 /* regulatory_usa_ca_CAAgency.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_185 /* regulatory_usa_ca_CAAgency.pb.swift */; };
-		OBJ_2245 /* search_SearchResult.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_186 /* search_SearchResult.pb.swift */; };
-		OBJ_2246 /* search_SearchSpec.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_187 /* search_SearchSpec.pb.swift */; };
-		OBJ_2247 /* security_DeviceTicket.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_188 /* security_DeviceTicket.pb.swift */; };
-		OBJ_2248 /* security_IdentityToken.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_189 /* security_IdentityToken.pb.swift */; };
-		OBJ_2249 /* security_Token.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_190 /* security_Token.pb.swift */; };
-		OBJ_2250 /* security_access_PartnerPermissions.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_191 /* security_access_PartnerPermissions.pb.swift */; };
-		OBJ_2251 /* services_ServiceStatus.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_192 /* services_ServiceStatus.pb.swift */; };
-		OBJ_2252 /* shop_v1_ShopService_v1.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_193 /* shop_v1_ShopService_v1.pb.swift */; };
-		OBJ_2253 /* structs_Genetics.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_194 /* structs_Genetics.pb.swift */; };
-		OBJ_2254 /* structs_Grow.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_195 /* structs_Grow.pb.swift */; };
-		OBJ_2255 /* structs_ProductFlags.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_196 /* structs_ProductFlags.pb.swift */; };
-		OBJ_2256 /* structs_Shelf.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_197 /* structs_Shelf.pb.swift */; };
-		OBJ_2257 /* structs_Species.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_198 /* structs_Species.pb.swift */; };
-		OBJ_2258 /* structs_Version.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_199 /* structs_Version.pb.swift */; };
-		OBJ_2259 /* structs_labtesting_TestResults.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_200 /* structs_labtesting_TestResults.pb.swift */; };
-		OBJ_2260 /* structs_labtesting_TestValue.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_201 /* structs_labtesting_TestValue.pb.swift */; };
-		OBJ_2261 /* structs_pricing_PricingDescriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_202 /* structs_pricing_PricingDescriptor.pb.swift */; };
-		OBJ_2262 /* structs_pricing_SaleDescriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_203 /* structs_pricing_SaleDescriptor.pb.swift */; };
-		OBJ_2263 /* telemetry_v1beta4_GenericEvents_Beta4.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_204 /* telemetry_v1beta4_GenericEvents_Beta4.pb.swift */; };
-		OBJ_2264 /* telemetry_v1beta4_TelemetryEvent_Beta4.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_205 /* telemetry_v1beta4_TelemetryEvent_Beta4.pb.swift */; };
-		OBJ_2265 /* telemetry_v1beta4_TelemetryService_Beta4.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_206 /* telemetry_v1beta4_TelemetryService_Beta4.pb.swift */; };
-		OBJ_2266 /* temporal_Date.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_207 /* temporal_Date.pb.swift */; };
-		OBJ_2267 /* temporal_Duration.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_208 /* temporal_Duration.pb.swift */; };
-		OBJ_2268 /* temporal_Instant.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_209 /* temporal_Instant.pb.swift */; };
-		OBJ_2269 /* temporal_Interval.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_210 /* temporal_Interval.pb.swift */; };
-		OBJ_2270 /* temporal_Schedule.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_211 /* temporal_Schedule.pb.swift */; };
-		OBJ_2271 /* temporal_Time.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_212 /* temporal_Time.pb.swift */; };
-		OBJ_2272 /* temporal_Timehash.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_213 /* temporal_Timehash.pb.swift */; };
-		OBJ_2273 /* wallet_v1_WalletService_v1.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_214 /* wallet_v1_WalletService_v1.pb.swift */; };
-		OBJ_2275 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftProtobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
-		OBJ_2281 /* ModelTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_217 /* ModelTool.swift */; };
-		OBJ_2282 /* SchemaTests+Codec.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_218 /* SchemaTests+Codec.swift */; };
-		OBJ_2283 /* SchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_219 /* SchemaTests.swift */; };
-		OBJ_2285 /* Bloombox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Bloombox::Bloombox::Product" /* Bloombox.framework */; };
-		OBJ_2286 /* BloomboxServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Bloombox::BloomboxServices::Product" /* BloomboxServices.framework */; };
-		OBJ_2287 /* SwiftGRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::SwiftGRPC::Product" /* SwiftGRPC.framework */; };
-		OBJ_2288 /* CgRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::CgRPC::Product" /* CgRPC.framework */; };
-		OBJ_2289 /* BoringSSL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::BoringSSL::Product" /* BoringSSL.framework */; };
-		OBJ_2290 /* OpenCannabis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Bloombox::OpenCannabis::Product" /* OpenCannabis.framework */; };
-		OBJ_2291 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftProtobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
-		OBJ_2303 /* ByteBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1181 /* ByteBuffer.swift */; };
-		OBJ_2304 /* Call.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1182 /* Call.swift */; };
-		OBJ_2305 /* CallError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1183 /* CallError.swift */; };
-		OBJ_2306 /* CallResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1184 /* CallResult.swift */; };
-		OBJ_2307 /* Channel.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1185 /* Channel.swift */; };
-		OBJ_2308 /* ChannelArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1186 /* ChannelArgument.swift */; };
-		OBJ_2309 /* CompletionQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1187 /* CompletionQueue.swift */; };
-		OBJ_2310 /* Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1188 /* Handler.swift */; };
-		OBJ_2311 /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1189 /* Metadata.swift */; };
-		OBJ_2312 /* Mutex.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1190 /* Mutex.swift */; };
-		OBJ_2313 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1191 /* Operation.swift */; };
-		OBJ_2314 /* OperationGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1192 /* OperationGroup.swift */; };
-		OBJ_2315 /* Roots.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1193 /* Roots.swift */; };
-		OBJ_2316 /* Server.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1194 /* Server.swift */; };
-		OBJ_2317 /* ServerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1195 /* ServerStatus.swift */; };
-		OBJ_2318 /* gRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1196 /* gRPC.swift */; };
-		OBJ_2319 /* ClientCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1198 /* ClientCall.swift */; };
-		OBJ_2320 /* ClientCallBidirectionalStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1199 /* ClientCallBidirectionalStreaming.swift */; };
-		OBJ_2321 /* ClientCallClientStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1200 /* ClientCallClientStreaming.swift */; };
-		OBJ_2322 /* ClientCallServerStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1201 /* ClientCallServerStreaming.swift */; };
-		OBJ_2323 /* ClientCallUnary.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1202 /* ClientCallUnary.swift */; };
-		OBJ_2324 /* RPCError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1203 /* RPCError.swift */; };
-		OBJ_2325 /* ServerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1204 /* ServerSession.swift */; };
-		OBJ_2326 /* ServerSessionBidirectionalStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1205 /* ServerSessionBidirectionalStreaming.swift */; };
-		OBJ_2327 /* ServerSessionClientStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1206 /* ServerSessionClientStreaming.swift */; };
-		OBJ_2328 /* ServerSessionServerStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1207 /* ServerSessionServerStreaming.swift */; };
-		OBJ_2329 /* ServerSessionUnary.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1208 /* ServerSessionUnary.swift */; };
-		OBJ_2330 /* ServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1209 /* ServiceClient.swift */; };
-		OBJ_2331 /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1210 /* ServiceProvider.swift */; };
-		OBJ_2332 /* ServiceServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1211 /* ServiceServer.swift */; };
-		OBJ_2333 /* StreamReceiving.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1212 /* StreamReceiving.swift */; };
-		OBJ_2334 /* StreamSending.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1213 /* StreamSending.swift */; };
-		OBJ_2336 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftProtobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */; };
-		OBJ_2337 /* CgRPC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::CgRPC::Product" /* CgRPC.framework */; };
-		OBJ_2338 /* BoringSSL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftGRPC::BoringSSL::Product" /* BoringSSL.framework */; };
-		OBJ_2347 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1214 /* Package.swift */; };
-		OBJ_2352 /* AnyMessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1219 /* AnyMessageStorage.swift */; };
-		OBJ_2353 /* AnyUnpackError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1220 /* AnyUnpackError.swift */; };
-		OBJ_2354 /* BinaryDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1221 /* BinaryDecoder.swift */; };
-		OBJ_2355 /* BinaryDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1222 /* BinaryDecodingError.swift */; };
-		OBJ_2356 /* BinaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1223 /* BinaryDecodingOptions.swift */; };
-		OBJ_2357 /* BinaryDelimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1224 /* BinaryDelimited.swift */; };
-		OBJ_2358 /* BinaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1225 /* BinaryEncoder.swift */; };
-		OBJ_2359 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1226 /* BinaryEncodingError.swift */; };
-		OBJ_2360 /* BinaryEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1227 /* BinaryEncodingSizeVisitor.swift */; };
-		OBJ_2361 /* BinaryEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1228 /* BinaryEncodingVisitor.swift */; };
-		OBJ_2362 /* CustomJSONCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1229 /* CustomJSONCodable.swift */; };
-		OBJ_2363 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1230 /* Decoder.swift */; };
-		OBJ_2364 /* DoubleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1231 /* DoubleFormatter.swift */; };
-		OBJ_2365 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1232 /* Enum.swift */; };
-		OBJ_2366 /* ExtensibleMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1233 /* ExtensibleMessage.swift */; };
-		OBJ_2367 /* ExtensionFieldValueSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1234 /* ExtensionFieldValueSet.swift */; };
-		OBJ_2368 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1235 /* ExtensionFields.swift */; };
-		OBJ_2369 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1236 /* ExtensionMap.swift */; };
-		OBJ_2370 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1237 /* FieldTag.swift */; };
-		OBJ_2371 /* FieldTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1238 /* FieldTypes.swift */; };
-		OBJ_2372 /* Google_Protobuf_Any+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1239 /* Google_Protobuf_Any+Extensions.swift */; };
-		OBJ_2373 /* Google_Protobuf_Any+Registry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1240 /* Google_Protobuf_Any+Registry.swift */; };
-		OBJ_2374 /* Google_Protobuf_Duration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1241 /* Google_Protobuf_Duration+Extensions.swift */; };
-		OBJ_2375 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1242 /* Google_Protobuf_FieldMask+Extensions.swift */; };
-		OBJ_2376 /* Google_Protobuf_ListValue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1243 /* Google_Protobuf_ListValue+Extensions.swift */; };
-		OBJ_2377 /* Google_Protobuf_Struct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1244 /* Google_Protobuf_Struct+Extensions.swift */; };
-		OBJ_2378 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1245 /* Google_Protobuf_Timestamp+Extensions.swift */; };
-		OBJ_2379 /* Google_Protobuf_Value+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1246 /* Google_Protobuf_Value+Extensions.swift */; };
-		OBJ_2380 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1247 /* Google_Protobuf_Wrappers+Extensions.swift */; };
-		OBJ_2381 /* HashVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1248 /* HashVisitor.swift */; };
-		OBJ_2382 /* Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1249 /* Internal.swift */; };
-		OBJ_2383 /* JSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1250 /* JSONDecoder.swift */; };
-		OBJ_2384 /* JSONDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1251 /* JSONDecodingError.swift */; };
-		OBJ_2385 /* JSONDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1252 /* JSONDecodingOptions.swift */; };
-		OBJ_2386 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1253 /* JSONEncoder.swift */; };
-		OBJ_2387 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1254 /* JSONEncodingError.swift */; };
-		OBJ_2388 /* JSONEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1255 /* JSONEncodingVisitor.swift */; };
-		OBJ_2389 /* JSONMapEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1256 /* JSONMapEncodingVisitor.swift */; };
-		OBJ_2390 /* JSONScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1257 /* JSONScanner.swift */; };
-		OBJ_2391 /* MathUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1258 /* MathUtils.swift */; };
-		OBJ_2392 /* Message+AnyAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1259 /* Message+AnyAdditions.swift */; };
-		OBJ_2393 /* Message+BinaryAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1260 /* Message+BinaryAdditions.swift */; };
-		OBJ_2394 /* Message+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1261 /* Message+JSONAdditions.swift */; };
-		OBJ_2395 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1262 /* Message+JSONArrayAdditions.swift */; };
-		OBJ_2396 /* Message+TextFormatAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1263 /* Message+TextFormatAdditions.swift */; };
-		OBJ_2397 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1264 /* Message.swift */; };
-		OBJ_2398 /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1265 /* MessageExtension.swift */; };
-		OBJ_2399 /* NameMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1266 /* NameMap.swift */; };
-		OBJ_2400 /* ProtoNameProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1267 /* ProtoNameProviding.swift */; };
-		OBJ_2401 /* ProtobufAPIVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1268 /* ProtobufAPIVersionCheck.swift */; };
-		OBJ_2402 /* ProtobufMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1269 /* ProtobufMap.swift */; };
-		OBJ_2403 /* SelectiveVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1270 /* SelectiveVisitor.swift */; };
-		OBJ_2404 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1271 /* SimpleExtensionMap.swift */; };
-		OBJ_2405 /* StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1272 /* StringUtils.swift */; };
-		OBJ_2406 /* TextFormatDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1273 /* TextFormatDecoder.swift */; };
-		OBJ_2407 /* TextFormatDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1274 /* TextFormatDecodingError.swift */; };
-		OBJ_2408 /* TextFormatEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1275 /* TextFormatEncoder.swift */; };
-		OBJ_2409 /* TextFormatEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1276 /* TextFormatEncodingVisitor.swift */; };
-		OBJ_2410 /* TextFormatScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1277 /* TextFormatScanner.swift */; };
-		OBJ_2411 /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1278 /* TimeUtils.swift */; };
-		OBJ_2412 /* UnknownStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1279 /* UnknownStorage.swift */; };
-		OBJ_2413 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1280 /* Varint.swift */; };
-		OBJ_2414 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1281 /* Version.swift */; };
-		OBJ_2415 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1282 /* Visitor.swift */; };
-		OBJ_2416 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1283 /* WireFormat.swift */; };
-		OBJ_2417 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1284 /* ZigZag.swift */; };
-		OBJ_2418 /* any.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1285 /* any.pb.swift */; };
-		OBJ_2419 /* api.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1286 /* api.pb.swift */; };
-		OBJ_2420 /* duration.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1287 /* duration.pb.swift */; };
-		OBJ_2421 /* empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1288 /* empty.pb.swift */; };
-		OBJ_2422 /* field_mask.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1289 /* field_mask.pb.swift */; };
-		OBJ_2423 /* source_context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1290 /* source_context.pb.swift */; };
-		OBJ_2424 /* struct.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1291 /* struct.pb.swift */; };
-		OBJ_2425 /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1292 /* timestamp.pb.swift */; };
-		OBJ_2426 /* type.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1293 /* type.pb.swift */; };
-		OBJ_2427 /* wrappers.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1294 /* wrappers.pb.swift */; };
-		OBJ_2434 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_1296 /* Package.swift */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		222EF12621C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::BloomboxServices";
-			remoteInfo = BloomboxServices;
-		};
-		222EF12721C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::SwiftGRPC";
-			remoteInfo = SwiftGRPC;
-		};
-		222EF12821C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftProtobuf::SwiftProtobuf";
-			remoteInfo = SwiftProtobuf;
-		};
-		222EF12921C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::CgRPC";
-			remoteInfo = CgRPC;
-		};
-		222EF12A21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::BoringSSL";
-			remoteInfo = BoringSSL;
-		};
-		222EF12B21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::BoringSSL";
-			remoteInfo = BoringSSL;
-		};
-		222EF12C21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::CgRPC";
-			remoteInfo = CgRPC;
-		};
-		222EF12D21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::BoringSSL";
-			remoteInfo = BoringSSL;
-		};
-		222EF12E21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::OpenCannabis";
-			remoteInfo = OpenCannabis;
-		};
-		222EF12F21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftProtobuf::SwiftProtobuf";
-			remoteInfo = SwiftProtobuf;
-		};
-		222EF13021C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftProtobuf::SwiftProtobuf";
-			remoteInfo = SwiftProtobuf;
-		};
-		222EF13121C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::SwiftGRPC";
-			remoteInfo = SwiftGRPC;
-		};
-		222EF13221C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::CgRPC";
-			remoteInfo = CgRPC;
-		};
-		222EF13321C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::BoringSSL";
-			remoteInfo = BoringSSL;
-		};
-		222EF13421C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::OpenCannabis";
-			remoteInfo = OpenCannabis;
-		};
-		222EF13521C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftProtobuf::SwiftProtobuf";
-			remoteInfo = SwiftProtobuf;
-		};
-		222EF13621C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::Bloombox";
-			remoteInfo = Bloombox;
-		};
-		222EF13721C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::BloomboxServices";
-			remoteInfo = BloomboxServices;
-		};
-		222EF13821C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::SwiftGRPC";
-			remoteInfo = SwiftGRPC;
-		};
-		222EF13921C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::CgRPC";
-			remoteInfo = CgRPC;
-		};
-		222EF13A21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::BoringSSL";
-			remoteInfo = BoringSSL;
-		};
-		222EF13B21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::OpenCannabis";
-			remoteInfo = OpenCannabis;
-		};
-		222EF13C21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftProtobuf::SwiftProtobuf";
-			remoteInfo = SwiftProtobuf;
-		};
-		222EF13D21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::Bloombox";
-			remoteInfo = Bloombox;
-		};
-		222EF13E21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::BloomboxServices";
-			remoteInfo = BloomboxServices;
-		};
-		222EF13F21C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::SwiftGRPC";
-			remoteInfo = SwiftGRPC;
-		};
-		222EF14021C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::CgRPC";
-			remoteInfo = CgRPC;
-		};
-		222EF14121C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftGRPC::BoringSSL";
-			remoteInfo = BoringSSL;
-		};
-		222EF14221C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::OpenCannabis";
-			remoteInfo = OpenCannabis;
-		};
-		222EF14321C6F81E0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "SwiftProtobuf::SwiftProtobuf";
-			remoteInfo = SwiftProtobuf;
-		};
-		222EF14421C6F81F0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::SchemaTests";
-			remoteInfo = SchemaTests;
-		};
-		222EF14521C6F81F0008D96B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = OBJ_1 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = "Bloombox::ClientTests";
-			remoteInfo = ClientTests;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXFileReference section */
-		222EF14621C6FBE90008D96B /* IdentityClient.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = IdentityClient.swift; sourceTree = "<group>"; tabWidth = 2; };
-		222EF14821C7268C0008D96B /* identity_bioprint_Aspects.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = identity_bioprint_Aspects.pb.swift; sourceTree = "<group>"; };
-		222EF14921C7268C0008D96B /* identity_bioprint_Weights.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = identity_bioprint_Weights.pb.swift; sourceTree = "<group>"; };
-		222EF14A21C7268D0008D96B /* identity_bioprint_Affinities.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = identity_bioprint_Affinities.pb.swift; sourceTree = "<group>"; };
-		222EF14B21C7268D0008D96B /* identity_bioprint_Bioprint.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = identity_bioprint_Bioprint.pb.swift; sourceTree = "<group>"; };
-		"Bloombox::Bloombox::Product" /* Bloombox.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bloombox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"Bloombox::BloomboxServices::Product" /* BloomboxServices.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BloomboxServices.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"Bloombox::ClientTests::Product" /* ClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = ClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		"Bloombox::OpenCannabis::Product" /* OpenCannabis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OpenCannabis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"Bloombox::SchemaTests::Product" /* SchemaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = SchemaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		OBJ_10 /* Bindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bindings.swift; sourceTree = "<group>"; };
-		OBJ_100 /* geo_Geohash.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = geo_Geohash.pb.swift; sourceTree = "<group>"; };
-		OBJ_1000 /* x509_lu.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_lu.c; sourceTree = "<group>"; };
-		OBJ_1001 /* x509_obj.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_obj.c; sourceTree = "<group>"; };
-		OBJ_1002 /* x509_r2x.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_r2x.c; sourceTree = "<group>"; };
-		OBJ_1003 /* x509_req.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_req.c; sourceTree = "<group>"; };
-		OBJ_1004 /* x509_set.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_set.c; sourceTree = "<group>"; };
-		OBJ_1005 /* x509_trs.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_trs.c; sourceTree = "<group>"; };
-		OBJ_1006 /* x509_txt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_txt.c; sourceTree = "<group>"; };
-		OBJ_1007 /* x509_v3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_v3.c; sourceTree = "<group>"; };
-		OBJ_1008 /* x509_vfy.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_vfy.c; sourceTree = "<group>"; };
-		OBJ_1009 /* x509_vpm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_vpm.c; sourceTree = "<group>"; };
-		OBJ_101 /* geo_Location.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = geo_Location.pb.swift; sourceTree = "<group>"; };
-		OBJ_1010 /* x509cset.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509cset.c; sourceTree = "<group>"; };
-		OBJ_1011 /* x509name.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509name.c; sourceTree = "<group>"; };
-		OBJ_1012 /* x509rset.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509rset.c; sourceTree = "<group>"; };
-		OBJ_1013 /* x509spki.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509spki.c; sourceTree = "<group>"; };
-		OBJ_1014 /* x_algor.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_algor.c; sourceTree = "<group>"; };
-		OBJ_1015 /* x_all.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_all.c; sourceTree = "<group>"; };
-		OBJ_1016 /* x_attrib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_attrib.c; sourceTree = "<group>"; };
-		OBJ_1017 /* x_crl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_crl.c; sourceTree = "<group>"; };
-		OBJ_1018 /* x_exten.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_exten.c; sourceTree = "<group>"; };
-		OBJ_1019 /* x_info.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_info.c; sourceTree = "<group>"; };
-		OBJ_102 /* geo_Point.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = geo_Point.pb.swift; sourceTree = "<group>"; };
-		OBJ_1020 /* x_name.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_name.c; sourceTree = "<group>"; };
-		OBJ_1021 /* x_pkey.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_pkey.c; sourceTree = "<group>"; };
-		OBJ_1022 /* x_pubkey.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_pubkey.c; sourceTree = "<group>"; };
-		OBJ_1023 /* x_req.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_req.c; sourceTree = "<group>"; };
-		OBJ_1024 /* x_sig.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_sig.c; sourceTree = "<group>"; };
-		OBJ_1025 /* x_spki.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_spki.c; sourceTree = "<group>"; };
-		OBJ_1026 /* x_val.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_val.c; sourceTree = "<group>"; };
-		OBJ_1027 /* x_x509.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_x509.c; sourceTree = "<group>"; };
-		OBJ_1028 /* x_x509a.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_x509a.c; sourceTree = "<group>"; };
-		OBJ_103 /* geo_Province.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = geo_Province.pb.swift; sourceTree = "<group>"; };
-		OBJ_1030 /* pcy_cache.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pcy_cache.c; sourceTree = "<group>"; };
-		OBJ_1031 /* pcy_data.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pcy_data.c; sourceTree = "<group>"; };
-		OBJ_1032 /* pcy_lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pcy_lib.c; sourceTree = "<group>"; };
-		OBJ_1033 /* pcy_map.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pcy_map.c; sourceTree = "<group>"; };
-		OBJ_1034 /* pcy_node.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pcy_node.c; sourceTree = "<group>"; };
-		OBJ_1035 /* pcy_tree.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pcy_tree.c; sourceTree = "<group>"; };
-		OBJ_1036 /* v3_akey.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_akey.c; sourceTree = "<group>"; };
-		OBJ_1037 /* v3_akeya.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_akeya.c; sourceTree = "<group>"; };
-		OBJ_1038 /* v3_alt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_alt.c; sourceTree = "<group>"; };
-		OBJ_1039 /* v3_bcons.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_bcons.c; sourceTree = "<group>"; };
-		OBJ_104 /* geo_USState.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = geo_USState.pb.swift; sourceTree = "<group>"; };
-		OBJ_1040 /* v3_bitst.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_bitst.c; sourceTree = "<group>"; };
-		OBJ_1041 /* v3_conf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_conf.c; sourceTree = "<group>"; };
-		OBJ_1042 /* v3_cpols.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_cpols.c; sourceTree = "<group>"; };
-		OBJ_1043 /* v3_crld.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_crld.c; sourceTree = "<group>"; };
-		OBJ_1044 /* v3_enum.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_enum.c; sourceTree = "<group>"; };
-		OBJ_1045 /* v3_extku.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_extku.c; sourceTree = "<group>"; };
-		OBJ_1046 /* v3_genn.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_genn.c; sourceTree = "<group>"; };
-		OBJ_1047 /* v3_ia5.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_ia5.c; sourceTree = "<group>"; };
-		OBJ_1048 /* v3_info.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_info.c; sourceTree = "<group>"; };
-		OBJ_1049 /* v3_int.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_int.c; sourceTree = "<group>"; };
-		OBJ_105 /* geo_usa_ca_CACounty.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = geo_usa_ca_CACounty.pb.swift; sourceTree = "<group>"; };
-		OBJ_1050 /* v3_lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_lib.c; sourceTree = "<group>"; };
-		OBJ_1051 /* v3_ncons.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_ncons.c; sourceTree = "<group>"; };
-		OBJ_1052 /* v3_pci.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_pci.c; sourceTree = "<group>"; };
-		OBJ_1053 /* v3_pcia.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_pcia.c; sourceTree = "<group>"; };
-		OBJ_1054 /* v3_pcons.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_pcons.c; sourceTree = "<group>"; };
-		OBJ_1055 /* v3_pku.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_pku.c; sourceTree = "<group>"; };
-		OBJ_1056 /* v3_pmaps.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_pmaps.c; sourceTree = "<group>"; };
-		OBJ_1057 /* v3_prn.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_prn.c; sourceTree = "<group>"; };
-		OBJ_1058 /* v3_purp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_purp.c; sourceTree = "<group>"; };
-		OBJ_1059 /* v3_skey.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_skey.c; sourceTree = "<group>"; };
-		OBJ_106 /* google_api_annotations.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = google_api_annotations.pb.swift; sourceTree = "<group>"; };
-		OBJ_1060 /* v3_sxnet.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_sxnet.c; sourceTree = "<group>"; };
-		OBJ_1061 /* v3_utl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = v3_utl.c; sourceTree = "<group>"; };
-		OBJ_1062 /* err_data.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = err_data.c; sourceTree = "<group>"; };
-		OBJ_1064 /* bio_ssl.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = bio_ssl.cc; sourceTree = "<group>"; };
-		OBJ_1065 /* custom_extensions.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = custom_extensions.cc; sourceTree = "<group>"; };
-		OBJ_1066 /* d1_both.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = d1_both.cc; sourceTree = "<group>"; };
-		OBJ_1067 /* d1_lib.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = d1_lib.cc; sourceTree = "<group>"; };
-		OBJ_1068 /* d1_pkt.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = d1_pkt.cc; sourceTree = "<group>"; };
-		OBJ_1069 /* d1_srtp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = d1_srtp.cc; sourceTree = "<group>"; };
-		OBJ_107 /* google_api_http.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = google_api_http.pb.swift; sourceTree = "<group>"; };
-		OBJ_1070 /* dtls_method.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dtls_method.cc; sourceTree = "<group>"; };
-		OBJ_1071 /* dtls_record.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dtls_record.cc; sourceTree = "<group>"; };
-		OBJ_1072 /* handshake.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = handshake.cc; sourceTree = "<group>"; };
-		OBJ_1073 /* handshake_client.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = handshake_client.cc; sourceTree = "<group>"; };
-		OBJ_1074 /* handshake_server.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = handshake_server.cc; sourceTree = "<group>"; };
-		OBJ_1075 /* s3_both.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = s3_both.cc; sourceTree = "<group>"; };
-		OBJ_1076 /* s3_lib.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = s3_lib.cc; sourceTree = "<group>"; };
-		OBJ_1077 /* s3_pkt.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = s3_pkt.cc; sourceTree = "<group>"; };
-		OBJ_1078 /* ssl_aead_ctx.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_aead_ctx.cc; sourceTree = "<group>"; };
-		OBJ_1079 /* ssl_asn1.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_asn1.cc; sourceTree = "<group>"; };
-		OBJ_108 /* google_protobuf_descriptor.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = google_protobuf_descriptor.pb.swift; sourceTree = "<group>"; };
-		OBJ_1080 /* ssl_buffer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_buffer.cc; sourceTree = "<group>"; };
-		OBJ_1081 /* ssl_cert.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_cert.cc; sourceTree = "<group>"; };
-		OBJ_1082 /* ssl_cipher.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_cipher.cc; sourceTree = "<group>"; };
-		OBJ_1083 /* ssl_file.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_file.cc; sourceTree = "<group>"; };
-		OBJ_1084 /* ssl_key_share.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_key_share.cc; sourceTree = "<group>"; };
-		OBJ_1085 /* ssl_lib.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_lib.cc; sourceTree = "<group>"; };
-		OBJ_1086 /* ssl_privkey.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_privkey.cc; sourceTree = "<group>"; };
-		OBJ_1087 /* ssl_session.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_session.cc; sourceTree = "<group>"; };
-		OBJ_1088 /* ssl_stat.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_stat.cc; sourceTree = "<group>"; };
-		OBJ_1089 /* ssl_transcript.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_transcript.cc; sourceTree = "<group>"; };
-		OBJ_109 /* identity_ID.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_ID.pb.swift; sourceTree = "<group>"; };
-		OBJ_1090 /* ssl_versions.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_versions.cc; sourceTree = "<group>"; };
-		OBJ_1091 /* ssl_x509.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_x509.cc; sourceTree = "<group>"; };
-		OBJ_1092 /* t1_enc.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = t1_enc.cc; sourceTree = "<group>"; };
-		OBJ_1093 /* t1_lib.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = t1_lib.cc; sourceTree = "<group>"; };
-		OBJ_1094 /* tls13_both.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tls13_both.cc; sourceTree = "<group>"; };
-		OBJ_1095 /* tls13_client.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tls13_client.cc; sourceTree = "<group>"; };
-		OBJ_1096 /* tls13_enc.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tls13_enc.cc; sourceTree = "<group>"; };
-		OBJ_1097 /* tls13_server.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tls13_server.cc; sourceTree = "<group>"; };
-		OBJ_1098 /* tls_method.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tls_method.cc; sourceTree = "<group>"; };
-		OBJ_1099 /* tls_record.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tls_record.cc; sourceTree = "<group>"; };
-		OBJ_11 /* Bloombox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bloombox.swift; sourceTree = "<group>"; };
-		OBJ_110 /* identity_IDMedia.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_IDMedia.pb.swift; sourceTree = "<group>"; };
-		OBJ_1102 /* curve25519.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = curve25519.c; sourceTree = "<group>"; };
-		OBJ_1105 /* pem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pem.h; sourceTree = "<group>"; };
-		OBJ_1106 /* nid.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = nid.h; sourceTree = "<group>"; };
-		OBJ_1107 /* ssl3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ssl3.h; sourceTree = "<group>"; };
-		OBJ_1108 /* ossl_typ.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ossl_typ.h; sourceTree = "<group>"; };
-		OBJ_1109 /* dtls1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dtls1.h; sourceTree = "<group>"; };
-		OBJ_111 /* identity_Membership.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_Membership.pb.swift; sourceTree = "<group>"; };
-		OBJ_1110 /* err.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = err.h; sourceTree = "<group>"; };
-		OBJ_1111 /* bn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bn.h; sourceTree = "<group>"; };
-		OBJ_1112 /* blowfish.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = blowfish.h; sourceTree = "<group>"; };
-		OBJ_1113 /* engine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = engine.h; sourceTree = "<group>"; };
-		OBJ_1114 /* bytestring.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bytestring.h; sourceTree = "<group>"; };
-		OBJ_1115 /* x509.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = x509.h; sourceTree = "<group>"; };
-		OBJ_1116 /* asn1_mac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = asn1_mac.h; sourceTree = "<group>"; };
-		OBJ_1117 /* pool.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pool.h; sourceTree = "<group>"; };
-		OBJ_1118 /* ec_key.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ec_key.h; sourceTree = "<group>"; };
-		OBJ_1119 /* base64.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = base64.h; sourceTree = "<group>"; };
-		OBJ_112 /* identity_MembershipKey.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_MembershipKey.pb.swift; sourceTree = "<group>"; };
-		OBJ_1120 /* is_boringssl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = is_boringssl.h; sourceTree = "<group>"; };
-		OBJ_1121 /* sha.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sha.h; sourceTree = "<group>"; };
-		OBJ_1122 /* asn1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = asn1.h; sourceTree = "<group>"; };
-		OBJ_1123 /* chacha.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = chacha.h; sourceTree = "<group>"; };
-		OBJ_1124 /* opensslconf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = opensslconf.h; sourceTree = "<group>"; };
-		OBJ_1125 /* arm_arch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = arm_arch.h; sourceTree = "<group>"; };
-		OBJ_1126 /* bio.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bio.h; sourceTree = "<group>"; };
-		OBJ_1127 /* dh.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dh.h; sourceTree = "<group>"; };
-		OBJ_1128 /* digest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = digest.h; sourceTree = "<group>"; };
-		OBJ_1129 /* x509v3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = x509v3.h; sourceTree = "<group>"; };
-		OBJ_113 /* identity_StaffUser.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_StaffUser.pb.swift; sourceTree = "<group>"; };
-		OBJ_1130 /* conf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = conf.h; sourceTree = "<group>"; };
-		OBJ_1131 /* poly1305.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = poly1305.h; sourceTree = "<group>"; };
-		OBJ_1132 /* hkdf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = hkdf.h; sourceTree = "<group>"; };
-		OBJ_1133 /* type_check.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = type_check.h; sourceTree = "<group>"; };
-		OBJ_1134 /* md5.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = md5.h; sourceTree = "<group>"; };
-		OBJ_1135 /* x509_vfy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = x509_vfy.h; sourceTree = "<group>"; };
-		OBJ_1136 /* pkcs8.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pkcs8.h; sourceTree = "<group>"; };
-		OBJ_1137 /* safestack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = safestack.h; sourceTree = "<group>"; };
-		OBJ_1138 /* buf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = buf.h; sourceTree = "<group>"; };
-		OBJ_1139 /* obj.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = obj.h; sourceTree = "<group>"; };
-		OBJ_114 /* identity_User.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_User.pb.swift; sourceTree = "<group>"; };
-		OBJ_1140 /* ecdsa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ecdsa.h; sourceTree = "<group>"; };
-		OBJ_1141 /* cipher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cipher.h; sourceTree = "<group>"; };
-		OBJ_1142 /* objects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = objects.h; sourceTree = "<group>"; };
-		OBJ_1143 /* pkcs12.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pkcs12.h; sourceTree = "<group>"; };
-		OBJ_1144 /* crypto.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = crypto.h; sourceTree = "<group>"; };
-		OBJ_1145 /* opensslv.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = opensslv.h; sourceTree = "<group>"; };
-		OBJ_1146 /* pkcs7.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pkcs7.h; sourceTree = "<group>"; };
-		OBJ_1147 /* obj_mac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = obj_mac.h; sourceTree = "<group>"; };
-		OBJ_1148 /* buffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = buffer.h; sourceTree = "<group>"; };
-		OBJ_1149 /* ssl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ssl.h; sourceTree = "<group>"; };
-		OBJ_115 /* identity_UserKey.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_UserKey.pb.swift; sourceTree = "<group>"; };
-		OBJ_1150 /* thread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = thread.h; sourceTree = "<group>"; };
-		OBJ_1151 /* evp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = evp.h; sourceTree = "<group>"; };
-		OBJ_1152 /* md4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = md4.h; sourceTree = "<group>"; };
-		OBJ_1153 /* hmac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = hmac.h; sourceTree = "<group>"; };
-		OBJ_1154 /* aes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = aes.h; sourceTree = "<group>"; };
-		OBJ_1155 /* cast.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cast.h; sourceTree = "<group>"; };
-		OBJ_1156 /* rc4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rc4.h; sourceTree = "<group>"; };
-		OBJ_1157 /* cpu.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cpu.h; sourceTree = "<group>"; };
-		OBJ_1158 /* stack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = stack.h; sourceTree = "<group>"; };
-		OBJ_1159 /* des.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = des.h; sourceTree = "<group>"; };
-		OBJ_1160 /* ec.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ec.h; sourceTree = "<group>"; };
-		OBJ_1161 /* ecdh.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ecdh.h; sourceTree = "<group>"; };
-		OBJ_1162 /* rand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rand.h; sourceTree = "<group>"; };
-		OBJ_1163 /* aead.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = aead.h; sourceTree = "<group>"; };
-		OBJ_1164 /* lhash_macros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lhash_macros.h; sourceTree = "<group>"; };
-		OBJ_1165 /* span.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = span.h; sourceTree = "<group>"; };
-		OBJ_1166 /* rsa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rsa.h; sourceTree = "<group>"; };
-		OBJ_1167 /* mem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mem.h; sourceTree = "<group>"; };
-		OBJ_1168 /* ripemd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ripemd.h; sourceTree = "<group>"; };
-		OBJ_1169 /* curve25519.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = curve25519.h; sourceTree = "<group>"; };
-		OBJ_1170 /* tls1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = tls1.h; sourceTree = "<group>"; };
-		OBJ_1171 /* dsa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dsa.h; sourceTree = "<group>"; };
-		OBJ_1172 /* srtp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = srtp.h; sourceTree = "<group>"; };
-		OBJ_1173 /* asn1t.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = asn1t.h; sourceTree = "<group>"; };
-		OBJ_1174 /* cmac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cmac.h; sourceTree = "<group>"; };
-		OBJ_1175 /* lhash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lhash.h; sourceTree = "<group>"; };
-		OBJ_1176 /* ex_data.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ex_data.h; sourceTree = "<group>"; };
-		OBJ_1177 /* base.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = base.h; sourceTree = "<group>"; };
-		OBJ_1178 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = /Volumes/PITBULL/Vault/Bloombox/Client/Swift/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap; sourceTree = "<group>"; };
-		OBJ_1181 /* ByteBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteBuffer.swift; sourceTree = "<group>"; };
-		OBJ_1182 /* Call.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Call.swift; sourceTree = "<group>"; };
-		OBJ_1183 /* CallError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallError.swift; sourceTree = "<group>"; };
-		OBJ_1184 /* CallResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallResult.swift; sourceTree = "<group>"; };
-		OBJ_1185 /* Channel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Channel.swift; sourceTree = "<group>"; };
-		OBJ_1186 /* ChannelArgument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelArgument.swift; sourceTree = "<group>"; };
-		OBJ_1187 /* CompletionQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionQueue.swift; sourceTree = "<group>"; };
-		OBJ_1188 /* Handler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Handler.swift; sourceTree = "<group>"; };
-		OBJ_1189 /* Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata.swift; sourceTree = "<group>"; };
-		OBJ_1190 /* Mutex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mutex.swift; sourceTree = "<group>"; };
-		OBJ_1191 /* Operation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operation.swift; sourceTree = "<group>"; };
-		OBJ_1192 /* OperationGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationGroup.swift; sourceTree = "<group>"; };
-		OBJ_1193 /* Roots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Roots.swift; sourceTree = "<group>"; };
-		OBJ_1194 /* Server.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Server.swift; sourceTree = "<group>"; };
-		OBJ_1195 /* ServerStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerStatus.swift; sourceTree = "<group>"; };
-		OBJ_1196 /* gRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = gRPC.swift; sourceTree = "<group>"; };
-		OBJ_1198 /* ClientCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCall.swift; sourceTree = "<group>"; };
-		OBJ_1199 /* ClientCallBidirectionalStreaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCallBidirectionalStreaming.swift; sourceTree = "<group>"; };
-		OBJ_12 /* DevicesClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicesClient.swift; sourceTree = "<group>"; };
-		OBJ_120 /* identity_ids_Passport.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_ids_Passport.pb.swift; sourceTree = "<group>"; };
-		OBJ_1200 /* ClientCallClientStreaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCallClientStreaming.swift; sourceTree = "<group>"; };
-		OBJ_1201 /* ClientCallServerStreaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCallServerStreaming.swift; sourceTree = "<group>"; };
-		OBJ_1202 /* ClientCallUnary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCallUnary.swift; sourceTree = "<group>"; };
-		OBJ_1203 /* RPCError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCError.swift; sourceTree = "<group>"; };
-		OBJ_1204 /* ServerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSession.swift; sourceTree = "<group>"; };
-		OBJ_1205 /* ServerSessionBidirectionalStreaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSessionBidirectionalStreaming.swift; sourceTree = "<group>"; };
-		OBJ_1206 /* ServerSessionClientStreaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSessionClientStreaming.swift; sourceTree = "<group>"; };
-		OBJ_1207 /* ServerSessionServerStreaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSessionServerStreaming.swift; sourceTree = "<group>"; };
-		OBJ_1208 /* ServerSessionUnary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerSessionUnary.swift; sourceTree = "<group>"; };
-		OBJ_1209 /* ServiceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceClient.swift; sourceTree = "<group>"; };
-		OBJ_121 /* identity_ids_USDL.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_ids_USDL.pb.swift; sourceTree = "<group>"; };
-		OBJ_1210 /* ServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProvider.swift; sourceTree = "<group>"; };
-		OBJ_1211 /* ServiceServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceServer.swift; sourceTree = "<group>"; };
-		OBJ_1212 /* StreamReceiving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamReceiving.swift; sourceTree = "<group>"; };
-		OBJ_1213 /* StreamSending.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamSending.swift; sourceTree = "<group>"; };
-		OBJ_1214 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Volumes/PITBULL/Vault/Bloombox/Client/Swift/.build/checkouts/grpc-swift.git--2568890431933451096/Package.swift"; sourceTree = "<group>"; };
-		OBJ_1219 /* AnyMessageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyMessageStorage.swift; sourceTree = "<group>"; };
-		OBJ_122 /* identity_ids_UserDoctorRec.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_ids_UserDoctorRec.pb.swift; sourceTree = "<group>"; };
-		OBJ_1220 /* AnyUnpackError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyUnpackError.swift; sourceTree = "<group>"; };
-		OBJ_1221 /* BinaryDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryDecoder.swift; sourceTree = "<group>"; };
-		OBJ_1222 /* BinaryDecodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryDecodingError.swift; sourceTree = "<group>"; };
-		OBJ_1223 /* BinaryDecodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryDecodingOptions.swift; sourceTree = "<group>"; };
-		OBJ_1224 /* BinaryDelimited.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryDelimited.swift; sourceTree = "<group>"; };
-		OBJ_1225 /* BinaryEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryEncoder.swift; sourceTree = "<group>"; };
-		OBJ_1226 /* BinaryEncodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryEncodingError.swift; sourceTree = "<group>"; };
-		OBJ_1227 /* BinaryEncodingSizeVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryEncodingSizeVisitor.swift; sourceTree = "<group>"; };
-		OBJ_1228 /* BinaryEncodingVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryEncodingVisitor.swift; sourceTree = "<group>"; };
-		OBJ_1229 /* CustomJSONCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomJSONCodable.swift; sourceTree = "<group>"; };
-		OBJ_123 /* identity_industry_DashboardStaffSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_industry_DashboardStaffSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_1230 /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
-		OBJ_1231 /* DoubleFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleFormatter.swift; sourceTree = "<group>"; };
-		OBJ_1232 /* Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enum.swift; sourceTree = "<group>"; };
-		OBJ_1233 /* ExtensibleMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensibleMessage.swift; sourceTree = "<group>"; };
-		OBJ_1234 /* ExtensionFieldValueSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFieldValueSet.swift; sourceTree = "<group>"; };
-		OBJ_1235 /* ExtensionFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFields.swift; sourceTree = "<group>"; };
-		OBJ_1236 /* ExtensionMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionMap.swift; sourceTree = "<group>"; };
-		OBJ_1237 /* FieldTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldTag.swift; sourceTree = "<group>"; };
-		OBJ_1238 /* FieldTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldTypes.swift; sourceTree = "<group>"; };
-		OBJ_1239 /* Google_Protobuf_Any+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Any+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_124 /* identity_industry_POSStaffSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_industry_POSStaffSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_1240 /* Google_Protobuf_Any+Registry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Any+Registry.swift"; sourceTree = "<group>"; };
-		OBJ_1241 /* Google_Protobuf_Duration+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Duration+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_1242 /* Google_Protobuf_FieldMask+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_FieldMask+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_1243 /* Google_Protobuf_ListValue+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_ListValue+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_1244 /* Google_Protobuf_Struct+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Struct+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_1245 /* Google_Protobuf_Timestamp+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Timestamp+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_1246 /* Google_Protobuf_Value+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Value+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_1247 /* Google_Protobuf_Wrappers+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Wrappers+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_1248 /* HashVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashVisitor.swift; sourceTree = "<group>"; };
-		OBJ_1249 /* Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Internal.swift; sourceTree = "<group>"; };
-		OBJ_125 /* identity_industry_StaffSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_industry_StaffSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_1250 /* JSONDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoder.swift; sourceTree = "<group>"; };
-		OBJ_1251 /* JSONDecodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodingError.swift; sourceTree = "<group>"; };
-		OBJ_1252 /* JSONDecodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodingOptions.swift; sourceTree = "<group>"; };
-		OBJ_1253 /* JSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncoder.swift; sourceTree = "<group>"; };
-		OBJ_1254 /* JSONEncodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncodingError.swift; sourceTree = "<group>"; };
-		OBJ_1255 /* JSONEncodingVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncodingVisitor.swift; sourceTree = "<group>"; };
-		OBJ_1256 /* JSONMapEncodingVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONMapEncodingVisitor.swift; sourceTree = "<group>"; };
-		OBJ_1257 /* JSONScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONScanner.swift; sourceTree = "<group>"; };
-		OBJ_1258 /* MathUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MathUtils.swift; sourceTree = "<group>"; };
-		OBJ_1259 /* Message+AnyAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+AnyAdditions.swift"; sourceTree = "<group>"; };
-		OBJ_126 /* identity_pass_Pass.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_pass_Pass.pb.swift; sourceTree = "<group>"; };
-		OBJ_1260 /* Message+BinaryAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+BinaryAdditions.swift"; sourceTree = "<group>"; };
-		OBJ_1261 /* Message+JSONAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+JSONAdditions.swift"; sourceTree = "<group>"; };
-		OBJ_1262 /* Message+JSONArrayAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+JSONArrayAdditions.swift"; sourceTree = "<group>"; };
-		OBJ_1263 /* Message+TextFormatAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+TextFormatAdditions.swift"; sourceTree = "<group>"; };
-		OBJ_1264 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
-		OBJ_1265 /* MessageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageExtension.swift; sourceTree = "<group>"; };
-		OBJ_1266 /* NameMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameMap.swift; sourceTree = "<group>"; };
-		OBJ_1267 /* ProtoNameProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtoNameProviding.swift; sourceTree = "<group>"; };
-		OBJ_1268 /* ProtobufAPIVersionCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufAPIVersionCheck.swift; sourceTree = "<group>"; };
-		OBJ_1269 /* ProtobufMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufMap.swift; sourceTree = "<group>"; };
-		OBJ_127 /* identity_pass_PassKey.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_pass_PassKey.pb.swift; sourceTree = "<group>"; };
-		OBJ_1270 /* SelectiveVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectiveVisitor.swift; sourceTree = "<group>"; };
-		OBJ_1271 /* SimpleExtensionMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleExtensionMap.swift; sourceTree = "<group>"; };
-		OBJ_1272 /* StringUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringUtils.swift; sourceTree = "<group>"; };
-		OBJ_1273 /* TextFormatDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatDecoder.swift; sourceTree = "<group>"; };
-		OBJ_1274 /* TextFormatDecodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatDecodingError.swift; sourceTree = "<group>"; };
-		OBJ_1275 /* TextFormatEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatEncoder.swift; sourceTree = "<group>"; };
-		OBJ_1276 /* TextFormatEncodingVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatEncodingVisitor.swift; sourceTree = "<group>"; };
-		OBJ_1277 /* TextFormatScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFormatScanner.swift; sourceTree = "<group>"; };
-		OBJ_1278 /* TimeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeUtils.swift; sourceTree = "<group>"; };
-		OBJ_1279 /* UnknownStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownStorage.swift; sourceTree = "<group>"; };
-		OBJ_128 /* identity_v1beta1_IdentityService_Beta1.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = identity_v1beta1_IdentityService_Beta1.pb.swift; sourceTree = "<group>"; };
-		OBJ_1280 /* Varint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Varint.swift; sourceTree = "<group>"; };
-		OBJ_1281 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
-		OBJ_1282 /* Visitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Visitor.swift; sourceTree = "<group>"; };
-		OBJ_1283 /* WireFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireFormat.swift; sourceTree = "<group>"; };
-		OBJ_1284 /* ZigZag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZigZag.swift; sourceTree = "<group>"; };
-		OBJ_1285 /* any.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = any.pb.swift; sourceTree = "<group>"; };
-		OBJ_1286 /* api.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = api.pb.swift; sourceTree = "<group>"; };
-		OBJ_1287 /* duration.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = duration.pb.swift; sourceTree = "<group>"; };
-		OBJ_1288 /* empty.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.pb.swift; sourceTree = "<group>"; };
-		OBJ_1289 /* field_mask.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = field_mask.pb.swift; sourceTree = "<group>"; };
-		OBJ_129 /* inventory_InventoryLocation.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = inventory_InventoryLocation.pb.swift; sourceTree = "<group>"; };
-		OBJ_1290 /* source_context.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = source_context.pb.swift; sourceTree = "<group>"; };
-		OBJ_1291 /* struct.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = struct.pb.swift; sourceTree = "<group>"; };
-		OBJ_1292 /* timestamp.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = timestamp.pb.swift; sourceTree = "<group>"; };
-		OBJ_1293 /* type.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = type.pb.swift; sourceTree = "<group>"; };
-		OBJ_1294 /* wrappers.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wrappers.pb.swift; sourceTree = "<group>"; };
-		OBJ_1296 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Volumes/PITBULL/Vault/Bloombox/Client/Swift/.build/checkouts/swift-protobuf.git-7923261648679470216/Package.swift"; sourceTree = "<group>"; };
-		OBJ_13 /* EventCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventCollection.swift; sourceTree = "<group>"; };
-		OBJ_130 /* inventory_InventoryProduct.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = inventory_InventoryProduct.pb.swift; sourceTree = "<group>"; };
-		OBJ_131 /* ledger_Account.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ledger_Account.pb.swift; sourceTree = "<group>"; };
-		OBJ_132 /* ledger_Asset.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ledger_Asset.pb.swift; sourceTree = "<group>"; };
-		OBJ_133 /* ledger_Transaction.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ledger_Transaction.pb.swift; sourceTree = "<group>"; };
-		OBJ_135 /* licensing_Licensure.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = licensing_Licensure.pb.swift; sourceTree = "<group>"; };
-		OBJ_136 /* marketing_Campaign.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = marketing_Campaign.pb.swift; sourceTree = "<group>"; };
-		OBJ_137 /* marketing_Targeting.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = marketing_Targeting.pb.swift; sourceTree = "<group>"; };
-		OBJ_139 /* media_MediaItem.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = media_MediaItem.pb.swift; sourceTree = "<group>"; };
-		OBJ_14 /* EventContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventContext.swift; sourceTree = "<group>"; };
-		OBJ_140 /* media_MediaKey.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = media_MediaKey.pb.swift; sourceTree = "<group>"; };
-		OBJ_141 /* media_MediaOrientation.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = media_MediaOrientation.pb.swift; sourceTree = "<group>"; };
-		OBJ_142 /* media_MediaType.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = media_MediaType.pb.swift; sourceTree = "<group>"; };
-		OBJ_143 /* media_v1beta1_MediaService_Beta1.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = media_v1beta1_MediaService_Beta1.pb.swift; sourceTree = "<group>"; };
-		OBJ_144 /* media_v1beta1_MediaTask.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = media_v1beta1_MediaTask.pb.swift; sourceTree = "<group>"; };
-		OBJ_145 /* menu_v1beta1_MenuService_Beta1.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = menu_v1beta1_MenuService_Beta1.pb.swift; sourceTree = "<group>"; };
-		OBJ_146 /* oauth_AuthorizationScope.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = oauth_AuthorizationScope.pb.swift; sourceTree = "<group>"; };
-		OBJ_147 /* oauth_Client.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = oauth_Client.pb.swift; sourceTree = "<group>"; };
-		OBJ_148 /* partner_LocationKey.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_LocationKey.pb.swift; sourceTree = "<group>"; };
-		OBJ_149 /* partner_Partner.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_Partner.pb.swift; sourceTree = "<group>"; };
-		OBJ_15 /* MenuClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuClient.swift; sourceTree = "<group>"; };
-		OBJ_150 /* partner_PartnerDevice.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_PartnerDevice.pb.swift; sourceTree = "<group>"; };
-		OBJ_151 /* partner_PartnerFlags.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_PartnerFlags.pb.swift; sourceTree = "<group>"; };
-		OBJ_152 /* partner_PartnerKey.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_PartnerKey.pb.swift; sourceTree = "<group>"; };
-		OBJ_153 /* partner_PartnerLocation.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_PartnerLocation.pb.swift; sourceTree = "<group>"; };
-		OBJ_154 /* partner_PartnerScope.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_PartnerScope.pb.swift; sourceTree = "<group>"; };
-		OBJ_155 /* partner_integrations_GSuiteSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_integrations_GSuiteSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_156 /* partner_integrations_GreenbitsSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_integrations_GreenbitsSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_157 /* partner_integrations_IntegrationSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_integrations_IntegrationSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_158 /* partner_integrations_MailchimpSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_integrations_MailchimpSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_159 /* partner_integrations_OnFleetSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_integrations_OnFleetSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_16 /* POSClient+AuthorizeUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "POSClient+AuthorizeUser.swift"; sourceTree = "<group>"; };
-		OBJ_160 /* partner_integrations_SendgridSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_integrations_SendgridSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_161 /* partner_integrations_TreezSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_integrations_TreezSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_162 /* partner_integrations_TwilioSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_integrations_TwilioSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_163 /* partner_settings_PartnerLocationSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_settings_PartnerLocationSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_164 /* partner_settings_PartnerSettings.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = partner_settings_PartnerSettings.pb.swift; sourceTree = "<group>"; };
-		OBJ_166 /* person_Person.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = person_Person.pb.swift; sourceTree = "<group>"; };
-		OBJ_167 /* person_PersonName.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = person_PersonName.pb.swift; sourceTree = "<group>"; };
-		OBJ_168 /* platform_v1_PlatformService_v1.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = platform_v1_PlatformService_v1.pb.swift; sourceTree = "<group>"; };
-		OBJ_169 /* pos_PointOfSale.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = pos_PointOfSale.pb.swift; sourceTree = "<group>"; };
-		OBJ_17 /* POSClient+Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "POSClient+Session.swift"; sourceTree = "<group>"; };
-		OBJ_170 /* pos_v1beta1_POSService_Beta1.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = pos_v1beta1_POSService_Beta1.pb.swift; sourceTree = "<group>"; };
-		OBJ_171 /* products_Apothecary.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_Apothecary.pb.swift; sourceTree = "<group>"; };
-		OBJ_172 /* products_Cartridge.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_Cartridge.pb.swift; sourceTree = "<group>"; };
-		OBJ_173 /* products_Edible.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_Edible.pb.swift; sourceTree = "<group>"; };
-		OBJ_174 /* products_Extract.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_Extract.pb.swift; sourceTree = "<group>"; };
-		OBJ_175 /* products_Flower.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_Flower.pb.swift; sourceTree = "<group>"; };
-		OBJ_176 /* products_Merchandise.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_Merchandise.pb.swift; sourceTree = "<group>"; };
-		OBJ_177 /* products_Plant.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_Plant.pb.swift; sourceTree = "<group>"; };
-		OBJ_178 /* products_Preroll.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_Preroll.pb.swift; sourceTree = "<group>"; };
-		OBJ_179 /* products_distribution_DistributionChannel.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_distribution_DistributionChannel.pb.swift; sourceTree = "<group>"; };
-		OBJ_18 /* POSClient+VerifyTicketKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "POSClient+VerifyTicketKey.swift"; sourceTree = "<group>"; };
-		OBJ_180 /* products_menu_Menu.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_menu_Menu.pb.swift; sourceTree = "<group>"; };
-		OBJ_181 /* products_menu_Section.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = products_menu_Section.pb.swift; sourceTree = "<group>"; };
-		OBJ_182 /* protoc-gen-swagger_options_openapiv2.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "protoc-gen-swagger_options_openapiv2.pb.swift"; sourceTree = "<group>"; };
-		OBJ_183 /* protoc-gen-swagger_options_swagger.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "protoc-gen-swagger_options_swagger.pb.swift"; sourceTree = "<group>"; };
-		OBJ_184 /* proximity_BluetoothBeacon.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = proximity_BluetoothBeacon.pb.swift; sourceTree = "<group>"; };
-		OBJ_185 /* regulatory_usa_ca_CAAgency.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = regulatory_usa_ca_CAAgency.pb.swift; sourceTree = "<group>"; };
-		OBJ_186 /* search_SearchResult.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = search_SearchResult.pb.swift; sourceTree = "<group>"; };
-		OBJ_187 /* search_SearchSpec.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = search_SearchSpec.pb.swift; sourceTree = "<group>"; };
-		OBJ_188 /* security_DeviceTicket.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = security_DeviceTicket.pb.swift; sourceTree = "<group>"; };
-		OBJ_189 /* security_IdentityToken.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = security_IdentityToken.pb.swift; sourceTree = "<group>"; };
-		OBJ_19 /* POSClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSClient.swift; sourceTree = "<group>"; };
-		OBJ_190 /* security_Token.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = security_Token.pb.swift; sourceTree = "<group>"; };
-		OBJ_191 /* security_access_PartnerPermissions.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = security_access_PartnerPermissions.pb.swift; sourceTree = "<group>"; };
-		OBJ_192 /* services_ServiceStatus.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = services_ServiceStatus.pb.swift; sourceTree = "<group>"; };
-		OBJ_193 /* shop_v1_ShopService_v1.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = shop_v1_ShopService_v1.pb.swift; sourceTree = "<group>"; };
-		OBJ_194 /* structs_Genetics.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = structs_Genetics.pb.swift; sourceTree = "<group>"; };
-		OBJ_195 /* structs_Grow.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = structs_Grow.pb.swift; sourceTree = "<group>"; };
-		OBJ_196 /* structs_ProductFlags.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = structs_ProductFlags.pb.swift; sourceTree = "<group>"; };
-		OBJ_197 /* structs_Shelf.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = structs_Shelf.pb.swift; sourceTree = "<group>"; };
-		OBJ_198 /* structs_Species.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = structs_Species.pb.swift; sourceTree = "<group>"; };
-		OBJ_199 /* structs_Version.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = structs_Version.pb.swift; sourceTree = "<group>"; };
-		OBJ_20 /* PlatformClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformClient.swift; sourceTree = "<group>"; };
-		OBJ_200 /* structs_labtesting_TestResults.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = structs_labtesting_TestResults.pb.swift; sourceTree = "<group>"; };
-		OBJ_201 /* structs_labtesting_TestValue.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = structs_labtesting_TestValue.pb.swift; sourceTree = "<group>"; };
-		OBJ_202 /* structs_pricing_PricingDescriptor.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = structs_pricing_PricingDescriptor.pb.swift; sourceTree = "<group>"; };
-		OBJ_203 /* structs_pricing_SaleDescriptor.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = structs_pricing_SaleDescriptor.pb.swift; sourceTree = "<group>"; };
-		OBJ_204 /* telemetry_v1beta4_GenericEvents_Beta4.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = telemetry_v1beta4_GenericEvents_Beta4.pb.swift; sourceTree = "<group>"; };
-		OBJ_205 /* telemetry_v1beta4_TelemetryEvent_Beta4.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = telemetry_v1beta4_TelemetryEvent_Beta4.pb.swift; sourceTree = "<group>"; };
-		OBJ_206 /* telemetry_v1beta4_TelemetryService_Beta4.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = telemetry_v1beta4_TelemetryService_Beta4.pb.swift; sourceTree = "<group>"; };
-		OBJ_207 /* temporal_Date.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = temporal_Date.pb.swift; sourceTree = "<group>"; };
-		OBJ_208 /* temporal_Duration.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = temporal_Duration.pb.swift; sourceTree = "<group>"; };
-		OBJ_209 /* temporal_Instant.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = temporal_Instant.pb.swift; sourceTree = "<group>"; };
-		OBJ_21 /* RPCLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCLogic.swift; sourceTree = "<group>"; };
-		OBJ_210 /* temporal_Interval.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = temporal_Interval.pb.swift; sourceTree = "<group>"; };
-		OBJ_211 /* temporal_Schedule.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = temporal_Schedule.pb.swift; sourceTree = "<group>"; };
-		OBJ_212 /* temporal_Time.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = temporal_Time.pb.swift; sourceTree = "<group>"; };
-		OBJ_213 /* temporal_Timehash.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = temporal_Timehash.pb.swift; sourceTree = "<group>"; };
-		OBJ_214 /* wallet_v1_WalletService_v1.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wallet_v1_WalletService_v1.pb.swift; sourceTree = "<group>"; };
-		OBJ_217 /* ModelTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTool.swift; sourceTree = "<group>"; };
-		OBJ_218 /* SchemaTests+Codec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SchemaTests+Codec.swift"; sourceTree = "<group>"; };
-		OBJ_219 /* SchemaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaTests.swift; sourceTree = "<group>"; };
-		OBJ_22 /* RemoteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteService.swift; sourceTree = "<group>"; };
-		OBJ_221 /* AuthClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthClientTests.swift; sourceTree = "<group>"; };
-		OBJ_222 /* ClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientTests.swift; sourceTree = "<group>"; };
-		OBJ_223 /* DeviceClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceClientTests.swift; sourceTree = "<group>"; };
-		OBJ_224 /* MenuClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuClientTests.swift; sourceTree = "<group>"; };
-		OBJ_225 /* PlatformClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformClientTests.swift; sourceTree = "<group>"; };
-		OBJ_226 /* ShopClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopClientTests.swift; sourceTree = "<group>"; };
-		OBJ_227 /* TelemetryClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryClientTests.swift; sourceTree = "<group>"; };
-		OBJ_228 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
-		OBJ_229 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = docs; sourceTree = SOURCE_ROOT; };
-		OBJ_23 /* Services.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Services.swift; sourceTree = "<group>"; tabWidth = 2; };
-		OBJ_230 /* Schema */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Schema; sourceTree = SOURCE_ROOT; };
-		OBJ_231 /* fastlane */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fastlane; sourceTree = SOURCE_ROOT; };
-		OBJ_232 /* SwiftGRPC */ = {isa = PBXFileReference; lastKnownFileType = folder; path = SwiftGRPC; sourceTree = SOURCE_ROOT; };
-		OBJ_24 /* ShopClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopClient.swift; sourceTree = "<group>"; };
-		OBJ_240 /* byte_buffer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = byte_buffer.c; sourceTree = "<group>"; };
-		OBJ_241 /* call.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = call.c; sourceTree = "<group>"; };
-		OBJ_242 /* channel.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = channel.c; sourceTree = "<group>"; };
-		OBJ_243 /* completion_queue.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = completion_queue.c; sourceTree = "<group>"; };
-		OBJ_244 /* event.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = event.c; sourceTree = "<group>"; };
-		OBJ_245 /* handler.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = handler.c; sourceTree = "<group>"; };
-		OBJ_246 /* internal.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = internal.c; sourceTree = "<group>"; };
-		OBJ_247 /* metadata.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = metadata.c; sourceTree = "<group>"; };
-		OBJ_248 /* mutex.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mutex.c; sourceTree = "<group>"; };
-		OBJ_249 /* observers.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = observers.c; sourceTree = "<group>"; };
-		OBJ_25 /* TelemetryClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryClient.swift; sourceTree = "<group>"; };
-		OBJ_250 /* operations.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = operations.c; sourceTree = "<group>"; };
-		OBJ_251 /* server.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = server.c; sourceTree = "<group>"; };
-		OBJ_256 /* grpc_context.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_context.cc; sourceTree = "<group>"; };
-		OBJ_259 /* backup_poller.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = backup_poller.cc; sourceTree = "<group>"; };
-		OBJ_26 /* TelemetryService+Generic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TelemetryService+Generic.swift"; sourceTree = "<group>"; };
-		OBJ_260 /* channel_connectivity.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_connectivity.cc; sourceTree = "<group>"; };
-		OBJ_261 /* client_channel.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = client_channel.cc; sourceTree = "<group>"; };
-		OBJ_262 /* client_channel_factory.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = client_channel_factory.cc; sourceTree = "<group>"; };
-		OBJ_263 /* client_channel_plugin.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = client_channel_plugin.cc; sourceTree = "<group>"; };
-		OBJ_264 /* connector.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = connector.cc; sourceTree = "<group>"; };
-		OBJ_265 /* http_connect_handshaker.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = http_connect_handshaker.cc; sourceTree = "<group>"; };
-		OBJ_266 /* http_proxy.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = http_proxy.cc; sourceTree = "<group>"; };
-		OBJ_267 /* lb_policy.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = lb_policy.cc; sourceTree = "<group>"; };
-		OBJ_27 /* Transport.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; tabWidth = 2; };
-		OBJ_270 /* client_load_reporting_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = client_load_reporting_filter.cc; sourceTree = "<group>"; };
-		OBJ_271 /* grpclb.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpclb.cc; sourceTree = "<group>"; };
-		OBJ_272 /* grpclb_channel_secure.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpclb_channel_secure.cc; sourceTree = "<group>"; };
-		OBJ_273 /* grpclb_client_stats.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpclb_client_stats.cc; sourceTree = "<group>"; };
-		OBJ_274 /* load_balancer_api.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = load_balancer_api.cc; sourceTree = "<group>"; };
-		OBJ_279 /* load_balancer.pb.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = load_balancer.pb.c; sourceTree = "<group>"; };
-		OBJ_281 /* pick_first.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pick_first.cc; sourceTree = "<group>"; };
-		OBJ_283 /* round_robin.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = round_robin.cc; sourceTree = "<group>"; };
-		OBJ_284 /* lb_policy_factory.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = lb_policy_factory.cc; sourceTree = "<group>"; };
-		OBJ_285 /* lb_policy_registry.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = lb_policy_registry.cc; sourceTree = "<group>"; };
-		OBJ_286 /* method_params.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = method_params.cc; sourceTree = "<group>"; };
-		OBJ_287 /* parse_address.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = parse_address.cc; sourceTree = "<group>"; };
-		OBJ_288 /* proxy_mapper.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = proxy_mapper.cc; sourceTree = "<group>"; };
-		OBJ_289 /* proxy_mapper_registry.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = proxy_mapper_registry.cc; sourceTree = "<group>"; };
-		OBJ_29 /* AuthService_Beta1.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService_Beta1.grpc.swift; sourceTree = "<group>"; };
-		OBJ_290 /* resolver.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = resolver.cc; sourceTree = "<group>"; };
-		OBJ_294 /* dns_resolver_ares.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dns_resolver_ares.cc; sourceTree = "<group>"; };
-		OBJ_295 /* grpc_ares_ev_driver_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_ares_ev_driver_posix.cc; sourceTree = "<group>"; };
-		OBJ_296 /* grpc_ares_wrapper.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_ares_wrapper.cc; sourceTree = "<group>"; };
-		OBJ_297 /* grpc_ares_wrapper_fallback.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_ares_wrapper_fallback.cc; sourceTree = "<group>"; };
-		OBJ_299 /* dns_resolver.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = dns_resolver.cc; sourceTree = "<group>"; };
-		OBJ_30 /* DevicesService_Beta1.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicesService_Beta1.grpc.swift; sourceTree = "<group>"; };
-		OBJ_301 /* fake_resolver.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = fake_resolver.cc; sourceTree = "<group>"; };
-		OBJ_303 /* sockaddr_resolver.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = sockaddr_resolver.cc; sourceTree = "<group>"; };
-		OBJ_304 /* resolver_registry.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = resolver_registry.cc; sourceTree = "<group>"; };
-		OBJ_305 /* retry_throttle.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = retry_throttle.cc; sourceTree = "<group>"; };
-		OBJ_306 /* subchannel.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = subchannel.cc; sourceTree = "<group>"; };
-		OBJ_307 /* subchannel_index.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = subchannel_index.cc; sourceTree = "<group>"; };
-		OBJ_308 /* uri_parser.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = uri_parser.cc; sourceTree = "<group>"; };
-		OBJ_31 /* IdentityService_Beta1.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityService_Beta1.grpc.swift; sourceTree = "<group>"; };
-		OBJ_310 /* deadline_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = deadline_filter.cc; sourceTree = "<group>"; };
-		OBJ_313 /* http_client_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = http_client_filter.cc; sourceTree = "<group>"; };
-		OBJ_314 /* client_authority_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = client_authority_filter.cc; sourceTree = "<group>"; };
-		OBJ_315 /* http_filters_plugin.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = http_filters_plugin.cc; sourceTree = "<group>"; };
-		OBJ_317 /* message_compress_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = message_compress_filter.cc; sourceTree = "<group>"; };
-		OBJ_319 /* http_server_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = http_server_filter.cc; sourceTree = "<group>"; };
-		OBJ_32 /* MediaService_Beta1.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaService_Beta1.grpc.swift; sourceTree = "<group>"; };
-		OBJ_321 /* server_load_reporting_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = server_load_reporting_filter.cc; sourceTree = "<group>"; };
-		OBJ_322 /* server_load_reporting_plugin.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = server_load_reporting_plugin.cc; sourceTree = "<group>"; };
-		OBJ_324 /* max_age_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = max_age_filter.cc; sourceTree = "<group>"; };
-		OBJ_326 /* message_size_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = message_size_filter.cc; sourceTree = "<group>"; };
-		OBJ_328 /* workaround_cronet_compression_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = workaround_cronet_compression_filter.cc; sourceTree = "<group>"; };
-		OBJ_329 /* workaround_utils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = workaround_utils.cc; sourceTree = "<group>"; };
-		OBJ_33 /* MenuService_Beta1.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuService_Beta1.grpc.swift; sourceTree = "<group>"; };
-		OBJ_333 /* alpn.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alpn.cc; sourceTree = "<group>"; };
-		OBJ_335 /* authority.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = authority.cc; sourceTree = "<group>"; };
-		OBJ_336 /* chttp2_connector.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = chttp2_connector.cc; sourceTree = "<group>"; };
-		OBJ_338 /* channel_create.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_create.cc; sourceTree = "<group>"; };
-		OBJ_339 /* channel_create_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_create_posix.cc; sourceTree = "<group>"; };
-		OBJ_34 /* POSService_Beta1.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSService_Beta1.grpc.swift; sourceTree = "<group>"; };
-		OBJ_341 /* secure_channel_create.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = secure_channel_create.cc; sourceTree = "<group>"; };
-		OBJ_343 /* chttp2_server.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = chttp2_server.cc; sourceTree = "<group>"; };
-		OBJ_345 /* server_chttp2.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = server_chttp2.cc; sourceTree = "<group>"; };
-		OBJ_346 /* server_chttp2_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = server_chttp2_posix.cc; sourceTree = "<group>"; };
-		OBJ_348 /* server_secure_chttp2.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = server_secure_chttp2.cc; sourceTree = "<group>"; };
-		OBJ_35 /* PlatformService_v1.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformService_v1.grpc.swift; sourceTree = "<group>"; };
-		OBJ_350 /* bin_decoder.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = bin_decoder.cc; sourceTree = "<group>"; };
-		OBJ_351 /* bin_encoder.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = bin_encoder.cc; sourceTree = "<group>"; };
-		OBJ_352 /* chttp2_plugin.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = chttp2_plugin.cc; sourceTree = "<group>"; };
-		OBJ_353 /* chttp2_transport.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = chttp2_transport.cc; sourceTree = "<group>"; };
-		OBJ_354 /* flow_control.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = flow_control.cc; sourceTree = "<group>"; };
-		OBJ_355 /* frame_data.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = frame_data.cc; sourceTree = "<group>"; };
-		OBJ_356 /* frame_goaway.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = frame_goaway.cc; sourceTree = "<group>"; };
-		OBJ_357 /* frame_ping.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = frame_ping.cc; sourceTree = "<group>"; };
-		OBJ_358 /* frame_rst_stream.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = frame_rst_stream.cc; sourceTree = "<group>"; };
-		OBJ_359 /* frame_settings.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = frame_settings.cc; sourceTree = "<group>"; };
-		OBJ_36 /* ShopService_v1.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopService_v1.grpc.swift; sourceTree = "<group>"; };
-		OBJ_360 /* frame_window_update.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = frame_window_update.cc; sourceTree = "<group>"; };
-		OBJ_361 /* hpack_encoder.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = hpack_encoder.cc; sourceTree = "<group>"; };
-		OBJ_362 /* hpack_parser.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = hpack_parser.cc; sourceTree = "<group>"; };
-		OBJ_363 /* hpack_table.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = hpack_table.cc; sourceTree = "<group>"; };
-		OBJ_364 /* http2_settings.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = http2_settings.cc; sourceTree = "<group>"; };
-		OBJ_365 /* huffsyms.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = huffsyms.cc; sourceTree = "<group>"; };
-		OBJ_366 /* incoming_metadata.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = incoming_metadata.cc; sourceTree = "<group>"; };
-		OBJ_367 /* parsing.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = parsing.cc; sourceTree = "<group>"; };
-		OBJ_368 /* stream_lists.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = stream_lists.cc; sourceTree = "<group>"; };
-		OBJ_369 /* stream_map.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = stream_map.cc; sourceTree = "<group>"; };
-		OBJ_37 /* TelemetryService_Beta4.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryService_Beta4.grpc.swift; sourceTree = "<group>"; };
-		OBJ_370 /* varint.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = varint.cc; sourceTree = "<group>"; };
-		OBJ_371 /* writing.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = writing.cc; sourceTree = "<group>"; };
-		OBJ_373 /* inproc_plugin.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = inproc_plugin.cc; sourceTree = "<group>"; };
-		OBJ_374 /* inproc_transport.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = inproc_transport.cc; sourceTree = "<group>"; };
-		OBJ_377 /* avl.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = avl.cc; sourceTree = "<group>"; };
-		OBJ_379 /* backoff.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = backoff.cc; sourceTree = "<group>"; };
-		OBJ_38 /* WalletService_v1.grpc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletService_v1.grpc.swift; sourceTree = "<group>"; };
-		OBJ_381 /* channel_args.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_args.cc; sourceTree = "<group>"; };
-		OBJ_382 /* channel_stack.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_stack.cc; sourceTree = "<group>"; };
-		OBJ_383 /* channel_stack_builder.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_stack_builder.cc; sourceTree = "<group>"; };
-		OBJ_384 /* channel_trace.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_trace.cc; sourceTree = "<group>"; };
-		OBJ_385 /* channel_trace_registry.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_trace_registry.cc; sourceTree = "<group>"; };
-		OBJ_386 /* connected_channel.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = connected_channel.cc; sourceTree = "<group>"; };
-		OBJ_387 /* handshaker.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = handshaker.cc; sourceTree = "<group>"; };
-		OBJ_388 /* handshaker_factory.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = handshaker_factory.cc; sourceTree = "<group>"; };
-		OBJ_389 /* handshaker_registry.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = handshaker_registry.cc; sourceTree = "<group>"; };
-		OBJ_390 /* status_util.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = status_util.cc; sourceTree = "<group>"; };
-		OBJ_392 /* compression.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = compression.cc; sourceTree = "<group>"; };
-		OBJ_393 /* compression_internal.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = compression_internal.cc; sourceTree = "<group>"; };
-		OBJ_394 /* message_compress.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = message_compress.cc; sourceTree = "<group>"; };
-		OBJ_395 /* stream_compression.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = stream_compression.cc; sourceTree = "<group>"; };
-		OBJ_396 /* stream_compression_gzip.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = stream_compression_gzip.cc; sourceTree = "<group>"; };
-		OBJ_397 /* stream_compression_identity.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = stream_compression_identity.cc; sourceTree = "<group>"; };
-		OBJ_399 /* stats.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = stats.cc; sourceTree = "<group>"; };
-		OBJ_40 /* accounting_Taxes.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = accounting_Taxes.pb.swift; sourceTree = "<group>"; };
-		OBJ_400 /* stats_data.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = stats_data.cc; sourceTree = "<group>"; };
-		OBJ_401 /* trace.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = trace.cc; sourceTree = "<group>"; };
-		OBJ_403 /* alloc.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alloc.cc; sourceTree = "<group>"; };
-		OBJ_404 /* arena.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = arena.cc; sourceTree = "<group>"; };
-		OBJ_405 /* atm.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = atm.cc; sourceTree = "<group>"; };
-		OBJ_406 /* cpu_iphone.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = cpu_iphone.cc; sourceTree = "<group>"; };
-		OBJ_407 /* cpu_linux.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = cpu_linux.cc; sourceTree = "<group>"; };
-		OBJ_408 /* cpu_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = cpu_posix.cc; sourceTree = "<group>"; };
-		OBJ_409 /* cpu_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = cpu_windows.cc; sourceTree = "<group>"; };
-		OBJ_41 /* analytics_Context.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_Context.pb.swift; sourceTree = "<group>"; };
-		OBJ_410 /* env_linux.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = env_linux.cc; sourceTree = "<group>"; };
-		OBJ_411 /* env_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = env_posix.cc; sourceTree = "<group>"; };
-		OBJ_412 /* env_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = env_windows.cc; sourceTree = "<group>"; };
-		OBJ_413 /* fork.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = fork.cc; sourceTree = "<group>"; };
-		OBJ_414 /* host_port.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = host_port.cc; sourceTree = "<group>"; };
-		OBJ_415 /* log.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = log.cc; sourceTree = "<group>"; };
-		OBJ_416 /* log_android.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = log_android.cc; sourceTree = "<group>"; };
-		OBJ_417 /* log_linux.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = log_linux.cc; sourceTree = "<group>"; };
-		OBJ_418 /* log_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = log_posix.cc; sourceTree = "<group>"; };
-		OBJ_419 /* log_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = log_windows.cc; sourceTree = "<group>"; };
-		OBJ_42 /* analytics_Scope.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_Scope.pb.swift; sourceTree = "<group>"; };
-		OBJ_420 /* mpscq.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = mpscq.cc; sourceTree = "<group>"; };
-		OBJ_421 /* murmur_hash.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = murmur_hash.cc; sourceTree = "<group>"; };
-		OBJ_422 /* string.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = string.cc; sourceTree = "<group>"; };
-		OBJ_423 /* string_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = string_posix.cc; sourceTree = "<group>"; };
-		OBJ_424 /* string_util_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = string_util_windows.cc; sourceTree = "<group>"; };
-		OBJ_425 /* string_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = string_windows.cc; sourceTree = "<group>"; };
-		OBJ_426 /* sync.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = sync.cc; sourceTree = "<group>"; };
-		OBJ_427 /* sync_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = sync_posix.cc; sourceTree = "<group>"; };
-		OBJ_428 /* sync_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = sync_windows.cc; sourceTree = "<group>"; };
-		OBJ_429 /* time.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = time.cc; sourceTree = "<group>"; };
-		OBJ_43 /* analytics_commerce_OrderAnalytics.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_commerce_OrderAnalytics.pb.swift; sourceTree = "<group>"; };
-		OBJ_430 /* time_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = time_posix.cc; sourceTree = "<group>"; };
-		OBJ_431 /* time_precise.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = time_precise.cc; sourceTree = "<group>"; };
-		OBJ_432 /* time_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = time_windows.cc; sourceTree = "<group>"; };
-		OBJ_433 /* tls_pthread.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tls_pthread.cc; sourceTree = "<group>"; };
-		OBJ_434 /* tmpfile_msys.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tmpfile_msys.cc; sourceTree = "<group>"; };
-		OBJ_435 /* tmpfile_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tmpfile_posix.cc; sourceTree = "<group>"; };
-		OBJ_436 /* tmpfile_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tmpfile_windows.cc; sourceTree = "<group>"; };
-		OBJ_437 /* wrap_memcpy.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = wrap_memcpy.cc; sourceTree = "<group>"; };
-		OBJ_439 /* thd_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = thd_posix.cc; sourceTree = "<group>"; };
-		OBJ_44 /* analytics_commerce_ProductAnalytics.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_commerce_ProductAnalytics.pb.swift; sourceTree = "<group>"; };
-		OBJ_440 /* thd_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = thd_windows.cc; sourceTree = "<group>"; };
-		OBJ_442 /* format_request.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = format_request.cc; sourceTree = "<group>"; };
-		OBJ_443 /* httpcli.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = httpcli.cc; sourceTree = "<group>"; };
-		OBJ_444 /* httpcli_security_connector.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = httpcli_security_connector.cc; sourceTree = "<group>"; };
-		OBJ_445 /* parser.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = parser.cc; sourceTree = "<group>"; };
-		OBJ_447 /* call_combiner.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = call_combiner.cc; sourceTree = "<group>"; };
-		OBJ_448 /* combiner.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = combiner.cc; sourceTree = "<group>"; };
-		OBJ_449 /* endpoint.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = endpoint.cc; sourceTree = "<group>"; };
-		OBJ_45 /* analytics_commerce_SectionAnalytics.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_commerce_SectionAnalytics.pb.swift; sourceTree = "<group>"; };
-		OBJ_450 /* endpoint_pair_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = endpoint_pair_posix.cc; sourceTree = "<group>"; };
-		OBJ_451 /* endpoint_pair_uv.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = endpoint_pair_uv.cc; sourceTree = "<group>"; };
-		OBJ_452 /* endpoint_pair_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = endpoint_pair_windows.cc; sourceTree = "<group>"; };
-		OBJ_453 /* error.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = error.cc; sourceTree = "<group>"; };
-		OBJ_454 /* ev_epoll1_linux.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ev_epoll1_linux.cc; sourceTree = "<group>"; };
-		OBJ_455 /* ev_epollex_linux.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ev_epollex_linux.cc; sourceTree = "<group>"; };
-		OBJ_456 /* ev_epollsig_linux.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ev_epollsig_linux.cc; sourceTree = "<group>"; };
-		OBJ_457 /* ev_poll_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ev_poll_posix.cc; sourceTree = "<group>"; };
-		OBJ_458 /* ev_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ev_posix.cc; sourceTree = "<group>"; };
-		OBJ_459 /* ev_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ev_windows.cc; sourceTree = "<group>"; };
-		OBJ_46 /* analytics_commerce_ShopAnalytics.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_commerce_ShopAnalytics.pb.swift; sourceTree = "<group>"; };
-		OBJ_460 /* exec_ctx.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = exec_ctx.cc; sourceTree = "<group>"; };
-		OBJ_461 /* executor.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = executor.cc; sourceTree = "<group>"; };
-		OBJ_462 /* fork_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = fork_posix.cc; sourceTree = "<group>"; };
-		OBJ_463 /* fork_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = fork_windows.cc; sourceTree = "<group>"; };
-		OBJ_464 /* gethostname_fallback.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = gethostname_fallback.cc; sourceTree = "<group>"; };
-		OBJ_465 /* gethostname_host_name_max.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = gethostname_host_name_max.cc; sourceTree = "<group>"; };
-		OBJ_466 /* gethostname_sysconf.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = gethostname_sysconf.cc; sourceTree = "<group>"; };
-		OBJ_467 /* iocp_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = iocp_windows.cc; sourceTree = "<group>"; };
-		OBJ_468 /* iomgr.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = iomgr.cc; sourceTree = "<group>"; };
-		OBJ_469 /* iomgr_custom.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = iomgr_custom.cc; sourceTree = "<group>"; };
-		OBJ_47 /* analytics_consumption_Biodelivery.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_consumption_Biodelivery.pb.swift; sourceTree = "<group>"; };
-		OBJ_470 /* iomgr_internal.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = iomgr_internal.cc; sourceTree = "<group>"; };
-		OBJ_471 /* iomgr_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = iomgr_posix.cc; sourceTree = "<group>"; };
-		OBJ_472 /* iomgr_uv.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = iomgr_uv.cc; sourceTree = "<group>"; };
-		OBJ_473 /* iomgr_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = iomgr_windows.cc; sourceTree = "<group>"; };
-		OBJ_474 /* is_epollexclusive_available.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = is_epollexclusive_available.cc; sourceTree = "<group>"; };
-		OBJ_475 /* load_file.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = load_file.cc; sourceTree = "<group>"; };
-		OBJ_476 /* lockfree_event.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = lockfree_event.cc; sourceTree = "<group>"; };
-		OBJ_477 /* network_status_tracker.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = network_status_tracker.cc; sourceTree = "<group>"; };
-		OBJ_478 /* polling_entity.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = polling_entity.cc; sourceTree = "<group>"; };
-		OBJ_479 /* pollset.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pollset.cc; sourceTree = "<group>"; };
-		OBJ_48 /* analytics_context_Application.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_context_Application.pb.swift; sourceTree = "<group>"; };
-		OBJ_480 /* pollset_custom.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pollset_custom.cc; sourceTree = "<group>"; };
-		OBJ_481 /* pollset_set.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pollset_set.cc; sourceTree = "<group>"; };
-		OBJ_482 /* pollset_set_custom.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pollset_set_custom.cc; sourceTree = "<group>"; };
-		OBJ_483 /* pollset_set_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pollset_set_windows.cc; sourceTree = "<group>"; };
-		OBJ_484 /* pollset_uv.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pollset_uv.cc; sourceTree = "<group>"; };
-		OBJ_485 /* pollset_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pollset_windows.cc; sourceTree = "<group>"; };
-		OBJ_486 /* resolve_address.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = resolve_address.cc; sourceTree = "<group>"; };
-		OBJ_487 /* resolve_address_custom.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = resolve_address_custom.cc; sourceTree = "<group>"; };
-		OBJ_488 /* resolve_address_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = resolve_address_posix.cc; sourceTree = "<group>"; };
-		OBJ_489 /* resolve_address_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = resolve_address_windows.cc; sourceTree = "<group>"; };
-		OBJ_49 /* analytics_context_Browser.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_context_Browser.pb.swift; sourceTree = "<group>"; };
-		OBJ_490 /* resource_quota.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = resource_quota.cc; sourceTree = "<group>"; };
-		OBJ_491 /* sockaddr_utils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = sockaddr_utils.cc; sourceTree = "<group>"; };
-		OBJ_492 /* socket_factory_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = socket_factory_posix.cc; sourceTree = "<group>"; };
-		OBJ_493 /* socket_mutator.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = socket_mutator.cc; sourceTree = "<group>"; };
-		OBJ_494 /* socket_utils_common_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = socket_utils_common_posix.cc; sourceTree = "<group>"; };
-		OBJ_495 /* socket_utils_linux.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = socket_utils_linux.cc; sourceTree = "<group>"; };
-		OBJ_496 /* socket_utils_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = socket_utils_posix.cc; sourceTree = "<group>"; };
-		OBJ_497 /* socket_utils_uv.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = socket_utils_uv.cc; sourceTree = "<group>"; };
-		OBJ_498 /* socket_utils_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = socket_utils_windows.cc; sourceTree = "<group>"; };
-		OBJ_499 /* socket_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = socket_windows.cc; sourceTree = "<group>"; };
-		OBJ_50 /* analytics_context_Collection.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_context_Collection.pb.swift; sourceTree = "<group>"; };
-		OBJ_500 /* tcp_client.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_client.cc; sourceTree = "<group>"; };
-		OBJ_501 /* tcp_client_custom.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_client_custom.cc; sourceTree = "<group>"; };
-		OBJ_502 /* tcp_client_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_client_posix.cc; sourceTree = "<group>"; };
-		OBJ_503 /* tcp_client_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_client_windows.cc; sourceTree = "<group>"; };
-		OBJ_504 /* tcp_custom.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_custom.cc; sourceTree = "<group>"; };
-		OBJ_505 /* tcp_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_posix.cc; sourceTree = "<group>"; };
-		OBJ_506 /* tcp_server.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_server.cc; sourceTree = "<group>"; };
-		OBJ_507 /* tcp_server_custom.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_server_custom.cc; sourceTree = "<group>"; };
-		OBJ_508 /* tcp_server_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_server_posix.cc; sourceTree = "<group>"; };
-		OBJ_509 /* tcp_server_utils_posix_common.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_server_utils_posix_common.cc; sourceTree = "<group>"; };
-		OBJ_51 /* analytics_context_Library.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_context_Library.pb.swift; sourceTree = "<group>"; };
-		OBJ_510 /* tcp_server_utils_posix_ifaddrs.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_server_utils_posix_ifaddrs.cc; sourceTree = "<group>"; };
-		OBJ_511 /* tcp_server_utils_posix_noifaddrs.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_server_utils_posix_noifaddrs.cc; sourceTree = "<group>"; };
-		OBJ_512 /* tcp_server_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_server_windows.cc; sourceTree = "<group>"; };
-		OBJ_513 /* tcp_uv.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_uv.cc; sourceTree = "<group>"; };
-		OBJ_514 /* tcp_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tcp_windows.cc; sourceTree = "<group>"; };
-		OBJ_515 /* time_averaged_stats.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = time_averaged_stats.cc; sourceTree = "<group>"; };
-		OBJ_516 /* timer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = timer.cc; sourceTree = "<group>"; };
-		OBJ_517 /* timer_custom.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = timer_custom.cc; sourceTree = "<group>"; };
-		OBJ_518 /* timer_generic.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = timer_generic.cc; sourceTree = "<group>"; };
-		OBJ_519 /* timer_heap.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = timer_heap.cc; sourceTree = "<group>"; };
-		OBJ_52 /* analytics_context_NativeDevice.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_context_NativeDevice.pb.swift; sourceTree = "<group>"; };
-		OBJ_520 /* timer_manager.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = timer_manager.cc; sourceTree = "<group>"; };
-		OBJ_521 /* timer_uv.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = timer_uv.cc; sourceTree = "<group>"; };
-		OBJ_522 /* udp_server.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = udp_server.cc; sourceTree = "<group>"; };
-		OBJ_523 /* unix_sockets_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = unix_sockets_posix.cc; sourceTree = "<group>"; };
-		OBJ_524 /* unix_sockets_posix_noop.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = unix_sockets_posix_noop.cc; sourceTree = "<group>"; };
-		OBJ_525 /* wakeup_fd_cv.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = wakeup_fd_cv.cc; sourceTree = "<group>"; };
-		OBJ_526 /* wakeup_fd_eventfd.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = wakeup_fd_eventfd.cc; sourceTree = "<group>"; };
-		OBJ_527 /* wakeup_fd_nospecial.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = wakeup_fd_nospecial.cc; sourceTree = "<group>"; };
-		OBJ_528 /* wakeup_fd_pipe.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = wakeup_fd_pipe.cc; sourceTree = "<group>"; };
-		OBJ_529 /* wakeup_fd_posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = wakeup_fd_posix.cc; sourceTree = "<group>"; };
-		OBJ_53 /* analytics_context_OS.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_context_OS.pb.swift; sourceTree = "<group>"; };
-		OBJ_531 /* json.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = json.cc; sourceTree = "<group>"; };
-		OBJ_532 /* json_reader.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = json_reader.cc; sourceTree = "<group>"; };
-		OBJ_533 /* json_string.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = json_string.cc; sourceTree = "<group>"; };
-		OBJ_534 /* json_writer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = json_writer.cc; sourceTree = "<group>"; };
-		OBJ_536 /* basic_timers.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = basic_timers.cc; sourceTree = "<group>"; };
-		OBJ_537 /* stap_timers.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = stap_timers.cc; sourceTree = "<group>"; };
-		OBJ_54 /* analytics_generic_Event.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_generic_Event.pb.swift; sourceTree = "<group>"; };
-		OBJ_540 /* security_context.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = security_context.cc; sourceTree = "<group>"; };
-		OBJ_543 /* alts_credentials.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_credentials.cc; sourceTree = "<group>"; };
-		OBJ_544 /* check_gcp_environment.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = check_gcp_environment.cc; sourceTree = "<group>"; };
-		OBJ_545 /* check_gcp_environment_linux.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = check_gcp_environment_linux.cc; sourceTree = "<group>"; };
-		OBJ_546 /* check_gcp_environment_no_op.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = check_gcp_environment_no_op.cc; sourceTree = "<group>"; };
-		OBJ_547 /* check_gcp_environment_windows.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = check_gcp_environment_windows.cc; sourceTree = "<group>"; };
-		OBJ_548 /* grpc_alts_credentials_client_options.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_alts_credentials_client_options.cc; sourceTree = "<group>"; };
-		OBJ_549 /* grpc_alts_credentials_options.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_alts_credentials_options.cc; sourceTree = "<group>"; };
-		OBJ_55 /* analytics_generic_Exception.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_generic_Exception.pb.swift; sourceTree = "<group>"; };
-		OBJ_550 /* grpc_alts_credentials_server_options.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_alts_credentials_server_options.cc; sourceTree = "<group>"; };
-		OBJ_552 /* composite_credentials.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = composite_credentials.cc; sourceTree = "<group>"; };
-		OBJ_553 /* credentials.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = credentials.cc; sourceTree = "<group>"; };
-		OBJ_554 /* credentials_metadata.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = credentials_metadata.cc; sourceTree = "<group>"; };
-		OBJ_556 /* fake_credentials.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = fake_credentials.cc; sourceTree = "<group>"; };
-		OBJ_558 /* credentials_generic.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = credentials_generic.cc; sourceTree = "<group>"; };
-		OBJ_559 /* google_default_credentials.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = google_default_credentials.cc; sourceTree = "<group>"; };
-		OBJ_56 /* analytics_identity_UserAnalytics.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_identity_UserAnalytics.pb.swift; sourceTree = "<group>"; };
-		OBJ_561 /* iam_credentials.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = iam_credentials.cc; sourceTree = "<group>"; };
-		OBJ_563 /* json_token.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = json_token.cc; sourceTree = "<group>"; };
-		OBJ_564 /* jwt_credentials.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = jwt_credentials.cc; sourceTree = "<group>"; };
-		OBJ_565 /* jwt_verifier.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = jwt_verifier.cc; sourceTree = "<group>"; };
-		OBJ_567 /* oauth2_credentials.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = oauth2_credentials.cc; sourceTree = "<group>"; };
-		OBJ_569 /* plugin_credentials.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = plugin_credentials.cc; sourceTree = "<group>"; };
-		OBJ_57 /* analytics_search_SearchProperty.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_search_SearchProperty.pb.swift; sourceTree = "<group>"; };
-		OBJ_571 /* ssl_credentials.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_credentials.cc; sourceTree = "<group>"; };
-		OBJ_573 /* alts_security_connector.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_security_connector.cc; sourceTree = "<group>"; };
-		OBJ_574 /* security_connector.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = security_connector.cc; sourceTree = "<group>"; };
-		OBJ_576 /* client_auth_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = client_auth_filter.cc; sourceTree = "<group>"; };
-		OBJ_577 /* secure_endpoint.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = secure_endpoint.cc; sourceTree = "<group>"; };
-		OBJ_578 /* security_handshaker.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = security_handshaker.cc; sourceTree = "<group>"; };
-		OBJ_579 /* server_auth_filter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = server_auth_filter.cc; sourceTree = "<group>"; };
-		OBJ_58 /* analytics_stats_OrderStats.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_stats_OrderStats.pb.swift; sourceTree = "<group>"; };
-		OBJ_580 /* target_authority_table.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = target_authority_table.cc; sourceTree = "<group>"; };
-		OBJ_581 /* tsi_error.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tsi_error.cc; sourceTree = "<group>"; };
-		OBJ_583 /* json_util.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = json_util.cc; sourceTree = "<group>"; };
-		OBJ_585 /* b64.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = b64.cc; sourceTree = "<group>"; };
-		OBJ_586 /* percent_encoding.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = percent_encoding.cc; sourceTree = "<group>"; };
-		OBJ_587 /* slice.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = slice.cc; sourceTree = "<group>"; };
-		OBJ_588 /* slice_buffer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = slice_buffer.cc; sourceTree = "<group>"; };
-		OBJ_589 /* slice_intern.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = slice_intern.cc; sourceTree = "<group>"; };
-		OBJ_59 /* analytics_stats_SessionStats.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_stats_SessionStats.pb.swift; sourceTree = "<group>"; };
-		OBJ_590 /* slice_string_helpers.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = slice_string_helpers.cc; sourceTree = "<group>"; };
-		OBJ_592 /* api_trace.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = api_trace.cc; sourceTree = "<group>"; };
-		OBJ_593 /* byte_buffer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = byte_buffer.cc; sourceTree = "<group>"; };
-		OBJ_594 /* byte_buffer_reader.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = byte_buffer_reader.cc; sourceTree = "<group>"; };
-		OBJ_595 /* call.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = call.cc; sourceTree = "<group>"; };
-		OBJ_596 /* call_details.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = call_details.cc; sourceTree = "<group>"; };
-		OBJ_597 /* call_log_batch.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = call_log_batch.cc; sourceTree = "<group>"; };
-		OBJ_598 /* channel.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel.cc; sourceTree = "<group>"; };
-		OBJ_599 /* channel_init.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_init.cc; sourceTree = "<group>"; };
-		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		OBJ_60 /* analytics_stream_Filter.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = analytics_stream_Filter.pb.swift; sourceTree = "<group>"; };
-		OBJ_600 /* channel_ping.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_ping.cc; sourceTree = "<group>"; };
-		OBJ_601 /* channel_stack_type.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = channel_stack_type.cc; sourceTree = "<group>"; };
-		OBJ_602 /* completion_queue.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = completion_queue.cc; sourceTree = "<group>"; };
-		OBJ_603 /* completion_queue_factory.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = completion_queue_factory.cc; sourceTree = "<group>"; };
-		OBJ_604 /* event_string.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = event_string.cc; sourceTree = "<group>"; };
-		OBJ_605 /* init.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = init.cc; sourceTree = "<group>"; };
-		OBJ_606 /* init_secure.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = init_secure.cc; sourceTree = "<group>"; };
-		OBJ_607 /* lame_client.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = lame_client.cc; sourceTree = "<group>"; };
-		OBJ_608 /* metadata_array.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = metadata_array.cc; sourceTree = "<group>"; };
-		OBJ_609 /* server.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = server.cc; sourceTree = "<group>"; };
-		OBJ_61 /* auth_v1beta1_AuthService_Beta1.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = auth_v1beta1_AuthService_Beta1.pb.swift; sourceTree = "<group>"; };
-		OBJ_610 /* validate_metadata.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = validate_metadata.cc; sourceTree = "<group>"; };
-		OBJ_611 /* version.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = version.cc; sourceTree = "<group>"; };
-		OBJ_613 /* bdp_estimator.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = bdp_estimator.cc; sourceTree = "<group>"; };
-		OBJ_614 /* byte_stream.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = byte_stream.cc; sourceTree = "<group>"; };
-		OBJ_615 /* connectivity_state.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = connectivity_state.cc; sourceTree = "<group>"; };
-		OBJ_616 /* error_utils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = error_utils.cc; sourceTree = "<group>"; };
-		OBJ_617 /* metadata.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = metadata.cc; sourceTree = "<group>"; };
-		OBJ_618 /* metadata_batch.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = metadata_batch.cc; sourceTree = "<group>"; };
-		OBJ_619 /* pid_controller.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pid_controller.cc; sourceTree = "<group>"; };
-		OBJ_62 /* base_Compression.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = base_Compression.pb.swift; sourceTree = "<group>"; };
-		OBJ_620 /* service_config.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = service_config.cc; sourceTree = "<group>"; };
-		OBJ_621 /* static_metadata.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = static_metadata.cc; sourceTree = "<group>"; };
-		OBJ_622 /* status_conversion.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = status_conversion.cc; sourceTree = "<group>"; };
-		OBJ_623 /* status_metadata.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = status_metadata.cc; sourceTree = "<group>"; };
-		OBJ_624 /* timeout_encoding.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = timeout_encoding.cc; sourceTree = "<group>"; };
-		OBJ_625 /* transport.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = transport.cc; sourceTree = "<group>"; };
-		OBJ_626 /* transport_op_string.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = transport_op_string.cc; sourceTree = "<group>"; };
-		OBJ_628 /* grpc_plugin_registry.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_plugin_registry.cc; sourceTree = "<group>"; };
-		OBJ_63 /* base_Language.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = base_Language.pb.swift; sourceTree = "<group>"; };
-		OBJ_632 /* aes_gcm.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = aes_gcm.cc; sourceTree = "<group>"; };
-		OBJ_633 /* gsec.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = gsec.cc; sourceTree = "<group>"; };
-		OBJ_635 /* alts_counter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_counter.cc; sourceTree = "<group>"; };
-		OBJ_636 /* alts_crypter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_crypter.cc; sourceTree = "<group>"; };
-		OBJ_637 /* alts_frame_protector.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_frame_protector.cc; sourceTree = "<group>"; };
-		OBJ_638 /* alts_record_protocol_crypter_common.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_record_protocol_crypter_common.cc; sourceTree = "<group>"; };
-		OBJ_639 /* alts_seal_privacy_integrity_crypter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_seal_privacy_integrity_crypter.cc; sourceTree = "<group>"; };
-		OBJ_64 /* base_ProductKey.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = base_ProductKey.pb.swift; sourceTree = "<group>"; };
-		OBJ_640 /* alts_unseal_privacy_integrity_crypter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_unseal_privacy_integrity_crypter.cc; sourceTree = "<group>"; };
-		OBJ_641 /* frame_handler.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = frame_handler.cc; sourceTree = "<group>"; };
-		OBJ_643 /* alts_handshaker_client.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_handshaker_client.cc; sourceTree = "<group>"; };
-		OBJ_644 /* alts_handshaker_service_api.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_handshaker_service_api.cc; sourceTree = "<group>"; };
-		OBJ_645 /* alts_handshaker_service_api_util.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_handshaker_service_api_util.cc; sourceTree = "<group>"; };
-		OBJ_646 /* alts_tsi_event.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_tsi_event.cc; sourceTree = "<group>"; };
-		OBJ_647 /* alts_tsi_handshaker.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_tsi_handshaker.cc; sourceTree = "<group>"; };
-		OBJ_648 /* alts_tsi_utils.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_tsi_utils.cc; sourceTree = "<group>"; };
-		OBJ_649 /* altscontext.pb.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = altscontext.pb.c; sourceTree = "<group>"; };
-		OBJ_65 /* base_ProductKind.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = base_ProductKind.pb.swift; sourceTree = "<group>"; };
-		OBJ_650 /* handshaker.pb.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = handshaker.pb.c; sourceTree = "<group>"; };
-		OBJ_651 /* transport_security_common.pb.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = transport_security_common.pb.c; sourceTree = "<group>"; };
-		OBJ_652 /* transport_security_common_api.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = transport_security_common_api.cc; sourceTree = "<group>"; };
-		OBJ_654 /* alts_grpc_integrity_only_record_protocol.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_grpc_integrity_only_record_protocol.cc; sourceTree = "<group>"; };
-		OBJ_655 /* alts_grpc_privacy_integrity_record_protocol.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_grpc_privacy_integrity_record_protocol.cc; sourceTree = "<group>"; };
-		OBJ_656 /* alts_grpc_record_protocol_common.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_grpc_record_protocol_common.cc; sourceTree = "<group>"; };
-		OBJ_657 /* alts_iovec_record_protocol.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_iovec_record_protocol.cc; sourceTree = "<group>"; };
-		OBJ_658 /* alts_zero_copy_grpc_protector.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_zero_copy_grpc_protector.cc; sourceTree = "<group>"; };
-		OBJ_659 /* alts_transport_security.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = alts_transport_security.cc; sourceTree = "<group>"; };
-		OBJ_660 /* fake_transport_security.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = fake_transport_security.cc; sourceTree = "<group>"; };
-		OBJ_663 /* ssl_session_boringssl.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_session_boringssl.cc; sourceTree = "<group>"; };
-		OBJ_664 /* ssl_session_cache.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_session_cache.cc; sourceTree = "<group>"; };
-		OBJ_665 /* ssl_session_openssl.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_session_openssl.cc; sourceTree = "<group>"; };
-		OBJ_666 /* ssl_transport_security.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_transport_security.cc; sourceTree = "<group>"; };
-		OBJ_667 /* transport_security.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = transport_security.cc; sourceTree = "<group>"; };
-		OBJ_668 /* transport_security_adapter.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = transport_security_adapter.cc; sourceTree = "<group>"; };
-		OBJ_669 /* transport_security_grpc.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = transport_security_grpc.cc; sourceTree = "<group>"; };
-		OBJ_67 /* commerce_Currency.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = commerce_Currency.pb.swift; sourceTree = "<group>"; };
-		OBJ_672 /* pb_common.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pb_common.c; sourceTree = "<group>"; };
-		OBJ_673 /* pb_decode.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pb_decode.c; sourceTree = "<group>"; };
-		OBJ_674 /* pb_encode.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pb_encode.c; sourceTree = "<group>"; };
-		OBJ_676 /* cgrpc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cgrpc.h; sourceTree = "<group>"; };
-		OBJ_678 /* grpc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = grpc.h; sourceTree = "<group>"; };
-		OBJ_679 /* status.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = status.h; sourceTree = "<group>"; };
-		OBJ_68 /* commerce_Customer.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = commerce_Customer.pb.swift; sourceTree = "<group>"; };
-		OBJ_680 /* census.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = census.h; sourceTree = "<group>"; };
-		OBJ_681 /* slice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = slice.h; sourceTree = "<group>"; };
-		OBJ_682 /* compression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = compression.h; sourceTree = "<group>"; };
-		OBJ_683 /* fork.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fork.h; sourceTree = "<group>"; };
-		OBJ_684 /* byte_buffer_reader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = byte_buffer_reader.h; sourceTree = "<group>"; };
-		OBJ_685 /* grpc_security_constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = grpc_security_constants.h; sourceTree = "<group>"; };
-		OBJ_686 /* byte_buffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = byte_buffer.h; sourceTree = "<group>"; };
-		OBJ_687 /* slice_buffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = slice_buffer.h; sourceTree = "<group>"; };
-		OBJ_688 /* grpc_posix.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = grpc_posix.h; sourceTree = "<group>"; };
-		OBJ_689 /* grpc_security.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = grpc_security.h; sourceTree = "<group>"; };
-		OBJ_69 /* commerce_Delivery.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = commerce_Delivery.pb.swift; sourceTree = "<group>"; };
-		OBJ_690 /* load_reporting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = load_reporting.h; sourceTree = "<group>"; };
-		OBJ_692 /* time.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = time.h; sourceTree = "<group>"; };
-		OBJ_693 /* port_platform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = port_platform.h; sourceTree = "<group>"; };
-		OBJ_694 /* log_windows.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = log_windows.h; sourceTree = "<group>"; };
-		OBJ_695 /* sync.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync.h; sourceTree = "<group>"; };
-		OBJ_696 /* string_util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = string_util.h; sourceTree = "<group>"; };
-		OBJ_697 /* sync_custom.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_custom.h; sourceTree = "<group>"; };
-		OBJ_698 /* thd_id.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = thd_id.h; sourceTree = "<group>"; };
-		OBJ_699 /* workaround_list.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = workaround_list.h; sourceTree = "<group>"; };
-		OBJ_70 /* commerce_Discounts.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = commerce_Discounts.pb.swift; sourceTree = "<group>"; };
-		OBJ_700 /* atm_gcc_sync.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = atm_gcc_sync.h; sourceTree = "<group>"; };
-		OBJ_701 /* atm_gcc_atomic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = atm_gcc_atomic.h; sourceTree = "<group>"; };
-		OBJ_702 /* atm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = atm.h; sourceTree = "<group>"; };
-		OBJ_703 /* sync_generic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_generic.h; sourceTree = "<group>"; };
-		OBJ_704 /* log.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = log.h; sourceTree = "<group>"; };
-		OBJ_705 /* cpu.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cpu.h; sourceTree = "<group>"; };
-		OBJ_706 /* sync_posix.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_posix.h; sourceTree = "<group>"; };
-		OBJ_707 /* atm_windows.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = atm_windows.h; sourceTree = "<group>"; };
-		OBJ_708 /* sync_windows.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_windows.h; sourceTree = "<group>"; };
-		OBJ_709 /* alloc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = alloc.h; sourceTree = "<group>"; };
-		OBJ_71 /* commerce_Item.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = commerce_Item.pb.swift; sourceTree = "<group>"; };
-		OBJ_712 /* port_platform.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = port_platform.h; sourceTree = "<group>"; };
-		OBJ_713 /* status.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = status.h; sourceTree = "<group>"; };
-		OBJ_714 /* gpr_types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = gpr_types.h; sourceTree = "<group>"; };
-		OBJ_715 /* sync.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync.h; sourceTree = "<group>"; };
-		OBJ_716 /* grpc_types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = grpc_types.h; sourceTree = "<group>"; };
-		OBJ_717 /* sync_custom.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_custom.h; sourceTree = "<group>"; };
-		OBJ_718 /* gpr_slice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = gpr_slice.h; sourceTree = "<group>"; };
-		OBJ_719 /* slice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = slice.h; sourceTree = "<group>"; };
-		OBJ_72 /* commerce_Order.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = commerce_Order.pb.swift; sourceTree = "<group>"; };
-		OBJ_720 /* compression_types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = compression_types.h; sourceTree = "<group>"; };
-		OBJ_721 /* atm_gcc_sync.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = atm_gcc_sync.h; sourceTree = "<group>"; };
-		OBJ_722 /* atm_gcc_atomic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = atm_gcc_atomic.h; sourceTree = "<group>"; };
-		OBJ_723 /* atm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = atm.h; sourceTree = "<group>"; };
-		OBJ_724 /* sync_generic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_generic.h; sourceTree = "<group>"; };
-		OBJ_725 /* fork.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fork.h; sourceTree = "<group>"; };
-		OBJ_726 /* byte_buffer_reader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = byte_buffer_reader.h; sourceTree = "<group>"; };
-		OBJ_727 /* sync_posix.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_posix.h; sourceTree = "<group>"; };
-		OBJ_728 /* atm_windows.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = atm_windows.h; sourceTree = "<group>"; };
-		OBJ_729 /* propagation_bits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = propagation_bits.h; sourceTree = "<group>"; };
-		OBJ_73 /* commerce_Purchase.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = commerce_Purchase.pb.swift; sourceTree = "<group>"; };
-		OBJ_730 /* byte_buffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = byte_buffer.h; sourceTree = "<group>"; };
-		OBJ_731 /* connectivity_state.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = connectivity_state.h; sourceTree = "<group>"; };
-		OBJ_732 /* sync_windows.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sync_windows.h; sourceTree = "<group>"; };
-		OBJ_733 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = module.modulemap; path = "/Volumes/PITBULL/Vault/Bloombox/Client/Swift/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap"; sourceTree = "<group>"; };
-		OBJ_738 /* a_bitstr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_bitstr.c; sourceTree = "<group>"; };
-		OBJ_739 /* a_bool.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_bool.c; sourceTree = "<group>"; };
-		OBJ_74 /* commerce_payments_Payment.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = commerce_payments_Payment.pb.swift; sourceTree = "<group>"; };
-		OBJ_740 /* a_d2i_fp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_d2i_fp.c; sourceTree = "<group>"; };
-		OBJ_741 /* a_dup.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_dup.c; sourceTree = "<group>"; };
-		OBJ_742 /* a_enum.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_enum.c; sourceTree = "<group>"; };
-		OBJ_743 /* a_gentm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_gentm.c; sourceTree = "<group>"; };
-		OBJ_744 /* a_i2d_fp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_i2d_fp.c; sourceTree = "<group>"; };
-		OBJ_745 /* a_int.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_int.c; sourceTree = "<group>"; };
-		OBJ_746 /* a_mbstr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_mbstr.c; sourceTree = "<group>"; };
-		OBJ_747 /* a_object.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_object.c; sourceTree = "<group>"; };
-		OBJ_748 /* a_octet.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_octet.c; sourceTree = "<group>"; };
-		OBJ_749 /* a_print.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_print.c; sourceTree = "<group>"; };
-		OBJ_75 /* comms_Comms.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = comms_Comms.pb.swift; sourceTree = "<group>"; };
-		OBJ_750 /* a_strnid.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_strnid.c; sourceTree = "<group>"; };
-		OBJ_751 /* a_time.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_time.c; sourceTree = "<group>"; };
-		OBJ_752 /* a_type.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_type.c; sourceTree = "<group>"; };
-		OBJ_753 /* a_utctm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_utctm.c; sourceTree = "<group>"; };
-		OBJ_754 /* a_utf8.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_utf8.c; sourceTree = "<group>"; };
-		OBJ_755 /* asn1_lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = asn1_lib.c; sourceTree = "<group>"; };
-		OBJ_756 /* asn1_par.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = asn1_par.c; sourceTree = "<group>"; };
-		OBJ_757 /* asn_pack.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = asn_pack.c; sourceTree = "<group>"; };
-		OBJ_758 /* f_enum.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = f_enum.c; sourceTree = "<group>"; };
-		OBJ_759 /* f_int.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = f_int.c; sourceTree = "<group>"; };
-		OBJ_76 /* comms_CommsTask.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = comms_CommsTask.pb.swift; sourceTree = "<group>"; };
-		OBJ_760 /* f_string.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = f_string.c; sourceTree = "<group>"; };
-		OBJ_761 /* tasn_dec.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = tasn_dec.c; sourceTree = "<group>"; };
-		OBJ_762 /* tasn_enc.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = tasn_enc.c; sourceTree = "<group>"; };
-		OBJ_763 /* tasn_fre.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = tasn_fre.c; sourceTree = "<group>"; };
-		OBJ_764 /* tasn_new.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = tasn_new.c; sourceTree = "<group>"; };
-		OBJ_765 /* tasn_typ.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = tasn_typ.c; sourceTree = "<group>"; };
-		OBJ_766 /* tasn_utl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = tasn_utl.c; sourceTree = "<group>"; };
-		OBJ_767 /* time_support.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = time_support.c; sourceTree = "<group>"; };
-		OBJ_769 /* base64.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = base64.c; sourceTree = "<group>"; };
-		OBJ_77 /* comms_Email.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = comms_Email.pb.swift; sourceTree = "<group>"; };
-		OBJ_771 /* bio.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bio.c; sourceTree = "<group>"; };
-		OBJ_772 /* bio_mem.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bio_mem.c; sourceTree = "<group>"; };
-		OBJ_773 /* connect.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = connect.c; sourceTree = "<group>"; };
-		OBJ_774 /* fd.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fd.c; sourceTree = "<group>"; };
-		OBJ_775 /* file.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = file.c; sourceTree = "<group>"; };
-		OBJ_776 /* hexdump.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = hexdump.c; sourceTree = "<group>"; };
-		OBJ_777 /* pair.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pair.c; sourceTree = "<group>"; };
-		OBJ_778 /* printf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = printf.c; sourceTree = "<group>"; };
-		OBJ_779 /* socket.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = socket.c; sourceTree = "<group>"; };
-		OBJ_78 /* comms_SMS.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = comms_SMS.pb.swift; sourceTree = "<group>"; };
-		OBJ_780 /* socket_helper.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = socket_helper.c; sourceTree = "<group>"; };
-		OBJ_782 /* bn_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bn_asn1.c; sourceTree = "<group>"; };
-		OBJ_783 /* convert.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = convert.c; sourceTree = "<group>"; };
-		OBJ_785 /* buf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = buf.c; sourceTree = "<group>"; };
-		OBJ_787 /* asn1_compat.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = asn1_compat.c; sourceTree = "<group>"; };
-		OBJ_788 /* ber.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ber.c; sourceTree = "<group>"; };
-		OBJ_789 /* cbb.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cbb.c; sourceTree = "<group>"; };
-		OBJ_79 /* contact_ContactInfo.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = contact_ContactInfo.pb.swift; sourceTree = "<group>"; };
-		OBJ_790 /* cbs.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cbs.c; sourceTree = "<group>"; };
-		OBJ_792 /* chacha.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = chacha.c; sourceTree = "<group>"; };
-		OBJ_794 /* cipher_extra.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cipher_extra.c; sourceTree = "<group>"; };
-		OBJ_795 /* derive_key.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = derive_key.c; sourceTree = "<group>"; };
-		OBJ_796 /* e_aesctrhmac.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = e_aesctrhmac.c; sourceTree = "<group>"; };
-		OBJ_797 /* e_aesgcmsiv.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = e_aesgcmsiv.c; sourceTree = "<group>"; };
-		OBJ_798 /* e_chacha20poly1305.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = e_chacha20poly1305.c; sourceTree = "<group>"; };
-		OBJ_799 /* e_null.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = e_null.c; sourceTree = "<group>"; };
-		OBJ_80 /* contact_EmailAddress.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = contact_EmailAddress.pb.swift; sourceTree = "<group>"; };
-		OBJ_800 /* e_rc2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = e_rc2.c; sourceTree = "<group>"; };
-		OBJ_801 /* e_rc4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = e_rc4.c; sourceTree = "<group>"; };
-		OBJ_802 /* e_ssl3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = e_ssl3.c; sourceTree = "<group>"; };
-		OBJ_803 /* e_tls.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = e_tls.c; sourceTree = "<group>"; };
-		OBJ_804 /* tls_cbc.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = tls_cbc.c; sourceTree = "<group>"; };
-		OBJ_806 /* cmac.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cmac.c; sourceTree = "<group>"; };
-		OBJ_808 /* conf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = conf.c; sourceTree = "<group>"; };
-		OBJ_809 /* cpu-aarch64-linux.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "cpu-aarch64-linux.c"; sourceTree = "<group>"; };
-		OBJ_81 /* contact_PhoneNumber.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = contact_PhoneNumber.pb.swift; sourceTree = "<group>"; };
-		OBJ_810 /* cpu-arm-linux.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "cpu-arm-linux.c"; sourceTree = "<group>"; };
-		OBJ_811 /* cpu-arm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "cpu-arm.c"; sourceTree = "<group>"; };
-		OBJ_812 /* cpu-intel.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "cpu-intel.c"; sourceTree = "<group>"; };
-		OBJ_813 /* cpu-ppc64le.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "cpu-ppc64le.c"; sourceTree = "<group>"; };
-		OBJ_814 /* crypto.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = crypto.c; sourceTree = "<group>"; };
-		OBJ_816 /* spake25519.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = spake25519.c; sourceTree = "<group>"; };
-		OBJ_817 /* x25519-x86_64.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "x25519-x86_64.c"; sourceTree = "<group>"; };
-		OBJ_819 /* check.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = check.c; sourceTree = "<group>"; };
-		OBJ_82 /* contact_Website.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = contact_Website.pb.swift; sourceTree = "<group>"; };
-		OBJ_820 /* dh.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dh.c; sourceTree = "<group>"; };
-		OBJ_821 /* dh_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dh_asn1.c; sourceTree = "<group>"; };
-		OBJ_822 /* params.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = params.c; sourceTree = "<group>"; };
-		OBJ_824 /* digest_extra.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = digest_extra.c; sourceTree = "<group>"; };
-		OBJ_826 /* dsa.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dsa.c; sourceTree = "<group>"; };
-		OBJ_827 /* dsa_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dsa_asn1.c; sourceTree = "<group>"; };
-		OBJ_829 /* ec_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ec_asn1.c; sourceTree = "<group>"; };
-		OBJ_83 /* content_Brand.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = content_Brand.pb.swift; sourceTree = "<group>"; };
-		OBJ_831 /* ecdh.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ecdh.c; sourceTree = "<group>"; };
-		OBJ_833 /* ecdsa_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ecdsa_asn1.c; sourceTree = "<group>"; };
-		OBJ_835 /* engine.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = engine.c; sourceTree = "<group>"; };
-		OBJ_837 /* err.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = err.c; sourceTree = "<group>"; };
-		OBJ_838 /* err_data.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = err_data.c; sourceTree = "<group>"; };
-		OBJ_84 /* content_Colors.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = content_Colors.pb.swift; sourceTree = "<group>"; };
-		OBJ_840 /* digestsign.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = digestsign.c; sourceTree = "<group>"; };
-		OBJ_841 /* evp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = evp.c; sourceTree = "<group>"; };
-		OBJ_842 /* evp_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = evp_asn1.c; sourceTree = "<group>"; };
-		OBJ_843 /* evp_ctx.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = evp_ctx.c; sourceTree = "<group>"; };
-		OBJ_844 /* p_dsa_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = p_dsa_asn1.c; sourceTree = "<group>"; };
-		OBJ_845 /* p_ec.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = p_ec.c; sourceTree = "<group>"; };
-		OBJ_846 /* p_ec_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = p_ec_asn1.c; sourceTree = "<group>"; };
-		OBJ_847 /* p_ed25519.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = p_ed25519.c; sourceTree = "<group>"; };
-		OBJ_848 /* p_ed25519_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = p_ed25519_asn1.c; sourceTree = "<group>"; };
-		OBJ_849 /* p_rsa.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = p_rsa.c; sourceTree = "<group>"; };
-		OBJ_85 /* content_Content.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = content_Content.pb.swift; sourceTree = "<group>"; };
-		OBJ_850 /* p_rsa_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = p_rsa_asn1.c; sourceTree = "<group>"; };
-		OBJ_851 /* pbkdf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pbkdf.c; sourceTree = "<group>"; };
-		OBJ_852 /* print.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = print.c; sourceTree = "<group>"; };
-		OBJ_853 /* scrypt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = scrypt.c; sourceTree = "<group>"; };
-		OBJ_854 /* sign.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sign.c; sourceTree = "<group>"; };
-		OBJ_855 /* ex_data.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ex_data.c; sourceTree = "<group>"; };
-		OBJ_858 /* aes.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aes.c; sourceTree = "<group>"; };
-		OBJ_859 /* key_wrap.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = key_wrap.c; sourceTree = "<group>"; };
-		OBJ_86 /* content_MaterialsData.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = content_MaterialsData.pb.swift; sourceTree = "<group>"; };
-		OBJ_860 /* mode_wrappers.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mode_wrappers.c; sourceTree = "<group>"; };
-		OBJ_862 /* add.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = add.c; sourceTree = "<group>"; };
-		OBJ_863 /* bn.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bn.c; sourceTree = "<group>"; };
-		OBJ_864 /* bytes.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bytes.c; sourceTree = "<group>"; };
-		OBJ_865 /* cmp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cmp.c; sourceTree = "<group>"; };
-		OBJ_866 /* ctx.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ctx.c; sourceTree = "<group>"; };
-		OBJ_867 /* div.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = div.c; sourceTree = "<group>"; };
-		OBJ_868 /* exponentiation.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = exponentiation.c; sourceTree = "<group>"; };
-		OBJ_869 /* gcd.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gcd.c; sourceTree = "<group>"; };
-		OBJ_87 /* content_Name.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = content_Name.pb.swift; sourceTree = "<group>"; };
-		OBJ_870 /* generic.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = generic.c; sourceTree = "<group>"; };
-		OBJ_871 /* jacobi.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = jacobi.c; sourceTree = "<group>"; };
-		OBJ_872 /* montgomery.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = montgomery.c; sourceTree = "<group>"; };
-		OBJ_873 /* montgomery_inv.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = montgomery_inv.c; sourceTree = "<group>"; };
-		OBJ_874 /* mul.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mul.c; sourceTree = "<group>"; };
-		OBJ_875 /* prime.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = prime.c; sourceTree = "<group>"; };
-		OBJ_876 /* random.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = random.c; sourceTree = "<group>"; };
-		OBJ_877 /* rsaz_exp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rsaz_exp.c; sourceTree = "<group>"; };
-		OBJ_878 /* shift.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = shift.c; sourceTree = "<group>"; };
-		OBJ_879 /* sqrt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sqrt.c; sourceTree = "<group>"; };
-		OBJ_88 /* content_ProductContent.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = content_ProductContent.pb.swift; sourceTree = "<group>"; };
-		OBJ_881 /* aead.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aead.c; sourceTree = "<group>"; };
-		OBJ_882 /* cipher.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cipher.c; sourceTree = "<group>"; };
-		OBJ_883 /* e_aes.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = e_aes.c; sourceTree = "<group>"; };
-		OBJ_884 /* e_des.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = e_des.c; sourceTree = "<group>"; };
-		OBJ_886 /* des.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = des.c; sourceTree = "<group>"; };
-		OBJ_888 /* digest.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = digest.c; sourceTree = "<group>"; };
-		OBJ_889 /* digests.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = digests.c; sourceTree = "<group>"; };
-		OBJ_89 /* core_Datamodel.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = core_Datamodel.pb.swift; sourceTree = "<group>"; };
-		OBJ_891 /* ec.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ec.c; sourceTree = "<group>"; };
-		OBJ_892 /* ec_key.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ec_key.c; sourceTree = "<group>"; };
-		OBJ_893 /* ec_montgomery.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ec_montgomery.c; sourceTree = "<group>"; };
-		OBJ_894 /* oct.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = oct.c; sourceTree = "<group>"; };
-		OBJ_895 /* p224-64.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "p224-64.c"; sourceTree = "<group>"; };
-		OBJ_896 /* p256-64.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "p256-64.c"; sourceTree = "<group>"; };
-		OBJ_897 /* p256-x86_64.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "p256-x86_64.c"; sourceTree = "<group>"; };
-		OBJ_898 /* simple.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = simple.c; sourceTree = "<group>"; };
-		OBJ_899 /* util-64.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "util-64.c"; sourceTree = "<group>"; };
-		OBJ_9 /* AuthClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthClient.swift; sourceTree = "<group>"; };
-		OBJ_90 /* crypto_Container.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = crypto_Container.pb.swift; sourceTree = "<group>"; };
-		OBJ_900 /* wnaf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = wnaf.c; sourceTree = "<group>"; };
-		OBJ_902 /* ecdsa.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ecdsa.c; sourceTree = "<group>"; };
-		OBJ_904 /* hmac.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = hmac.c; sourceTree = "<group>"; };
-		OBJ_905 /* is_fips.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = is_fips.c; sourceTree = "<group>"; };
-		OBJ_907 /* md4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = md4.c; sourceTree = "<group>"; };
-		OBJ_909 /* md5.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = md5.c; sourceTree = "<group>"; };
-		OBJ_91 /* crypto_Signature.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = crypto_Signature.pb.swift; sourceTree = "<group>"; };
-		OBJ_911 /* cbc.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cbc.c; sourceTree = "<group>"; };
-		OBJ_912 /* cfb.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cfb.c; sourceTree = "<group>"; };
-		OBJ_913 /* ctr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ctr.c; sourceTree = "<group>"; };
-		OBJ_914 /* gcm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gcm.c; sourceTree = "<group>"; };
-		OBJ_915 /* ofb.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ofb.c; sourceTree = "<group>"; };
-		OBJ_916 /* polyval.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = polyval.c; sourceTree = "<group>"; };
-		OBJ_918 /* ctrdrbg.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ctrdrbg.c; sourceTree = "<group>"; };
-		OBJ_919 /* rand.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rand.c; sourceTree = "<group>"; };
-		OBJ_92 /* crypto_primitives_Integrity.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = crypto_primitives_Integrity.pb.swift; sourceTree = "<group>"; };
-		OBJ_920 /* urandom.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = urandom.c; sourceTree = "<group>"; };
-		OBJ_922 /* blinding.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = blinding.c; sourceTree = "<group>"; };
-		OBJ_923 /* padding.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = padding.c; sourceTree = "<group>"; };
-		OBJ_924 /* rsa.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rsa.c; sourceTree = "<group>"; };
-		OBJ_925 /* rsa_impl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rsa_impl.c; sourceTree = "<group>"; };
-		OBJ_927 /* sha1-altivec.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "sha1-altivec.c"; sourceTree = "<group>"; };
-		OBJ_928 /* sha1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
-		OBJ_929 /* sha256.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sha256.c; sourceTree = "<group>"; };
-		OBJ_93 /* crypto_primitives_Keys.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = crypto_primitives_Keys.pb.swift; sourceTree = "<group>"; };
-		OBJ_930 /* sha512.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sha512.c; sourceTree = "<group>"; };
-		OBJ_932 /* hkdf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = hkdf.c; sourceTree = "<group>"; };
-		OBJ_934 /* lhash.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lhash.c; sourceTree = "<group>"; };
-		OBJ_935 /* mem.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mem.c; sourceTree = "<group>"; };
-		OBJ_937 /* obj.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = obj.c; sourceTree = "<group>"; };
-		OBJ_938 /* obj_xref.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = obj_xref.c; sourceTree = "<group>"; };
-		OBJ_940 /* pem_all.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pem_all.c; sourceTree = "<group>"; };
-		OBJ_941 /* pem_info.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pem_info.c; sourceTree = "<group>"; };
-		OBJ_942 /* pem_lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pem_lib.c; sourceTree = "<group>"; };
-		OBJ_943 /* pem_oth.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pem_oth.c; sourceTree = "<group>"; };
-		OBJ_944 /* pem_pk8.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pem_pk8.c; sourceTree = "<group>"; };
-		OBJ_945 /* pem_pkey.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pem_pkey.c; sourceTree = "<group>"; };
-		OBJ_946 /* pem_x509.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pem_x509.c; sourceTree = "<group>"; };
-		OBJ_947 /* pem_xaux.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pem_xaux.c; sourceTree = "<group>"; };
-		OBJ_949 /* pkcs7.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pkcs7.c; sourceTree = "<group>"; };
-		OBJ_95 /* device_Device.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = device_Device.pb.swift; sourceTree = "<group>"; };
-		OBJ_950 /* pkcs7_x509.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pkcs7_x509.c; sourceTree = "<group>"; };
-		OBJ_952 /* p5_pbev2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = p5_pbev2.c; sourceTree = "<group>"; };
-		OBJ_953 /* pkcs8.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pkcs8.c; sourceTree = "<group>"; };
-		OBJ_954 /* pkcs8_x509.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pkcs8_x509.c; sourceTree = "<group>"; };
-		OBJ_956 /* poly1305.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = poly1305.c; sourceTree = "<group>"; };
-		OBJ_957 /* poly1305_arm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = poly1305_arm.c; sourceTree = "<group>"; };
-		OBJ_958 /* poly1305_vec.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = poly1305_vec.c; sourceTree = "<group>"; };
-		OBJ_96 /* devices_v1beta1_DevicesService_Beta1.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = devices_v1beta1_DevicesService_Beta1.pb.swift; sourceTree = "<group>"; };
-		OBJ_960 /* pool.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pool.c; sourceTree = "<group>"; };
-		OBJ_962 /* deterministic.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = deterministic.c; sourceTree = "<group>"; };
-		OBJ_963 /* forkunsafe.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = forkunsafe.c; sourceTree = "<group>"; };
-		OBJ_964 /* fuchsia.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fuchsia.c; sourceTree = "<group>"; };
-		OBJ_965 /* rand_extra.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rand_extra.c; sourceTree = "<group>"; };
-		OBJ_966 /* windows.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = windows.c; sourceTree = "<group>"; };
-		OBJ_968 /* rc4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rc4.c; sourceTree = "<group>"; };
-		OBJ_969 /* refcount_c11.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = refcount_c11.c; sourceTree = "<group>"; };
-		OBJ_97 /* geo_Address.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = geo_Address.pb.swift; sourceTree = "<group>"; };
-		OBJ_970 /* refcount_lock.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = refcount_lock.c; sourceTree = "<group>"; };
-		OBJ_972 /* rsa_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rsa_asn1.c; sourceTree = "<group>"; };
-		OBJ_974 /* stack.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = stack.c; sourceTree = "<group>"; };
-		OBJ_975 /* thread.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = thread.c; sourceTree = "<group>"; };
-		OBJ_976 /* thread_none.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = thread_none.c; sourceTree = "<group>"; };
-		OBJ_977 /* thread_pthread.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = thread_pthread.c; sourceTree = "<group>"; };
-		OBJ_978 /* thread_win.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = thread_win.c; sourceTree = "<group>"; };
-		OBJ_98 /* geo_Country.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = geo_Country.pb.swift; sourceTree = "<group>"; };
-		OBJ_980 /* a_digest.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_digest.c; sourceTree = "<group>"; };
-		OBJ_981 /* a_sign.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_sign.c; sourceTree = "<group>"; };
-		OBJ_982 /* a_strex.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_strex.c; sourceTree = "<group>"; };
-		OBJ_983 /* a_verify.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_verify.c; sourceTree = "<group>"; };
-		OBJ_984 /* algorithm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = algorithm.c; sourceTree = "<group>"; };
-		OBJ_985 /* asn1_gen.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = asn1_gen.c; sourceTree = "<group>"; };
-		OBJ_986 /* by_dir.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = by_dir.c; sourceTree = "<group>"; };
-		OBJ_987 /* by_file.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = by_file.c; sourceTree = "<group>"; };
-		OBJ_988 /* i2d_pr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = i2d_pr.c; sourceTree = "<group>"; };
-		OBJ_989 /* rsa_pss.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rsa_pss.c; sourceTree = "<group>"; };
-		OBJ_99 /* geo_Distance.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = geo_Distance.pb.swift; sourceTree = "<group>"; };
-		OBJ_990 /* t_crl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = t_crl.c; sourceTree = "<group>"; };
-		OBJ_991 /* t_req.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = t_req.c; sourceTree = "<group>"; };
-		OBJ_992 /* t_x509.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = t_x509.c; sourceTree = "<group>"; };
-		OBJ_993 /* t_x509a.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = t_x509a.c; sourceTree = "<group>"; };
-		OBJ_994 /* x509.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509.c; sourceTree = "<group>"; };
-		OBJ_995 /* x509_att.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_att.c; sourceTree = "<group>"; };
-		OBJ_996 /* x509_cmp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_cmp.c; sourceTree = "<group>"; };
-		OBJ_997 /* x509_d2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_d2.c; sourceTree = "<group>"; };
-		OBJ_998 /* x509_def.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_def.c; sourceTree = "<group>"; };
-		OBJ_999 /* x509_ext.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x509_ext.c; sourceTree = "<group>"; };
-		"SwiftGRPC::BoringSSL::Product" /* BoringSSL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = BoringSSL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"SwiftGRPC::CgRPC::Product" /* CgRPC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CgRPC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"SwiftGRPC::SwiftGRPC::Product" /* SwiftGRPC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwiftGRPC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"SwiftProtobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		OBJ_1331 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_1332 /* BloomboxServices.framework in Frameworks */,
-				OBJ_1333 /* SwiftGRPC.framework in Frameworks */,
-				OBJ_1334 /* CgRPC.framework in Frameworks */,
-				OBJ_1335 /* BoringSSL.framework in Frameworks */,
-				OBJ_1336 /* OpenCannabis.framework in Frameworks */,
-				OBJ_1337 /* SwiftProtobuf.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_1378 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_1379 /* SwiftGRPC.framework in Frameworks */,
-				OBJ_1380 /* CgRPC.framework in Frameworks */,
-				OBJ_1381 /* BoringSSL.framework in Frameworks */,
-				OBJ_1382 /* OpenCannabis.framework in Frameworks */,
-				OBJ_1383 /* SwiftProtobuf.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_1707 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2066 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2067 /* BoringSSL.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2080 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2081 /* Bloombox.framework in Frameworks */,
-				OBJ_2082 /* BloomboxServices.framework in Frameworks */,
-				OBJ_2083 /* SwiftGRPC.framework in Frameworks */,
-				OBJ_2084 /* CgRPC.framework in Frameworks */,
-				OBJ_2085 /* BoringSSL.framework in Frameworks */,
-				OBJ_2086 /* OpenCannabis.framework in Frameworks */,
-				OBJ_2087 /* SwiftProtobuf.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2274 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2275 /* SwiftProtobuf.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2284 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2285 /* Bloombox.framework in Frameworks */,
-				OBJ_2286 /* BloomboxServices.framework in Frameworks */,
-				OBJ_2287 /* SwiftGRPC.framework in Frameworks */,
-				OBJ_2288 /* CgRPC.framework in Frameworks */,
-				OBJ_2289 /* BoringSSL.framework in Frameworks */,
-				OBJ_2290 /* OpenCannabis.framework in Frameworks */,
-				OBJ_2291 /* SwiftProtobuf.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2335 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2336 /* SwiftProtobuf.framework in Frameworks */,
-				OBJ_2337 /* CgRPC.framework in Frameworks */,
-				OBJ_2338 /* BoringSSL.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2428 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		OBJ_1029 /* x509v3 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1030 /* pcy_cache.c */,
-				OBJ_1031 /* pcy_data.c */,
-				OBJ_1032 /* pcy_lib.c */,
-				OBJ_1033 /* pcy_map.c */,
-				OBJ_1034 /* pcy_node.c */,
-				OBJ_1035 /* pcy_tree.c */,
-				OBJ_1036 /* v3_akey.c */,
-				OBJ_1037 /* v3_akeya.c */,
-				OBJ_1038 /* v3_alt.c */,
-				OBJ_1039 /* v3_bcons.c */,
-				OBJ_1040 /* v3_bitst.c */,
-				OBJ_1041 /* v3_conf.c */,
-				OBJ_1042 /* v3_cpols.c */,
-				OBJ_1043 /* v3_crld.c */,
-				OBJ_1044 /* v3_enum.c */,
-				OBJ_1045 /* v3_extku.c */,
-				OBJ_1046 /* v3_genn.c */,
-				OBJ_1047 /* v3_ia5.c */,
-				OBJ_1048 /* v3_info.c */,
-				OBJ_1049 /* v3_int.c */,
-				OBJ_1050 /* v3_lib.c */,
-				OBJ_1051 /* v3_ncons.c */,
-				OBJ_1052 /* v3_pci.c */,
-				OBJ_1053 /* v3_pcia.c */,
-				OBJ_1054 /* v3_pcons.c */,
-				OBJ_1055 /* v3_pku.c */,
-				OBJ_1056 /* v3_pmaps.c */,
-				OBJ_1057 /* v3_prn.c */,
-				OBJ_1058 /* v3_purp.c */,
-				OBJ_1059 /* v3_skey.c */,
-				OBJ_1060 /* v3_sxnet.c */,
-				OBJ_1061 /* v3_utl.c */,
-			);
-			path = x509v3;
-			sourceTree = "<group>";
-		};
-		OBJ_1063 /* ssl */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1064 /* bio_ssl.cc */,
-				OBJ_1065 /* custom_extensions.cc */,
-				OBJ_1066 /* d1_both.cc */,
-				OBJ_1067 /* d1_lib.cc */,
-				OBJ_1068 /* d1_pkt.cc */,
-				OBJ_1069 /* d1_srtp.cc */,
-				OBJ_1070 /* dtls_method.cc */,
-				OBJ_1071 /* dtls_record.cc */,
-				OBJ_1072 /* handshake.cc */,
-				OBJ_1073 /* handshake_client.cc */,
-				OBJ_1074 /* handshake_server.cc */,
-				OBJ_1075 /* s3_both.cc */,
-				OBJ_1076 /* s3_lib.cc */,
-				OBJ_1077 /* s3_pkt.cc */,
-				OBJ_1078 /* ssl_aead_ctx.cc */,
-				OBJ_1079 /* ssl_asn1.cc */,
-				OBJ_1080 /* ssl_buffer.cc */,
-				OBJ_1081 /* ssl_cert.cc */,
-				OBJ_1082 /* ssl_cipher.cc */,
-				OBJ_1083 /* ssl_file.cc */,
-				OBJ_1084 /* ssl_key_share.cc */,
-				OBJ_1085 /* ssl_lib.cc */,
-				OBJ_1086 /* ssl_privkey.cc */,
-				OBJ_1087 /* ssl_session.cc */,
-				OBJ_1088 /* ssl_stat.cc */,
-				OBJ_1089 /* ssl_transcript.cc */,
-				OBJ_1090 /* ssl_versions.cc */,
-				OBJ_1091 /* ssl_x509.cc */,
-				OBJ_1092 /* t1_enc.cc */,
-				OBJ_1093 /* t1_lib.cc */,
-				OBJ_1094 /* tls13_both.cc */,
-				OBJ_1095 /* tls13_client.cc */,
-				OBJ_1096 /* tls13_enc.cc */,
-				OBJ_1097 /* tls13_server.cc */,
-				OBJ_1098 /* tls_method.cc */,
-				OBJ_1099 /* tls_record.cc */,
-			);
-			path = ssl;
-			sourceTree = "<group>";
-		};
-		OBJ_1100 /* third_party */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1101 /* fiat */,
-			);
-			path = third_party;
-			sourceTree = "<group>";
-		};
-		OBJ_1101 /* fiat */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1102 /* curve25519.c */,
-			);
-			path = fiat;
-			sourceTree = "<group>";
-		};
-		OBJ_1103 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1104 /* openssl */,
-				OBJ_1178 /* module.modulemap */,
-			);
-			path = include;
-			sourceTree = "<group>";
-		};
-		OBJ_1104 /* openssl */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1105 /* pem.h */,
-				OBJ_1106 /* nid.h */,
-				OBJ_1107 /* ssl3.h */,
-				OBJ_1108 /* ossl_typ.h */,
-				OBJ_1109 /* dtls1.h */,
-				OBJ_1110 /* err.h */,
-				OBJ_1111 /* bn.h */,
-				OBJ_1112 /* blowfish.h */,
-				OBJ_1113 /* engine.h */,
-				OBJ_1114 /* bytestring.h */,
-				OBJ_1115 /* x509.h */,
-				OBJ_1116 /* asn1_mac.h */,
-				OBJ_1117 /* pool.h */,
-				OBJ_1118 /* ec_key.h */,
-				OBJ_1119 /* base64.h */,
-				OBJ_1120 /* is_boringssl.h */,
-				OBJ_1121 /* sha.h */,
-				OBJ_1122 /* asn1.h */,
-				OBJ_1123 /* chacha.h */,
-				OBJ_1124 /* opensslconf.h */,
-				OBJ_1125 /* arm_arch.h */,
-				OBJ_1126 /* bio.h */,
-				OBJ_1127 /* dh.h */,
-				OBJ_1128 /* digest.h */,
-				OBJ_1129 /* x509v3.h */,
-				OBJ_1130 /* conf.h */,
-				OBJ_1131 /* poly1305.h */,
-				OBJ_1132 /* hkdf.h */,
-				OBJ_1133 /* type_check.h */,
-				OBJ_1134 /* md5.h */,
-				OBJ_1135 /* x509_vfy.h */,
-				OBJ_1136 /* pkcs8.h */,
-				OBJ_1137 /* safestack.h */,
-				OBJ_1138 /* buf.h */,
-				OBJ_1139 /* obj.h */,
-				OBJ_1140 /* ecdsa.h */,
-				OBJ_1141 /* cipher.h */,
-				OBJ_1142 /* objects.h */,
-				OBJ_1143 /* pkcs12.h */,
-				OBJ_1144 /* crypto.h */,
-				OBJ_1145 /* opensslv.h */,
-				OBJ_1146 /* pkcs7.h */,
-				OBJ_1147 /* obj_mac.h */,
-				OBJ_1148 /* buffer.h */,
-				OBJ_1149 /* ssl.h */,
-				OBJ_1150 /* thread.h */,
-				OBJ_1151 /* evp.h */,
-				OBJ_1152 /* md4.h */,
-				OBJ_1153 /* hmac.h */,
-				OBJ_1154 /* aes.h */,
-				OBJ_1155 /* cast.h */,
-				OBJ_1156 /* rc4.h */,
-				OBJ_1157 /* cpu.h */,
-				OBJ_1158 /* stack.h */,
-				OBJ_1159 /* des.h */,
-				OBJ_1160 /* ec.h */,
-				OBJ_1161 /* ecdh.h */,
-				OBJ_1162 /* rand.h */,
-				OBJ_1163 /* aead.h */,
-				OBJ_1164 /* lhash_macros.h */,
-				OBJ_1165 /* span.h */,
-				OBJ_1166 /* rsa.h */,
-				OBJ_1167 /* mem.h */,
-				OBJ_1168 /* ripemd.h */,
-				OBJ_1169 /* curve25519.h */,
-				OBJ_1170 /* tls1.h */,
-				OBJ_1171 /* dsa.h */,
-				OBJ_1172 /* srtp.h */,
-				OBJ_1173 /* asn1t.h */,
-				OBJ_1174 /* cmac.h */,
-				OBJ_1175 /* lhash.h */,
-				OBJ_1176 /* ex_data.h */,
-				OBJ_1177 /* base.h */,
-			);
-			path = openssl;
-			sourceTree = "<group>";
-		};
-		OBJ_1179 /* SwiftGRPC */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1180 /* Core */,
-				OBJ_1197 /* Runtime */,
-			);
-			name = SwiftGRPC;
-			path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/SwiftGRPC";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_1180 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1181 /* ByteBuffer.swift */,
-				OBJ_1182 /* Call.swift */,
-				OBJ_1183 /* CallError.swift */,
-				OBJ_1184 /* CallResult.swift */,
-				OBJ_1185 /* Channel.swift */,
-				OBJ_1186 /* ChannelArgument.swift */,
-				OBJ_1187 /* CompletionQueue.swift */,
-				OBJ_1188 /* Handler.swift */,
-				OBJ_1189 /* Metadata.swift */,
-				OBJ_1190 /* Mutex.swift */,
-				OBJ_1191 /* Operation.swift */,
-				OBJ_1192 /* OperationGroup.swift */,
-				OBJ_1193 /* Roots.swift */,
-				OBJ_1194 /* Server.swift */,
-				OBJ_1195 /* ServerStatus.swift */,
-				OBJ_1196 /* gRPC.swift */,
-			);
-			path = Core;
-			sourceTree = "<group>";
-		};
-		OBJ_1197 /* Runtime */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1198 /* ClientCall.swift */,
-				OBJ_1199 /* ClientCallBidirectionalStreaming.swift */,
-				OBJ_1200 /* ClientCallClientStreaming.swift */,
-				OBJ_1201 /* ClientCallServerStreaming.swift */,
-				OBJ_1202 /* ClientCallUnary.swift */,
-				OBJ_1203 /* RPCError.swift */,
-				OBJ_1204 /* ServerSession.swift */,
-				OBJ_1205 /* ServerSessionBidirectionalStreaming.swift */,
-				OBJ_1206 /* ServerSessionClientStreaming.swift */,
-				OBJ_1207 /* ServerSessionServerStreaming.swift */,
-				OBJ_1208 /* ServerSessionUnary.swift */,
-				OBJ_1209 /* ServiceClient.swift */,
-				OBJ_1210 /* ServiceProvider.swift */,
-				OBJ_1211 /* ServiceServer.swift */,
-				OBJ_1212 /* StreamReceiving.swift */,
-				OBJ_1213 /* StreamSending.swift */,
-			);
-			path = Runtime;
-			sourceTree = "<group>";
-		};
-		OBJ_1215 /* SwiftProtobuf 1.1.2 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1216 /* Conformance */,
-				OBJ_1217 /* protoc-gen-swift */,
-				OBJ_1218 /* SwiftProtobuf */,
-				OBJ_1295 /* SwiftProtobufPluginLibrary */,
-				OBJ_1296 /* Package.swift */,
-			);
-			name = "SwiftProtobuf 1.1.2";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_1216 /* Conformance */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Conformance;
-			path = ".build/checkouts/swift-protobuf.git-7923261648679470216/Sources/Conformance";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_1217 /* protoc-gen-swift */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "protoc-gen-swift";
-			path = ".build/checkouts/swift-protobuf.git-7923261648679470216/Sources/protoc-gen-swift";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_1218 /* SwiftProtobuf */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_1219 /* AnyMessageStorage.swift */,
-				OBJ_1220 /* AnyUnpackError.swift */,
-				OBJ_1221 /* BinaryDecoder.swift */,
-				OBJ_1222 /* BinaryDecodingError.swift */,
-				OBJ_1223 /* BinaryDecodingOptions.swift */,
-				OBJ_1224 /* BinaryDelimited.swift */,
-				OBJ_1225 /* BinaryEncoder.swift */,
-				OBJ_1226 /* BinaryEncodingError.swift */,
-				OBJ_1227 /* BinaryEncodingSizeVisitor.swift */,
-				OBJ_1228 /* BinaryEncodingVisitor.swift */,
-				OBJ_1229 /* CustomJSONCodable.swift */,
-				OBJ_1230 /* Decoder.swift */,
-				OBJ_1231 /* DoubleFormatter.swift */,
-				OBJ_1232 /* Enum.swift */,
-				OBJ_1233 /* ExtensibleMessage.swift */,
-				OBJ_1234 /* ExtensionFieldValueSet.swift */,
-				OBJ_1235 /* ExtensionFields.swift */,
-				OBJ_1236 /* ExtensionMap.swift */,
-				OBJ_1237 /* FieldTag.swift */,
-				OBJ_1238 /* FieldTypes.swift */,
-				OBJ_1239 /* Google_Protobuf_Any+Extensions.swift */,
-				OBJ_1240 /* Google_Protobuf_Any+Registry.swift */,
-				OBJ_1241 /* Google_Protobuf_Duration+Extensions.swift */,
-				OBJ_1242 /* Google_Protobuf_FieldMask+Extensions.swift */,
-				OBJ_1243 /* Google_Protobuf_ListValue+Extensions.swift */,
-				OBJ_1244 /* Google_Protobuf_Struct+Extensions.swift */,
-				OBJ_1245 /* Google_Protobuf_Timestamp+Extensions.swift */,
-				OBJ_1246 /* Google_Protobuf_Value+Extensions.swift */,
-				OBJ_1247 /* Google_Protobuf_Wrappers+Extensions.swift */,
-				OBJ_1248 /* HashVisitor.swift */,
-				OBJ_1249 /* Internal.swift */,
-				OBJ_1250 /* JSONDecoder.swift */,
-				OBJ_1251 /* JSONDecodingError.swift */,
-				OBJ_1252 /* JSONDecodingOptions.swift */,
-				OBJ_1253 /* JSONEncoder.swift */,
-				OBJ_1254 /* JSONEncodingError.swift */,
-				OBJ_1255 /* JSONEncodingVisitor.swift */,
-				OBJ_1256 /* JSONMapEncodingVisitor.swift */,
-				OBJ_1257 /* JSONScanner.swift */,
-				OBJ_1258 /* MathUtils.swift */,
-				OBJ_1259 /* Message+AnyAdditions.swift */,
-				OBJ_1260 /* Message+BinaryAdditions.swift */,
-				OBJ_1261 /* Message+JSONAdditions.swift */,
-				OBJ_1262 /* Message+JSONArrayAdditions.swift */,
-				OBJ_1263 /* Message+TextFormatAdditions.swift */,
-				OBJ_1264 /* Message.swift */,
-				OBJ_1265 /* MessageExtension.swift */,
-				OBJ_1266 /* NameMap.swift */,
-				OBJ_1267 /* ProtoNameProviding.swift */,
-				OBJ_1268 /* ProtobufAPIVersionCheck.swift */,
-				OBJ_1269 /* ProtobufMap.swift */,
-				OBJ_1270 /* SelectiveVisitor.swift */,
-				OBJ_1271 /* SimpleExtensionMap.swift */,
-				OBJ_1272 /* StringUtils.swift */,
-				OBJ_1273 /* TextFormatDecoder.swift */,
-				OBJ_1274 /* TextFormatDecodingError.swift */,
-				OBJ_1275 /* TextFormatEncoder.swift */,
-				OBJ_1276 /* TextFormatEncodingVisitor.swift */,
-				OBJ_1277 /* TextFormatScanner.swift */,
-				OBJ_1278 /* TimeUtils.swift */,
-				OBJ_1279 /* UnknownStorage.swift */,
-				OBJ_1280 /* Varint.swift */,
-				OBJ_1281 /* Version.swift */,
-				OBJ_1282 /* Visitor.swift */,
-				OBJ_1283 /* WireFormat.swift */,
-				OBJ_1284 /* ZigZag.swift */,
-				OBJ_1285 /* any.pb.swift */,
-				OBJ_1286 /* api.pb.swift */,
-				OBJ_1287 /* duration.pb.swift */,
-				OBJ_1288 /* empty.pb.swift */,
-				OBJ_1289 /* field_mask.pb.swift */,
-				OBJ_1290 /* source_context.pb.swift */,
-				OBJ_1291 /* struct.pb.swift */,
-				OBJ_1292 /* timestamp.pb.swift */,
-				OBJ_1293 /* type.pb.swift */,
-				OBJ_1294 /* wrappers.pb.swift */,
-			);
-			name = SwiftProtobuf;
-			path = ".build/checkouts/swift-protobuf.git-7923261648679470216/Sources/SwiftProtobuf";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_1295 /* SwiftProtobufPluginLibrary */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = SwiftProtobufPluginLibrary;
-			path = ".build/checkouts/swift-protobuf.git-7923261648679470216/Sources/SwiftProtobufPluginLibrary";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_1297 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				"Bloombox::Bloombox::Product" /* Bloombox.framework */,
-				"SwiftGRPC::BoringSSL::Product" /* BoringSSL.framework */,
-				"Bloombox::ClientTests::Product" /* ClientTests.xctest */,
-				"Bloombox::SchemaTests::Product" /* SchemaTests.xctest */,
-				"Bloombox::BloomboxServices::Product" /* BloomboxServices.framework */,
-				"Bloombox::OpenCannabis::Product" /* OpenCannabis.framework */,
-				"SwiftGRPC::SwiftGRPC::Product" /* SwiftGRPC.framework */,
-				"SwiftProtobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */,
-				"SwiftGRPC::CgRPC::Product" /* CgRPC.framework */,
-			);
-			name = Products;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		OBJ_215 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_216 /* SchemaTests */,
-				OBJ_220 /* ClientTests */,
-			);
-			name = Tests;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_216 /* SchemaTests */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_217 /* ModelTool.swift */,
-				OBJ_218 /* SchemaTests+Codec.swift */,
-				OBJ_219 /* SchemaTests.swift */,
-			);
-			name = SchemaTests;
-			path = Tests/SchemaTests;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_220 /* ClientTests */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_221 /* AuthClientTests.swift */,
-				OBJ_222 /* ClientTests.swift */,
-				OBJ_223 /* DeviceClientTests.swift */,
-				OBJ_224 /* MenuClientTests.swift */,
-				OBJ_225 /* PlatformClientTests.swift */,
-				OBJ_226 /* ShopClientTests.swift */,
-				OBJ_227 /* TelemetryClientTests.swift */,
-			);
-			name = ClientTests;
-			path = Tests/ClientTests;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_233 /* Dependencies */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_234 /* SwiftGRPC */,
-				OBJ_1215 /* SwiftProtobuf 1.1.2 */,
-			);
-			name = Dependencies;
-			sourceTree = "<group>";
-		};
-		OBJ_234 /* SwiftGRPC */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_235 /* Echo */,
-				OBJ_236 /* Simple */,
-				OBJ_237 /* protoc-gen-swiftgrpc */,
-				OBJ_238 /* CgRPC */,
-				OBJ_734 /* RootsEncoder */,
-				OBJ_735 /* BoringSSL */,
-				OBJ_1179 /* SwiftGRPC */,
-				OBJ_1214 /* Package.swift */,
-			);
-			name = SwiftGRPC;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_235 /* Echo */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Echo;
-			path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/Examples/Echo";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_236 /* Simple */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Simple;
-			path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/Examples/Simple";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_237 /* protoc-gen-swiftgrpc */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "protoc-gen-swiftgrpc";
-			path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/protoc-gen-swiftgrpc";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_238 /* CgRPC */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_239 /* shim */,
-				OBJ_252 /* src */,
-				OBJ_670 /* third_party */,
-				OBJ_675 /* include */,
-			);
-			name = CgRPC;
-			path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_239 /* shim */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_240 /* byte_buffer.c */,
-				OBJ_241 /* call.c */,
-				OBJ_242 /* channel.c */,
-				OBJ_243 /* completion_queue.c */,
-				OBJ_244 /* event.c */,
-				OBJ_245 /* handler.c */,
-				OBJ_246 /* internal.c */,
-				OBJ_247 /* metadata.c */,
-				OBJ_248 /* mutex.c */,
-				OBJ_249 /* observers.c */,
-				OBJ_250 /* operations.c */,
-				OBJ_251 /* server.c */,
-			);
-			path = shim;
-			sourceTree = "<group>";
-		};
-		OBJ_252 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_253 /* core */,
-			);
-			path = src;
-			sourceTree = "<group>";
-		};
-		OBJ_253 /* core */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_254 /* ext */,
-				OBJ_375 /* lib */,
-				OBJ_627 /* plugin_registry */,
-				OBJ_629 /* tsi */,
-			);
-			path = core;
-			sourceTree = "<group>";
-		};
-		OBJ_254 /* ext */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_255 /* census */,
-				OBJ_257 /* filters */,
-				OBJ_330 /* transport */,
-			);
-			path = ext;
-			sourceTree = "<group>";
-		};
-		OBJ_255 /* census */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_256 /* grpc_context.cc */,
-			);
-			path = census;
-			sourceTree = "<group>";
-		};
-		OBJ_257 /* filters */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_258 /* client_channel */,
-				OBJ_309 /* deadline */,
-				OBJ_311 /* http */,
-				OBJ_320 /* load_reporting */,
-				OBJ_323 /* max_age */,
-				OBJ_325 /* message_size */,
-				OBJ_327 /* workarounds */,
-			);
-			path = filters;
-			sourceTree = "<group>";
-		};
-		OBJ_258 /* client_channel */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_259 /* backup_poller.cc */,
-				OBJ_260 /* channel_connectivity.cc */,
-				OBJ_261 /* client_channel.cc */,
-				OBJ_262 /* client_channel_factory.cc */,
-				OBJ_263 /* client_channel_plugin.cc */,
-				OBJ_264 /* connector.cc */,
-				OBJ_265 /* http_connect_handshaker.cc */,
-				OBJ_266 /* http_proxy.cc */,
-				OBJ_267 /* lb_policy.cc */,
-				OBJ_268 /* lb_policy */,
-				OBJ_284 /* lb_policy_factory.cc */,
-				OBJ_285 /* lb_policy_registry.cc */,
-				OBJ_286 /* method_params.cc */,
-				OBJ_287 /* parse_address.cc */,
-				OBJ_288 /* proxy_mapper.cc */,
-				OBJ_289 /* proxy_mapper_registry.cc */,
-				OBJ_290 /* resolver.cc */,
-				OBJ_291 /* resolver */,
-				OBJ_304 /* resolver_registry.cc */,
-				OBJ_305 /* retry_throttle.cc */,
-				OBJ_306 /* subchannel.cc */,
-				OBJ_307 /* subchannel_index.cc */,
-				OBJ_308 /* uri_parser.cc */,
-			);
-			path = client_channel;
-			sourceTree = "<group>";
-		};
-		OBJ_268 /* lb_policy */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_269 /* grpclb */,
-				OBJ_280 /* pick_first */,
-				OBJ_282 /* round_robin */,
-			);
-			path = lb_policy;
-			sourceTree = "<group>";
-		};
-		OBJ_269 /* grpclb */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_270 /* client_load_reporting_filter.cc */,
-				OBJ_271 /* grpclb.cc */,
-				OBJ_272 /* grpclb_channel_secure.cc */,
-				OBJ_273 /* grpclb_client_stats.cc */,
-				OBJ_274 /* load_balancer_api.cc */,
-				OBJ_275 /* proto */,
-			);
-			path = grpclb;
-			sourceTree = "<group>";
-		};
-		OBJ_275 /* proto */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_276 /* grpc */,
-			);
-			path = proto;
-			sourceTree = "<group>";
-		};
-		OBJ_276 /* grpc */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_277 /* lb */,
-			);
-			path = grpc;
-			sourceTree = "<group>";
-		};
-		OBJ_277 /* lb */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_278 /* v1 */,
-			);
-			path = lb;
-			sourceTree = "<group>";
-		};
-		OBJ_278 /* v1 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_279 /* load_balancer.pb.c */,
-			);
-			path = v1;
-			sourceTree = "<group>";
-		};
-		OBJ_28 /* BloomboxServices */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_29 /* AuthService_Beta1.grpc.swift */,
-				OBJ_30 /* DevicesService_Beta1.grpc.swift */,
-				OBJ_31 /* IdentityService_Beta1.grpc.swift */,
-				OBJ_32 /* MediaService_Beta1.grpc.swift */,
-				OBJ_33 /* MenuService_Beta1.grpc.swift */,
-				OBJ_34 /* POSService_Beta1.grpc.swift */,
-				OBJ_35 /* PlatformService_v1.grpc.swift */,
-				OBJ_36 /* ShopService_v1.grpc.swift */,
-				OBJ_37 /* TelemetryService_Beta4.grpc.swift */,
-				OBJ_38 /* WalletService_v1.grpc.swift */,
-			);
-			name = BloomboxServices;
-			path = Sources/Services;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_280 /* pick_first */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_281 /* pick_first.cc */,
-			);
-			path = pick_first;
-			sourceTree = "<group>";
-		};
-		OBJ_282 /* round_robin */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_283 /* round_robin.cc */,
-			);
-			path = round_robin;
-			sourceTree = "<group>";
-		};
-		OBJ_291 /* resolver */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_292 /* dns */,
-				OBJ_300 /* fake */,
-				OBJ_302 /* sockaddr */,
-			);
-			path = resolver;
-			sourceTree = "<group>";
-		};
-		OBJ_292 /* dns */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_293 /* c_ares */,
-				OBJ_298 /* native */,
-			);
-			path = dns;
-			sourceTree = "<group>";
-		};
-		OBJ_293 /* c_ares */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_294 /* dns_resolver_ares.cc */,
-				OBJ_295 /* grpc_ares_ev_driver_posix.cc */,
-				OBJ_296 /* grpc_ares_wrapper.cc */,
-				OBJ_297 /* grpc_ares_wrapper_fallback.cc */,
-			);
-			path = c_ares;
-			sourceTree = "<group>";
-		};
-		OBJ_298 /* native */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_299 /* dns_resolver.cc */,
-			);
-			path = native;
-			sourceTree = "<group>";
-		};
-		OBJ_300 /* fake */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_301 /* fake_resolver.cc */,
-			);
-			path = fake;
-			sourceTree = "<group>";
-		};
-		OBJ_302 /* sockaddr */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_303 /* sockaddr_resolver.cc */,
-			);
-			path = sockaddr;
-			sourceTree = "<group>";
-		};
-		OBJ_309 /* deadline */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_310 /* deadline_filter.cc */,
-			);
-			path = deadline;
-			sourceTree = "<group>";
-		};
-		OBJ_311 /* http */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_312 /* client */,
-				OBJ_314 /* client_authority_filter.cc */,
-				OBJ_315 /* http_filters_plugin.cc */,
-				OBJ_316 /* message_compress */,
-				OBJ_318 /* server */,
-			);
-			path = http;
-			sourceTree = "<group>";
-		};
-		OBJ_312 /* client */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_313 /* http_client_filter.cc */,
-			);
-			path = client;
-			sourceTree = "<group>";
-		};
-		OBJ_316 /* message_compress */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_317 /* message_compress_filter.cc */,
-			);
-			path = message_compress;
-			sourceTree = "<group>";
-		};
-		OBJ_318 /* server */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_319 /* http_server_filter.cc */,
-			);
-			path = server;
-			sourceTree = "<group>";
-		};
-		OBJ_320 /* load_reporting */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_321 /* server_load_reporting_filter.cc */,
-				OBJ_322 /* server_load_reporting_plugin.cc */,
-			);
-			path = load_reporting;
-			sourceTree = "<group>";
-		};
-		OBJ_323 /* max_age */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_324 /* max_age_filter.cc */,
-			);
-			path = max_age;
-			sourceTree = "<group>";
-		};
-		OBJ_325 /* message_size */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_326 /* message_size_filter.cc */,
-			);
-			path = message_size;
-			sourceTree = "<group>";
-		};
-		OBJ_327 /* workarounds */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_328 /* workaround_cronet_compression_filter.cc */,
-				OBJ_329 /* workaround_utils.cc */,
-			);
-			path = workarounds;
-			sourceTree = "<group>";
-		};
-		OBJ_330 /* transport */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_331 /* chttp2 */,
-				OBJ_372 /* inproc */,
-			);
-			path = transport;
-			sourceTree = "<group>";
-		};
-		OBJ_331 /* chttp2 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_332 /* alpn */,
-				OBJ_334 /* client */,
-				OBJ_342 /* server */,
-				OBJ_349 /* transport */,
-			);
-			path = chttp2;
-			sourceTree = "<group>";
-		};
-		OBJ_332 /* alpn */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_333 /* alpn.cc */,
-			);
-			path = alpn;
-			sourceTree = "<group>";
-		};
-		OBJ_334 /* client */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_335 /* authority.cc */,
-				OBJ_336 /* chttp2_connector.cc */,
-				OBJ_337 /* insecure */,
-				OBJ_340 /* secure */,
-			);
-			path = client;
-			sourceTree = "<group>";
-		};
-		OBJ_337 /* insecure */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_338 /* channel_create.cc */,
-				OBJ_339 /* channel_create_posix.cc */,
-			);
-			path = insecure;
-			sourceTree = "<group>";
-		};
-		OBJ_340 /* secure */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_341 /* secure_channel_create.cc */,
-			);
-			path = secure;
-			sourceTree = "<group>";
-		};
-		OBJ_342 /* server */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_343 /* chttp2_server.cc */,
-				OBJ_344 /* insecure */,
-				OBJ_347 /* secure */,
-			);
-			path = server;
-			sourceTree = "<group>";
-		};
-		OBJ_344 /* insecure */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_345 /* server_chttp2.cc */,
-				OBJ_346 /* server_chttp2_posix.cc */,
-			);
-			path = insecure;
-			sourceTree = "<group>";
-		};
-		OBJ_347 /* secure */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_348 /* server_secure_chttp2.cc */,
-			);
-			path = secure;
-			sourceTree = "<group>";
-		};
-		OBJ_349 /* transport */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_350 /* bin_decoder.cc */,
-				OBJ_351 /* bin_encoder.cc */,
-				OBJ_352 /* chttp2_plugin.cc */,
-				OBJ_353 /* chttp2_transport.cc */,
-				OBJ_354 /* flow_control.cc */,
-				OBJ_355 /* frame_data.cc */,
-				OBJ_356 /* frame_goaway.cc */,
-				OBJ_357 /* frame_ping.cc */,
-				OBJ_358 /* frame_rst_stream.cc */,
-				OBJ_359 /* frame_settings.cc */,
-				OBJ_360 /* frame_window_update.cc */,
-				OBJ_361 /* hpack_encoder.cc */,
-				OBJ_362 /* hpack_parser.cc */,
-				OBJ_363 /* hpack_table.cc */,
-				OBJ_364 /* http2_settings.cc */,
-				OBJ_365 /* huffsyms.cc */,
-				OBJ_366 /* incoming_metadata.cc */,
-				OBJ_367 /* parsing.cc */,
-				OBJ_368 /* stream_lists.cc */,
-				OBJ_369 /* stream_map.cc */,
-				OBJ_370 /* varint.cc */,
-				OBJ_371 /* writing.cc */,
-			);
-			path = transport;
-			sourceTree = "<group>";
-		};
-		OBJ_372 /* inproc */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_373 /* inproc_plugin.cc */,
-				OBJ_374 /* inproc_transport.cc */,
-			);
-			path = inproc;
-			sourceTree = "<group>";
-		};
-		OBJ_375 /* lib */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_376 /* avl */,
-				OBJ_378 /* backoff */,
-				OBJ_380 /* channel */,
-				OBJ_391 /* compression */,
-				OBJ_398 /* debug */,
-				OBJ_402 /* gpr */,
-				OBJ_438 /* gprpp */,
-				OBJ_441 /* http */,
-				OBJ_446 /* iomgr */,
-				OBJ_530 /* json */,
-				OBJ_535 /* profiling */,
-				OBJ_538 /* security */,
-				OBJ_584 /* slice */,
-				OBJ_591 /* surface */,
-				OBJ_612 /* transport */,
-			);
-			path = lib;
-			sourceTree = "<group>";
-		};
-		OBJ_376 /* avl */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_377 /* avl.cc */,
-			);
-			path = avl;
-			sourceTree = "<group>";
-		};
-		OBJ_378 /* backoff */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_379 /* backoff.cc */,
-			);
-			path = backoff;
-			sourceTree = "<group>";
-		};
-		OBJ_380 /* channel */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_381 /* channel_args.cc */,
-				OBJ_382 /* channel_stack.cc */,
-				OBJ_383 /* channel_stack_builder.cc */,
-				OBJ_384 /* channel_trace.cc */,
-				OBJ_385 /* channel_trace_registry.cc */,
-				OBJ_386 /* connected_channel.cc */,
-				OBJ_387 /* handshaker.cc */,
-				OBJ_388 /* handshaker_factory.cc */,
-				OBJ_389 /* handshaker_registry.cc */,
-				OBJ_390 /* status_util.cc */,
-			);
-			path = channel;
-			sourceTree = "<group>";
-		};
-		OBJ_39 /* OpenCannabis */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_40 /* accounting_Taxes.pb.swift */,
-				OBJ_41 /* analytics_Context.pb.swift */,
-				OBJ_42 /* analytics_Scope.pb.swift */,
-				OBJ_43 /* analytics_commerce_OrderAnalytics.pb.swift */,
-				OBJ_44 /* analytics_commerce_ProductAnalytics.pb.swift */,
-				OBJ_45 /* analytics_commerce_SectionAnalytics.pb.swift */,
-				OBJ_46 /* analytics_commerce_ShopAnalytics.pb.swift */,
-				OBJ_47 /* analytics_consumption_Biodelivery.pb.swift */,
-				OBJ_48 /* analytics_context_Application.pb.swift */,
-				OBJ_49 /* analytics_context_Browser.pb.swift */,
-				OBJ_50 /* analytics_context_Collection.pb.swift */,
-				OBJ_51 /* analytics_context_Library.pb.swift */,
-				OBJ_52 /* analytics_context_NativeDevice.pb.swift */,
-				OBJ_53 /* analytics_context_OS.pb.swift */,
-				OBJ_54 /* analytics_generic_Event.pb.swift */,
-				OBJ_55 /* analytics_generic_Exception.pb.swift */,
-				OBJ_56 /* analytics_identity_UserAnalytics.pb.swift */,
-				OBJ_57 /* analytics_search_SearchProperty.pb.swift */,
-				OBJ_58 /* analytics_stats_OrderStats.pb.swift */,
-				OBJ_59 /* analytics_stats_SessionStats.pb.swift */,
-				OBJ_60 /* analytics_stream_Filter.pb.swift */,
-				OBJ_61 /* auth_v1beta1_AuthService_Beta1.pb.swift */,
-				OBJ_62 /* base_Compression.pb.swift */,
-				OBJ_63 /* base_Language.pb.swift */,
-				OBJ_64 /* base_ProductKey.pb.swift */,
-				OBJ_65 /* base_ProductKind.pb.swift */,
-				OBJ_67 /* commerce_Currency.pb.swift */,
-				OBJ_68 /* commerce_Customer.pb.swift */,
-				OBJ_69 /* commerce_Delivery.pb.swift */,
-				OBJ_70 /* commerce_Discounts.pb.swift */,
-				OBJ_71 /* commerce_Item.pb.swift */,
-				OBJ_72 /* commerce_Order.pb.swift */,
-				OBJ_73 /* commerce_Purchase.pb.swift */,
-				OBJ_74 /* commerce_payments_Payment.pb.swift */,
-				OBJ_75 /* comms_Comms.pb.swift */,
-				OBJ_76 /* comms_CommsTask.pb.swift */,
-				OBJ_77 /* comms_Email.pb.swift */,
-				OBJ_78 /* comms_SMS.pb.swift */,
-				OBJ_79 /* contact_ContactInfo.pb.swift */,
-				OBJ_80 /* contact_EmailAddress.pb.swift */,
-				OBJ_81 /* contact_PhoneNumber.pb.swift */,
-				OBJ_82 /* contact_Website.pb.swift */,
-				OBJ_83 /* content_Brand.pb.swift */,
-				OBJ_84 /* content_Colors.pb.swift */,
-				OBJ_85 /* content_Content.pb.swift */,
-				OBJ_86 /* content_MaterialsData.pb.swift */,
-				OBJ_87 /* content_Name.pb.swift */,
-				OBJ_88 /* content_ProductContent.pb.swift */,
-				OBJ_89 /* core_Datamodel.pb.swift */,
-				OBJ_90 /* crypto_Container.pb.swift */,
-				OBJ_91 /* crypto_Signature.pb.swift */,
-				OBJ_92 /* crypto_primitives_Integrity.pb.swift */,
-				OBJ_93 /* crypto_primitives_Keys.pb.swift */,
-				OBJ_95 /* device_Device.pb.swift */,
-				OBJ_96 /* devices_v1beta1_DevicesService_Beta1.pb.swift */,
-				OBJ_97 /* geo_Address.pb.swift */,
-				OBJ_98 /* geo_Country.pb.swift */,
-				OBJ_99 /* geo_Distance.pb.swift */,
-				OBJ_100 /* geo_Geohash.pb.swift */,
-				OBJ_101 /* geo_Location.pb.swift */,
-				OBJ_102 /* geo_Point.pb.swift */,
-				OBJ_103 /* geo_Province.pb.swift */,
-				OBJ_104 /* geo_USState.pb.swift */,
-				OBJ_105 /* geo_usa_ca_CACounty.pb.swift */,
-				OBJ_106 /* google_api_annotations.pb.swift */,
-				OBJ_107 /* google_api_http.pb.swift */,
-				OBJ_108 /* google_protobuf_descriptor.pb.swift */,
-				222EF14A21C7268D0008D96B /* identity_bioprint_Affinities.pb.swift */,
-				222EF14821C7268C0008D96B /* identity_bioprint_Aspects.pb.swift */,
-				222EF14B21C7268D0008D96B /* identity_bioprint_Bioprint.pb.swift */,
-				222EF14921C7268C0008D96B /* identity_bioprint_Weights.pb.swift */,
-				OBJ_109 /* identity_ID.pb.swift */,
-				OBJ_110 /* identity_IDMedia.pb.swift */,
-				OBJ_111 /* identity_Membership.pb.swift */,
-				OBJ_112 /* identity_MembershipKey.pb.swift */,
-				OBJ_113 /* identity_StaffUser.pb.swift */,
-				OBJ_114 /* identity_User.pb.swift */,
-				OBJ_115 /* identity_UserKey.pb.swift */,
-				OBJ_120 /* identity_ids_Passport.pb.swift */,
-				OBJ_121 /* identity_ids_USDL.pb.swift */,
-				OBJ_122 /* identity_ids_UserDoctorRec.pb.swift */,
-				OBJ_123 /* identity_industry_DashboardStaffSettings.pb.swift */,
-				OBJ_124 /* identity_industry_POSStaffSettings.pb.swift */,
-				OBJ_125 /* identity_industry_StaffSettings.pb.swift */,
-				OBJ_126 /* identity_pass_Pass.pb.swift */,
-				OBJ_127 /* identity_pass_PassKey.pb.swift */,
-				OBJ_128 /* identity_v1beta1_IdentityService_Beta1.pb.swift */,
-				OBJ_129 /* inventory_InventoryLocation.pb.swift */,
-				OBJ_130 /* inventory_InventoryProduct.pb.swift */,
-				OBJ_131 /* ledger_Account.pb.swift */,
-				OBJ_132 /* ledger_Asset.pb.swift */,
-				OBJ_133 /* ledger_Transaction.pb.swift */,
-				OBJ_135 /* licensing_Licensure.pb.swift */,
-				OBJ_136 /* marketing_Campaign.pb.swift */,
-				OBJ_137 /* marketing_Targeting.pb.swift */,
-				OBJ_139 /* media_MediaItem.pb.swift */,
-				OBJ_140 /* media_MediaKey.pb.swift */,
-				OBJ_141 /* media_MediaOrientation.pb.swift */,
-				OBJ_142 /* media_MediaType.pb.swift */,
-				OBJ_143 /* media_v1beta1_MediaService_Beta1.pb.swift */,
-				OBJ_144 /* media_v1beta1_MediaTask.pb.swift */,
-				OBJ_145 /* menu_v1beta1_MenuService_Beta1.pb.swift */,
-				OBJ_146 /* oauth_AuthorizationScope.pb.swift */,
-				OBJ_147 /* oauth_Client.pb.swift */,
-				OBJ_148 /* partner_LocationKey.pb.swift */,
-				OBJ_149 /* partner_Partner.pb.swift */,
-				OBJ_150 /* partner_PartnerDevice.pb.swift */,
-				OBJ_151 /* partner_PartnerFlags.pb.swift */,
-				OBJ_152 /* partner_PartnerKey.pb.swift */,
-				OBJ_153 /* partner_PartnerLocation.pb.swift */,
-				OBJ_154 /* partner_PartnerScope.pb.swift */,
-				OBJ_155 /* partner_integrations_GSuiteSettings.pb.swift */,
-				OBJ_156 /* partner_integrations_GreenbitsSettings.pb.swift */,
-				OBJ_157 /* partner_integrations_IntegrationSettings.pb.swift */,
-				OBJ_158 /* partner_integrations_MailchimpSettings.pb.swift */,
-				OBJ_159 /* partner_integrations_OnFleetSettings.pb.swift */,
-				OBJ_160 /* partner_integrations_SendgridSettings.pb.swift */,
-				OBJ_161 /* partner_integrations_TreezSettings.pb.swift */,
-				OBJ_162 /* partner_integrations_TwilioSettings.pb.swift */,
-				OBJ_163 /* partner_settings_PartnerLocationSettings.pb.swift */,
-				OBJ_164 /* partner_settings_PartnerSettings.pb.swift */,
-				OBJ_166 /* person_Person.pb.swift */,
-				OBJ_167 /* person_PersonName.pb.swift */,
-				OBJ_168 /* platform_v1_PlatformService_v1.pb.swift */,
-				OBJ_169 /* pos_PointOfSale.pb.swift */,
-				OBJ_170 /* pos_v1beta1_POSService_Beta1.pb.swift */,
-				OBJ_171 /* products_Apothecary.pb.swift */,
-				OBJ_172 /* products_Cartridge.pb.swift */,
-				OBJ_173 /* products_Edible.pb.swift */,
-				OBJ_174 /* products_Extract.pb.swift */,
-				OBJ_175 /* products_Flower.pb.swift */,
-				OBJ_176 /* products_Merchandise.pb.swift */,
-				OBJ_177 /* products_Plant.pb.swift */,
-				OBJ_178 /* products_Preroll.pb.swift */,
-				OBJ_179 /* products_distribution_DistributionChannel.pb.swift */,
-				OBJ_180 /* products_menu_Menu.pb.swift */,
-				OBJ_181 /* products_menu_Section.pb.swift */,
-				OBJ_182 /* protoc-gen-swagger_options_openapiv2.pb.swift */,
-				OBJ_183 /* protoc-gen-swagger_options_swagger.pb.swift */,
-				OBJ_184 /* proximity_BluetoothBeacon.pb.swift */,
-				OBJ_185 /* regulatory_usa_ca_CAAgency.pb.swift */,
-				OBJ_186 /* search_SearchResult.pb.swift */,
-				OBJ_187 /* search_SearchSpec.pb.swift */,
-				OBJ_188 /* security_DeviceTicket.pb.swift */,
-				OBJ_189 /* security_IdentityToken.pb.swift */,
-				OBJ_190 /* security_Token.pb.swift */,
-				OBJ_191 /* security_access_PartnerPermissions.pb.swift */,
-				OBJ_192 /* services_ServiceStatus.pb.swift */,
-				OBJ_193 /* shop_v1_ShopService_v1.pb.swift */,
-				OBJ_194 /* structs_Genetics.pb.swift */,
-				OBJ_195 /* structs_Grow.pb.swift */,
-				OBJ_196 /* structs_ProductFlags.pb.swift */,
-				OBJ_197 /* structs_Shelf.pb.swift */,
-				OBJ_198 /* structs_Species.pb.swift */,
-				OBJ_199 /* structs_Version.pb.swift */,
-				OBJ_200 /* structs_labtesting_TestResults.pb.swift */,
-				OBJ_201 /* structs_labtesting_TestValue.pb.swift */,
-				OBJ_202 /* structs_pricing_PricingDescriptor.pb.swift */,
-				OBJ_203 /* structs_pricing_SaleDescriptor.pb.swift */,
-				OBJ_204 /* telemetry_v1beta4_GenericEvents_Beta4.pb.swift */,
-				OBJ_205 /* telemetry_v1beta4_TelemetryEvent_Beta4.pb.swift */,
-				OBJ_206 /* telemetry_v1beta4_TelemetryService_Beta4.pb.swift */,
-				OBJ_207 /* temporal_Date.pb.swift */,
-				OBJ_208 /* temporal_Duration.pb.swift */,
-				OBJ_209 /* temporal_Instant.pb.swift */,
-				OBJ_210 /* temporal_Interval.pb.swift */,
-				OBJ_211 /* temporal_Schedule.pb.swift */,
-				OBJ_212 /* temporal_Time.pb.swift */,
-				OBJ_213 /* temporal_Timehash.pb.swift */,
-				OBJ_214 /* wallet_v1_WalletService_v1.pb.swift */,
-			);
-			name = OpenCannabis;
-			path = Sources/Schema;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_391 /* compression */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_392 /* compression.cc */,
-				OBJ_393 /* compression_internal.cc */,
-				OBJ_394 /* message_compress.cc */,
-				OBJ_395 /* stream_compression.cc */,
-				OBJ_396 /* stream_compression_gzip.cc */,
-				OBJ_397 /* stream_compression_identity.cc */,
-			);
-			path = compression;
-			sourceTree = "<group>";
-		};
-		OBJ_398 /* debug */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_399 /* stats.cc */,
-				OBJ_400 /* stats_data.cc */,
-				OBJ_401 /* trace.cc */,
-			);
-			path = debug;
-			sourceTree = "<group>";
-		};
-		OBJ_402 /* gpr */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_403 /* alloc.cc */,
-				OBJ_404 /* arena.cc */,
-				OBJ_405 /* atm.cc */,
-				OBJ_406 /* cpu_iphone.cc */,
-				OBJ_407 /* cpu_linux.cc */,
-				OBJ_408 /* cpu_posix.cc */,
-				OBJ_409 /* cpu_windows.cc */,
-				OBJ_410 /* env_linux.cc */,
-				OBJ_411 /* env_posix.cc */,
-				OBJ_412 /* env_windows.cc */,
-				OBJ_413 /* fork.cc */,
-				OBJ_414 /* host_port.cc */,
-				OBJ_415 /* log.cc */,
-				OBJ_416 /* log_android.cc */,
-				OBJ_417 /* log_linux.cc */,
-				OBJ_418 /* log_posix.cc */,
-				OBJ_419 /* log_windows.cc */,
-				OBJ_420 /* mpscq.cc */,
-				OBJ_421 /* murmur_hash.cc */,
-				OBJ_422 /* string.cc */,
-				OBJ_423 /* string_posix.cc */,
-				OBJ_424 /* string_util_windows.cc */,
-				OBJ_425 /* string_windows.cc */,
-				OBJ_426 /* sync.cc */,
-				OBJ_427 /* sync_posix.cc */,
-				OBJ_428 /* sync_windows.cc */,
-				OBJ_429 /* time.cc */,
-				OBJ_430 /* time_posix.cc */,
-				OBJ_431 /* time_precise.cc */,
-				OBJ_432 /* time_windows.cc */,
-				OBJ_433 /* tls_pthread.cc */,
-				OBJ_434 /* tmpfile_msys.cc */,
-				OBJ_435 /* tmpfile_posix.cc */,
-				OBJ_436 /* tmpfile_windows.cc */,
-				OBJ_437 /* wrap_memcpy.cc */,
-			);
-			path = gpr;
-			sourceTree = "<group>";
-		};
-		OBJ_438 /* gprpp */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_439 /* thd_posix.cc */,
-				OBJ_440 /* thd_windows.cc */,
-			);
-			path = gprpp;
-			sourceTree = "<group>";
-		};
-		OBJ_441 /* http */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_442 /* format_request.cc */,
-				OBJ_443 /* httpcli.cc */,
-				OBJ_444 /* httpcli_security_connector.cc */,
-				OBJ_445 /* parser.cc */,
-			);
-			path = http;
-			sourceTree = "<group>";
-		};
-		OBJ_446 /* iomgr */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_447 /* call_combiner.cc */,
-				OBJ_448 /* combiner.cc */,
-				OBJ_449 /* endpoint.cc */,
-				OBJ_450 /* endpoint_pair_posix.cc */,
-				OBJ_451 /* endpoint_pair_uv.cc */,
-				OBJ_452 /* endpoint_pair_windows.cc */,
-				OBJ_453 /* error.cc */,
-				OBJ_454 /* ev_epoll1_linux.cc */,
-				OBJ_455 /* ev_epollex_linux.cc */,
-				OBJ_456 /* ev_epollsig_linux.cc */,
-				OBJ_457 /* ev_poll_posix.cc */,
-				OBJ_458 /* ev_posix.cc */,
-				OBJ_459 /* ev_windows.cc */,
-				OBJ_460 /* exec_ctx.cc */,
-				OBJ_461 /* executor.cc */,
-				OBJ_462 /* fork_posix.cc */,
-				OBJ_463 /* fork_windows.cc */,
-				OBJ_464 /* gethostname_fallback.cc */,
-				OBJ_465 /* gethostname_host_name_max.cc */,
-				OBJ_466 /* gethostname_sysconf.cc */,
-				OBJ_467 /* iocp_windows.cc */,
-				OBJ_468 /* iomgr.cc */,
-				OBJ_469 /* iomgr_custom.cc */,
-				OBJ_470 /* iomgr_internal.cc */,
-				OBJ_471 /* iomgr_posix.cc */,
-				OBJ_472 /* iomgr_uv.cc */,
-				OBJ_473 /* iomgr_windows.cc */,
-				OBJ_474 /* is_epollexclusive_available.cc */,
-				OBJ_475 /* load_file.cc */,
-				OBJ_476 /* lockfree_event.cc */,
-				OBJ_477 /* network_status_tracker.cc */,
-				OBJ_478 /* polling_entity.cc */,
-				OBJ_479 /* pollset.cc */,
-				OBJ_480 /* pollset_custom.cc */,
-				OBJ_481 /* pollset_set.cc */,
-				OBJ_482 /* pollset_set_custom.cc */,
-				OBJ_483 /* pollset_set_windows.cc */,
-				OBJ_484 /* pollset_uv.cc */,
-				OBJ_485 /* pollset_windows.cc */,
-				OBJ_486 /* resolve_address.cc */,
-				OBJ_487 /* resolve_address_custom.cc */,
-				OBJ_488 /* resolve_address_posix.cc */,
-				OBJ_489 /* resolve_address_windows.cc */,
-				OBJ_490 /* resource_quota.cc */,
-				OBJ_491 /* sockaddr_utils.cc */,
-				OBJ_492 /* socket_factory_posix.cc */,
-				OBJ_493 /* socket_mutator.cc */,
-				OBJ_494 /* socket_utils_common_posix.cc */,
-				OBJ_495 /* socket_utils_linux.cc */,
-				OBJ_496 /* socket_utils_posix.cc */,
-				OBJ_497 /* socket_utils_uv.cc */,
-				OBJ_498 /* socket_utils_windows.cc */,
-				OBJ_499 /* socket_windows.cc */,
-				OBJ_500 /* tcp_client.cc */,
-				OBJ_501 /* tcp_client_custom.cc */,
-				OBJ_502 /* tcp_client_posix.cc */,
-				OBJ_503 /* tcp_client_windows.cc */,
-				OBJ_504 /* tcp_custom.cc */,
-				OBJ_505 /* tcp_posix.cc */,
-				OBJ_506 /* tcp_server.cc */,
-				OBJ_507 /* tcp_server_custom.cc */,
-				OBJ_508 /* tcp_server_posix.cc */,
-				OBJ_509 /* tcp_server_utils_posix_common.cc */,
-				OBJ_510 /* tcp_server_utils_posix_ifaddrs.cc */,
-				OBJ_511 /* tcp_server_utils_posix_noifaddrs.cc */,
-				OBJ_512 /* tcp_server_windows.cc */,
-				OBJ_513 /* tcp_uv.cc */,
-				OBJ_514 /* tcp_windows.cc */,
-				OBJ_515 /* time_averaged_stats.cc */,
-				OBJ_516 /* timer.cc */,
-				OBJ_517 /* timer_custom.cc */,
-				OBJ_518 /* timer_generic.cc */,
-				OBJ_519 /* timer_heap.cc */,
-				OBJ_520 /* timer_manager.cc */,
-				OBJ_521 /* timer_uv.cc */,
-				OBJ_522 /* udp_server.cc */,
-				OBJ_523 /* unix_sockets_posix.cc */,
-				OBJ_524 /* unix_sockets_posix_noop.cc */,
-				OBJ_525 /* wakeup_fd_cv.cc */,
-				OBJ_526 /* wakeup_fd_eventfd.cc */,
-				OBJ_527 /* wakeup_fd_nospecial.cc */,
-				OBJ_528 /* wakeup_fd_pipe.cc */,
-				OBJ_529 /* wakeup_fd_posix.cc */,
-			);
-			path = iomgr;
-			sourceTree = "<group>";
-		};
-		OBJ_5 /*  */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_6 /* Package.swift */,
-				OBJ_7 /* Sources */,
-				OBJ_215 /* Tests */,
-				OBJ_228 /* Example */,
-				OBJ_229 /* docs */,
-				OBJ_230 /* Schema */,
-				OBJ_231 /* fastlane */,
-				OBJ_232 /* SwiftGRPC */,
-				OBJ_233 /* Dependencies */,
-				OBJ_1297 /* Products */,
-			);
-			name = "";
-			sourceTree = "<group>";
-		};
-		OBJ_530 /* json */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_531 /* json.cc */,
-				OBJ_532 /* json_reader.cc */,
-				OBJ_533 /* json_string.cc */,
-				OBJ_534 /* json_writer.cc */,
-			);
-			path = json;
-			sourceTree = "<group>";
-		};
-		OBJ_535 /* profiling */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_536 /* basic_timers.cc */,
-				OBJ_537 /* stap_timers.cc */,
-			);
-			path = profiling;
-			sourceTree = "<group>";
-		};
-		OBJ_538 /* security */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_539 /* context */,
-				OBJ_541 /* credentials */,
-				OBJ_572 /* security_connector */,
-				OBJ_575 /* transport */,
-				OBJ_582 /* util */,
-			);
-			path = security;
-			sourceTree = "<group>";
-		};
-		OBJ_539 /* context */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_540 /* security_context.cc */,
-			);
-			path = context;
-			sourceTree = "<group>";
-		};
-		OBJ_541 /* credentials */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_542 /* alts */,
-				OBJ_551 /* composite */,
-				OBJ_553 /* credentials.cc */,
-				OBJ_554 /* credentials_metadata.cc */,
-				OBJ_555 /* fake */,
-				OBJ_557 /* google_default */,
-				OBJ_560 /* iam */,
-				OBJ_562 /* jwt */,
-				OBJ_566 /* oauth2 */,
-				OBJ_568 /* plugin */,
-				OBJ_570 /* ssl */,
-			);
-			path = credentials;
-			sourceTree = "<group>";
-		};
-		OBJ_542 /* alts */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_543 /* alts_credentials.cc */,
-				OBJ_544 /* check_gcp_environment.cc */,
-				OBJ_545 /* check_gcp_environment_linux.cc */,
-				OBJ_546 /* check_gcp_environment_no_op.cc */,
-				OBJ_547 /* check_gcp_environment_windows.cc */,
-				OBJ_548 /* grpc_alts_credentials_client_options.cc */,
-				OBJ_549 /* grpc_alts_credentials_options.cc */,
-				OBJ_550 /* grpc_alts_credentials_server_options.cc */,
-			);
-			path = alts;
-			sourceTree = "<group>";
-		};
-		OBJ_551 /* composite */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_552 /* composite_credentials.cc */,
-			);
-			path = composite;
-			sourceTree = "<group>";
-		};
-		OBJ_555 /* fake */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_556 /* fake_credentials.cc */,
-			);
-			path = fake;
-			sourceTree = "<group>";
-		};
-		OBJ_557 /* google_default */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_558 /* credentials_generic.cc */,
-				OBJ_559 /* google_default_credentials.cc */,
-			);
-			path = google_default;
-			sourceTree = "<group>";
-		};
-		OBJ_560 /* iam */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_561 /* iam_credentials.cc */,
-			);
-			path = iam;
-			sourceTree = "<group>";
-		};
-		OBJ_562 /* jwt */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_563 /* json_token.cc */,
-				OBJ_564 /* jwt_credentials.cc */,
-				OBJ_565 /* jwt_verifier.cc */,
-			);
-			path = jwt;
-			sourceTree = "<group>";
-		};
-		OBJ_566 /* oauth2 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_567 /* oauth2_credentials.cc */,
-			);
-			path = oauth2;
-			sourceTree = "<group>";
-		};
-		OBJ_568 /* plugin */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_569 /* plugin_credentials.cc */,
-			);
-			path = plugin;
-			sourceTree = "<group>";
-		};
-		OBJ_570 /* ssl */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_571 /* ssl_credentials.cc */,
-			);
-			path = ssl;
-			sourceTree = "<group>";
-		};
-		OBJ_572 /* security_connector */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_573 /* alts_security_connector.cc */,
-				OBJ_574 /* security_connector.cc */,
-			);
-			path = security_connector;
-			sourceTree = "<group>";
-		};
-		OBJ_575 /* transport */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_576 /* client_auth_filter.cc */,
-				OBJ_577 /* secure_endpoint.cc */,
-				OBJ_578 /* security_handshaker.cc */,
-				OBJ_579 /* server_auth_filter.cc */,
-				OBJ_580 /* target_authority_table.cc */,
-				OBJ_581 /* tsi_error.cc */,
-			);
-			path = transport;
-			sourceTree = "<group>";
-		};
-		OBJ_582 /* util */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_583 /* json_util.cc */,
-			);
-			path = util;
-			sourceTree = "<group>";
-		};
-		OBJ_584 /* slice */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_585 /* b64.cc */,
-				OBJ_586 /* percent_encoding.cc */,
-				OBJ_587 /* slice.cc */,
-				OBJ_588 /* slice_buffer.cc */,
-				OBJ_589 /* slice_intern.cc */,
-				OBJ_590 /* slice_string_helpers.cc */,
-			);
-			path = slice;
-			sourceTree = "<group>";
-		};
-		OBJ_591 /* surface */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_592 /* api_trace.cc */,
-				OBJ_593 /* byte_buffer.cc */,
-				OBJ_594 /* byte_buffer_reader.cc */,
-				OBJ_595 /* call.cc */,
-				OBJ_596 /* call_details.cc */,
-				OBJ_597 /* call_log_batch.cc */,
-				OBJ_598 /* channel.cc */,
-				OBJ_599 /* channel_init.cc */,
-				OBJ_600 /* channel_ping.cc */,
-				OBJ_601 /* channel_stack_type.cc */,
-				OBJ_602 /* completion_queue.cc */,
-				OBJ_603 /* completion_queue_factory.cc */,
-				OBJ_604 /* event_string.cc */,
-				OBJ_605 /* init.cc */,
-				OBJ_606 /* init_secure.cc */,
-				OBJ_607 /* lame_client.cc */,
-				OBJ_608 /* metadata_array.cc */,
-				OBJ_609 /* server.cc */,
-				OBJ_610 /* validate_metadata.cc */,
-				OBJ_611 /* version.cc */,
-			);
-			path = surface;
-			sourceTree = "<group>";
-		};
-		OBJ_612 /* transport */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_613 /* bdp_estimator.cc */,
-				OBJ_614 /* byte_stream.cc */,
-				OBJ_615 /* connectivity_state.cc */,
-				OBJ_616 /* error_utils.cc */,
-				OBJ_617 /* metadata.cc */,
-				OBJ_618 /* metadata_batch.cc */,
-				OBJ_619 /* pid_controller.cc */,
-				OBJ_620 /* service_config.cc */,
-				OBJ_621 /* static_metadata.cc */,
-				OBJ_622 /* status_conversion.cc */,
-				OBJ_623 /* status_metadata.cc */,
-				OBJ_624 /* timeout_encoding.cc */,
-				OBJ_625 /* transport.cc */,
-				OBJ_626 /* transport_op_string.cc */,
-			);
-			path = transport;
-			sourceTree = "<group>";
-		};
-		OBJ_627 /* plugin_registry */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_628 /* grpc_plugin_registry.cc */,
-			);
-			path = plugin_registry;
-			sourceTree = "<group>";
-		};
-		OBJ_629 /* tsi */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_630 /* alts */,
-				OBJ_659 /* alts_transport_security.cc */,
-				OBJ_660 /* fake_transport_security.cc */,
-				OBJ_661 /* ssl */,
-				OBJ_666 /* ssl_transport_security.cc */,
-				OBJ_667 /* transport_security.cc */,
-				OBJ_668 /* transport_security_adapter.cc */,
-				OBJ_669 /* transport_security_grpc.cc */,
-			);
-			path = tsi;
-			sourceTree = "<group>";
-		};
-		OBJ_630 /* alts */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_631 /* crypt */,
-				OBJ_634 /* frame_protector */,
-				OBJ_642 /* handshaker */,
-				OBJ_653 /* zero_copy_frame_protector */,
-			);
-			path = alts;
-			sourceTree = "<group>";
-		};
-		OBJ_631 /* crypt */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_632 /* aes_gcm.cc */,
-				OBJ_633 /* gsec.cc */,
-			);
-			path = crypt;
-			sourceTree = "<group>";
-		};
-		OBJ_634 /* frame_protector */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_635 /* alts_counter.cc */,
-				OBJ_636 /* alts_crypter.cc */,
-				OBJ_637 /* alts_frame_protector.cc */,
-				OBJ_638 /* alts_record_protocol_crypter_common.cc */,
-				OBJ_639 /* alts_seal_privacy_integrity_crypter.cc */,
-				OBJ_640 /* alts_unseal_privacy_integrity_crypter.cc */,
-				OBJ_641 /* frame_handler.cc */,
-			);
-			path = frame_protector;
-			sourceTree = "<group>";
-		};
-		OBJ_642 /* handshaker */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_643 /* alts_handshaker_client.cc */,
-				OBJ_644 /* alts_handshaker_service_api.cc */,
-				OBJ_645 /* alts_handshaker_service_api_util.cc */,
-				OBJ_646 /* alts_tsi_event.cc */,
-				OBJ_647 /* alts_tsi_handshaker.cc */,
-				OBJ_648 /* alts_tsi_utils.cc */,
-				OBJ_649 /* altscontext.pb.c */,
-				OBJ_650 /* handshaker.pb.c */,
-				OBJ_651 /* transport_security_common.pb.c */,
-				OBJ_652 /* transport_security_common_api.cc */,
-			);
-			path = handshaker;
-			sourceTree = "<group>";
-		};
-		OBJ_653 /* zero_copy_frame_protector */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_654 /* alts_grpc_integrity_only_record_protocol.cc */,
-				OBJ_655 /* alts_grpc_privacy_integrity_record_protocol.cc */,
-				OBJ_656 /* alts_grpc_record_protocol_common.cc */,
-				OBJ_657 /* alts_iovec_record_protocol.cc */,
-				OBJ_658 /* alts_zero_copy_grpc_protector.cc */,
-			);
-			path = zero_copy_frame_protector;
-			sourceTree = "<group>";
-		};
-		OBJ_661 /* ssl */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_662 /* session_cache */,
-			);
-			path = ssl;
-			sourceTree = "<group>";
-		};
-		OBJ_662 /* session_cache */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_663 /* ssl_session_boringssl.cc */,
-				OBJ_664 /* ssl_session_cache.cc */,
-				OBJ_665 /* ssl_session_openssl.cc */,
-			);
-			path = session_cache;
-			sourceTree = "<group>";
-		};
-		OBJ_670 /* third_party */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_671 /* nanopb */,
-			);
-			path = third_party;
-			sourceTree = "<group>";
-		};
-		OBJ_671 /* nanopb */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_672 /* pb_common.c */,
-				OBJ_673 /* pb_decode.c */,
-				OBJ_674 /* pb_encode.c */,
-			);
-			path = nanopb;
-			sourceTree = "<group>";
-		};
-		OBJ_675 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_676 /* cgrpc.h */,
-				OBJ_677 /* grpc */,
-				OBJ_733 /* module.modulemap */,
-			);
-			path = include;
-			sourceTree = "<group>";
-		};
-		OBJ_677 /* grpc */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_678 /* grpc.h */,
-				OBJ_679 /* status.h */,
-				OBJ_680 /* census.h */,
-				OBJ_681 /* slice.h */,
-				OBJ_682 /* compression.h */,
-				OBJ_683 /* fork.h */,
-				OBJ_684 /* byte_buffer_reader.h */,
-				OBJ_685 /* grpc_security_constants.h */,
-				OBJ_686 /* byte_buffer.h */,
-				OBJ_687 /* slice_buffer.h */,
-				OBJ_688 /* grpc_posix.h */,
-				OBJ_689 /* grpc_security.h */,
-				OBJ_690 /* load_reporting.h */,
-				OBJ_691 /* support */,
-				OBJ_710 /* impl */,
-			);
-			path = grpc;
-			sourceTree = "<group>";
-		};
-		OBJ_691 /* support */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_692 /* time.h */,
-				OBJ_693 /* port_platform.h */,
-				OBJ_694 /* log_windows.h */,
-				OBJ_695 /* sync.h */,
-				OBJ_696 /* string_util.h */,
-				OBJ_697 /* sync_custom.h */,
-				OBJ_698 /* thd_id.h */,
-				OBJ_699 /* workaround_list.h */,
-				OBJ_700 /* atm_gcc_sync.h */,
-				OBJ_701 /* atm_gcc_atomic.h */,
-				OBJ_702 /* atm.h */,
-				OBJ_703 /* sync_generic.h */,
-				OBJ_704 /* log.h */,
-				OBJ_705 /* cpu.h */,
-				OBJ_706 /* sync_posix.h */,
-				OBJ_707 /* atm_windows.h */,
-				OBJ_708 /* sync_windows.h */,
-				OBJ_709 /* alloc.h */,
-			);
-			path = support;
-			sourceTree = "<group>";
-		};
-		OBJ_7 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_8 /* Bloombox */,
-				OBJ_28 /* BloomboxServices */,
-				OBJ_39 /* OpenCannabis */,
-			);
-			name = Sources;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_710 /* impl */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_711 /* codegen */,
-			);
-			path = impl;
-			sourceTree = "<group>";
-		};
-		OBJ_711 /* codegen */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_712 /* port_platform.h */,
-				OBJ_713 /* status.h */,
-				OBJ_714 /* gpr_types.h */,
-				OBJ_715 /* sync.h */,
-				OBJ_716 /* grpc_types.h */,
-				OBJ_717 /* sync_custom.h */,
-				OBJ_718 /* gpr_slice.h */,
-				OBJ_719 /* slice.h */,
-				OBJ_720 /* compression_types.h */,
-				OBJ_721 /* atm_gcc_sync.h */,
-				OBJ_722 /* atm_gcc_atomic.h */,
-				OBJ_723 /* atm.h */,
-				OBJ_724 /* sync_generic.h */,
-				OBJ_725 /* fork.h */,
-				OBJ_726 /* byte_buffer_reader.h */,
-				OBJ_727 /* sync_posix.h */,
-				OBJ_728 /* atm_windows.h */,
-				OBJ_729 /* propagation_bits.h */,
-				OBJ_730 /* byte_buffer.h */,
-				OBJ_731 /* connectivity_state.h */,
-				OBJ_732 /* sync_windows.h */,
-			);
-			path = codegen;
-			sourceTree = "<group>";
-		};
-		OBJ_734 /* RootsEncoder */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = RootsEncoder;
-			path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/RootsEncoder";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_735 /* BoringSSL */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_736 /* crypto */,
-				OBJ_1062 /* err_data.c */,
-				OBJ_1063 /* ssl */,
-				OBJ_1100 /* third_party */,
-				OBJ_1103 /* include */,
-			);
-			name = BoringSSL;
-			path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL";
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_736 /* crypto */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_737 /* asn1 */,
-				OBJ_768 /* base64 */,
-				OBJ_770 /* bio */,
-				OBJ_781 /* bn_extra */,
-				OBJ_784 /* buf */,
-				OBJ_786 /* bytestring */,
-				OBJ_791 /* chacha */,
-				OBJ_793 /* cipher_extra */,
-				OBJ_805 /* cmac */,
-				OBJ_807 /* conf */,
-				OBJ_809 /* cpu-aarch64-linux.c */,
-				OBJ_810 /* cpu-arm-linux.c */,
-				OBJ_811 /* cpu-arm.c */,
-				OBJ_812 /* cpu-intel.c */,
-				OBJ_813 /* cpu-ppc64le.c */,
-				OBJ_814 /* crypto.c */,
-				OBJ_815 /* curve25519 */,
-				OBJ_818 /* dh */,
-				OBJ_823 /* digest_extra */,
-				OBJ_825 /* dsa */,
-				OBJ_828 /* ec_extra */,
-				OBJ_830 /* ecdh */,
-				OBJ_832 /* ecdsa_extra */,
-				OBJ_834 /* engine */,
-				OBJ_836 /* err */,
-				OBJ_839 /* evp */,
-				OBJ_855 /* ex_data.c */,
-				OBJ_856 /* fipsmodule */,
-				OBJ_931 /* hkdf */,
-				OBJ_933 /* lhash */,
-				OBJ_935 /* mem.c */,
-				OBJ_936 /* obj */,
-				OBJ_939 /* pem */,
-				OBJ_948 /* pkcs7 */,
-				OBJ_951 /* pkcs8 */,
-				OBJ_955 /* poly1305 */,
-				OBJ_959 /* pool */,
-				OBJ_961 /* rand_extra */,
-				OBJ_967 /* rc4 */,
-				OBJ_969 /* refcount_c11.c */,
-				OBJ_970 /* refcount_lock.c */,
-				OBJ_971 /* rsa_extra */,
-				OBJ_973 /* stack */,
-				OBJ_975 /* thread.c */,
-				OBJ_976 /* thread_none.c */,
-				OBJ_977 /* thread_pthread.c */,
-				OBJ_978 /* thread_win.c */,
-				OBJ_979 /* x509 */,
-				OBJ_1029 /* x509v3 */,
-			);
-			path = crypto;
-			sourceTree = "<group>";
-		};
-		OBJ_737 /* asn1 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_738 /* a_bitstr.c */,
-				OBJ_739 /* a_bool.c */,
-				OBJ_740 /* a_d2i_fp.c */,
-				OBJ_741 /* a_dup.c */,
-				OBJ_742 /* a_enum.c */,
-				OBJ_743 /* a_gentm.c */,
-				OBJ_744 /* a_i2d_fp.c */,
-				OBJ_745 /* a_int.c */,
-				OBJ_746 /* a_mbstr.c */,
-				OBJ_747 /* a_object.c */,
-				OBJ_748 /* a_octet.c */,
-				OBJ_749 /* a_print.c */,
-				OBJ_750 /* a_strnid.c */,
-				OBJ_751 /* a_time.c */,
-				OBJ_752 /* a_type.c */,
-				OBJ_753 /* a_utctm.c */,
-				OBJ_754 /* a_utf8.c */,
-				OBJ_755 /* asn1_lib.c */,
-				OBJ_756 /* asn1_par.c */,
-				OBJ_757 /* asn_pack.c */,
-				OBJ_758 /* f_enum.c */,
-				OBJ_759 /* f_int.c */,
-				OBJ_760 /* f_string.c */,
-				OBJ_761 /* tasn_dec.c */,
-				OBJ_762 /* tasn_enc.c */,
-				OBJ_763 /* tasn_fre.c */,
-				OBJ_764 /* tasn_new.c */,
-				OBJ_765 /* tasn_typ.c */,
-				OBJ_766 /* tasn_utl.c */,
-				OBJ_767 /* time_support.c */,
-			);
-			path = asn1;
-			sourceTree = "<group>";
-		};
-		OBJ_768 /* base64 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_769 /* base64.c */,
-			);
-			path = base64;
-			sourceTree = "<group>";
-		};
-		OBJ_770 /* bio */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_771 /* bio.c */,
-				OBJ_772 /* bio_mem.c */,
-				OBJ_773 /* connect.c */,
-				OBJ_774 /* fd.c */,
-				OBJ_775 /* file.c */,
-				OBJ_776 /* hexdump.c */,
-				OBJ_777 /* pair.c */,
-				OBJ_778 /* printf.c */,
-				OBJ_779 /* socket.c */,
-				OBJ_780 /* socket_helper.c */,
-			);
-			path = bio;
-			sourceTree = "<group>";
-		};
-		OBJ_781 /* bn_extra */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_782 /* bn_asn1.c */,
-				OBJ_783 /* convert.c */,
-			);
-			path = bn_extra;
-			sourceTree = "<group>";
-		};
-		OBJ_784 /* buf */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_785 /* buf.c */,
-			);
-			path = buf;
-			sourceTree = "<group>";
-		};
-		OBJ_786 /* bytestring */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_787 /* asn1_compat.c */,
-				OBJ_788 /* ber.c */,
-				OBJ_789 /* cbb.c */,
-				OBJ_790 /* cbs.c */,
-			);
-			path = bytestring;
-			sourceTree = "<group>";
-		};
-		OBJ_791 /* chacha */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_792 /* chacha.c */,
-			);
-			path = chacha;
-			sourceTree = "<group>";
-		};
-		OBJ_793 /* cipher_extra */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_794 /* cipher_extra.c */,
-				OBJ_795 /* derive_key.c */,
-				OBJ_796 /* e_aesctrhmac.c */,
-				OBJ_797 /* e_aesgcmsiv.c */,
-				OBJ_798 /* e_chacha20poly1305.c */,
-				OBJ_799 /* e_null.c */,
-				OBJ_800 /* e_rc2.c */,
-				OBJ_801 /* e_rc4.c */,
-				OBJ_802 /* e_ssl3.c */,
-				OBJ_803 /* e_tls.c */,
-				OBJ_804 /* tls_cbc.c */,
-			);
-			path = cipher_extra;
-			sourceTree = "<group>";
-		};
-		OBJ_8 /* Bloombox */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_9 /* AuthClient.swift */,
-				OBJ_10 /* Bindings.swift */,
-				OBJ_11 /* Bloombox.swift */,
-				OBJ_12 /* DevicesClient.swift */,
-				OBJ_13 /* EventCollection.swift */,
-				OBJ_14 /* EventContext.swift */,
-				OBJ_15 /* MenuClient.swift */,
-				222EF14621C6FBE90008D96B /* IdentityClient.swift */,
-				OBJ_16 /* POSClient+AuthorizeUser.swift */,
-				OBJ_17 /* POSClient+Session.swift */,
-				OBJ_18 /* POSClient+VerifyTicketKey.swift */,
-				OBJ_19 /* POSClient.swift */,
-				OBJ_20 /* PlatformClient.swift */,
-				OBJ_21 /* RPCLogic.swift */,
-				OBJ_22 /* RemoteService.swift */,
-				OBJ_23 /* Services.swift */,
-				OBJ_24 /* ShopClient.swift */,
-				OBJ_25 /* TelemetryClient.swift */,
-				OBJ_26 /* TelemetryService+Generic.swift */,
-				OBJ_27 /* Transport.swift */,
-			);
-			name = Bloombox;
-			path = Sources/Client;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_805 /* cmac */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_806 /* cmac.c */,
-			);
-			path = cmac;
-			sourceTree = "<group>";
-		};
-		OBJ_807 /* conf */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_808 /* conf.c */,
-			);
-			path = conf;
-			sourceTree = "<group>";
-		};
-		OBJ_815 /* curve25519 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_816 /* spake25519.c */,
-				OBJ_817 /* x25519-x86_64.c */,
-			);
-			path = curve25519;
-			sourceTree = "<group>";
-		};
-		OBJ_818 /* dh */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_819 /* check.c */,
-				OBJ_820 /* dh.c */,
-				OBJ_821 /* dh_asn1.c */,
-				OBJ_822 /* params.c */,
-			);
-			path = dh;
-			sourceTree = "<group>";
-		};
-		OBJ_823 /* digest_extra */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_824 /* digest_extra.c */,
-			);
-			path = digest_extra;
-			sourceTree = "<group>";
-		};
-		OBJ_825 /* dsa */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_826 /* dsa.c */,
-				OBJ_827 /* dsa_asn1.c */,
-			);
-			path = dsa;
-			sourceTree = "<group>";
-		};
-		OBJ_828 /* ec_extra */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_829 /* ec_asn1.c */,
-			);
-			path = ec_extra;
-			sourceTree = "<group>";
-		};
-		OBJ_830 /* ecdh */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_831 /* ecdh.c */,
-			);
-			path = ecdh;
-			sourceTree = "<group>";
-		};
-		OBJ_832 /* ecdsa_extra */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_833 /* ecdsa_asn1.c */,
-			);
-			path = ecdsa_extra;
-			sourceTree = "<group>";
-		};
-		OBJ_834 /* engine */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_835 /* engine.c */,
-			);
-			path = engine;
-			sourceTree = "<group>";
-		};
-		OBJ_836 /* err */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_837 /* err.c */,
-				OBJ_838 /* err_data.c */,
-			);
-			path = err;
-			sourceTree = "<group>";
-		};
-		OBJ_839 /* evp */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_840 /* digestsign.c */,
-				OBJ_841 /* evp.c */,
-				OBJ_842 /* evp_asn1.c */,
-				OBJ_843 /* evp_ctx.c */,
-				OBJ_844 /* p_dsa_asn1.c */,
-				OBJ_845 /* p_ec.c */,
-				OBJ_846 /* p_ec_asn1.c */,
-				OBJ_847 /* p_ed25519.c */,
-				OBJ_848 /* p_ed25519_asn1.c */,
-				OBJ_849 /* p_rsa.c */,
-				OBJ_850 /* p_rsa_asn1.c */,
-				OBJ_851 /* pbkdf.c */,
-				OBJ_852 /* print.c */,
-				OBJ_853 /* scrypt.c */,
-				OBJ_854 /* sign.c */,
-			);
-			path = evp;
-			sourceTree = "<group>";
-		};
-		OBJ_856 /* fipsmodule */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_857 /* aes */,
-				OBJ_861 /* bn */,
-				OBJ_880 /* cipher */,
-				OBJ_885 /* des */,
-				OBJ_887 /* digest */,
-				OBJ_890 /* ec */,
-				OBJ_901 /* ecdsa */,
-				OBJ_903 /* hmac */,
-				OBJ_905 /* is_fips.c */,
-				OBJ_906 /* md4 */,
-				OBJ_908 /* md5 */,
-				OBJ_910 /* modes */,
-				OBJ_917 /* rand */,
-				OBJ_921 /* rsa */,
-				OBJ_926 /* sha */,
-			);
-			path = fipsmodule;
-			sourceTree = "<group>";
-		};
-		OBJ_857 /* aes */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_858 /* aes.c */,
-				OBJ_859 /* key_wrap.c */,
-				OBJ_860 /* mode_wrappers.c */,
-			);
-			path = aes;
-			sourceTree = "<group>";
-		};
-		OBJ_861 /* bn */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_862 /* add.c */,
-				OBJ_863 /* bn.c */,
-				OBJ_864 /* bytes.c */,
-				OBJ_865 /* cmp.c */,
-				OBJ_866 /* ctx.c */,
-				OBJ_867 /* div.c */,
-				OBJ_868 /* exponentiation.c */,
-				OBJ_869 /* gcd.c */,
-				OBJ_870 /* generic.c */,
-				OBJ_871 /* jacobi.c */,
-				OBJ_872 /* montgomery.c */,
-				OBJ_873 /* montgomery_inv.c */,
-				OBJ_874 /* mul.c */,
-				OBJ_875 /* prime.c */,
-				OBJ_876 /* random.c */,
-				OBJ_877 /* rsaz_exp.c */,
-				OBJ_878 /* shift.c */,
-				OBJ_879 /* sqrt.c */,
-			);
-			path = bn;
-			sourceTree = "<group>";
-		};
-		OBJ_880 /* cipher */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_881 /* aead.c */,
-				OBJ_882 /* cipher.c */,
-				OBJ_883 /* e_aes.c */,
-				OBJ_884 /* e_des.c */,
-			);
-			path = cipher;
-			sourceTree = "<group>";
-		};
-		OBJ_885 /* des */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_886 /* des.c */,
-			);
-			path = des;
-			sourceTree = "<group>";
-		};
-		OBJ_887 /* digest */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_888 /* digest.c */,
-				OBJ_889 /* digests.c */,
-			);
-			path = digest;
-			sourceTree = "<group>";
-		};
-		OBJ_890 /* ec */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_891 /* ec.c */,
-				OBJ_892 /* ec_key.c */,
-				OBJ_893 /* ec_montgomery.c */,
-				OBJ_894 /* oct.c */,
-				OBJ_895 /* p224-64.c */,
-				OBJ_896 /* p256-64.c */,
-				OBJ_897 /* p256-x86_64.c */,
-				OBJ_898 /* simple.c */,
-				OBJ_899 /* util-64.c */,
-				OBJ_900 /* wnaf.c */,
-			);
-			path = ec;
-			sourceTree = "<group>";
-		};
-		OBJ_901 /* ecdsa */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_902 /* ecdsa.c */,
-			);
-			path = ecdsa;
-			sourceTree = "<group>";
-		};
-		OBJ_903 /* hmac */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_904 /* hmac.c */,
-			);
-			path = hmac;
-			sourceTree = "<group>";
-		};
-		OBJ_906 /* md4 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_907 /* md4.c */,
-			);
-			path = md4;
-			sourceTree = "<group>";
-		};
-		OBJ_908 /* md5 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_909 /* md5.c */,
-			);
-			path = md5;
-			sourceTree = "<group>";
-		};
-		OBJ_910 /* modes */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_911 /* cbc.c */,
-				OBJ_912 /* cfb.c */,
-				OBJ_913 /* ctr.c */,
-				OBJ_914 /* gcm.c */,
-				OBJ_915 /* ofb.c */,
-				OBJ_916 /* polyval.c */,
-			);
-			path = modes;
-			sourceTree = "<group>";
-		};
-		OBJ_917 /* rand */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_918 /* ctrdrbg.c */,
-				OBJ_919 /* rand.c */,
-				OBJ_920 /* urandom.c */,
-			);
-			path = rand;
-			sourceTree = "<group>";
-		};
-		OBJ_921 /* rsa */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_922 /* blinding.c */,
-				OBJ_923 /* padding.c */,
-				OBJ_924 /* rsa.c */,
-				OBJ_925 /* rsa_impl.c */,
-			);
-			path = rsa;
-			sourceTree = "<group>";
-		};
-		OBJ_926 /* sha */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_927 /* sha1-altivec.c */,
-				OBJ_928 /* sha1.c */,
-				OBJ_929 /* sha256.c */,
-				OBJ_930 /* sha512.c */,
-			);
-			path = sha;
-			sourceTree = "<group>";
-		};
-		OBJ_931 /* hkdf */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_932 /* hkdf.c */,
-			);
-			path = hkdf;
-			sourceTree = "<group>";
-		};
-		OBJ_933 /* lhash */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_934 /* lhash.c */,
-			);
-			path = lhash;
-			sourceTree = "<group>";
-		};
-		OBJ_936 /* obj */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_937 /* obj.c */,
-				OBJ_938 /* obj_xref.c */,
-			);
-			path = obj;
-			sourceTree = "<group>";
-		};
-		OBJ_939 /* pem */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_940 /* pem_all.c */,
-				OBJ_941 /* pem_info.c */,
-				OBJ_942 /* pem_lib.c */,
-				OBJ_943 /* pem_oth.c */,
-				OBJ_944 /* pem_pk8.c */,
-				OBJ_945 /* pem_pkey.c */,
-				OBJ_946 /* pem_x509.c */,
-				OBJ_947 /* pem_xaux.c */,
-			);
-			path = pem;
-			sourceTree = "<group>";
-		};
-		OBJ_948 /* pkcs7 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_949 /* pkcs7.c */,
-				OBJ_950 /* pkcs7_x509.c */,
-			);
-			path = pkcs7;
-			sourceTree = "<group>";
-		};
-		OBJ_951 /* pkcs8 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_952 /* p5_pbev2.c */,
-				OBJ_953 /* pkcs8.c */,
-				OBJ_954 /* pkcs8_x509.c */,
-			);
-			path = pkcs8;
-			sourceTree = "<group>";
-		};
-		OBJ_955 /* poly1305 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_956 /* poly1305.c */,
-				OBJ_957 /* poly1305_arm.c */,
-				OBJ_958 /* poly1305_vec.c */,
-			);
-			path = poly1305;
-			sourceTree = "<group>";
-		};
-		OBJ_959 /* pool */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_960 /* pool.c */,
-			);
-			path = pool;
-			sourceTree = "<group>";
-		};
-		OBJ_961 /* rand_extra */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_962 /* deterministic.c */,
-				OBJ_963 /* forkunsafe.c */,
-				OBJ_964 /* fuchsia.c */,
-				OBJ_965 /* rand_extra.c */,
-				OBJ_966 /* windows.c */,
-			);
-			path = rand_extra;
-			sourceTree = "<group>";
-		};
-		OBJ_967 /* rc4 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_968 /* rc4.c */,
-			);
-			path = rc4;
-			sourceTree = "<group>";
-		};
-		OBJ_971 /* rsa_extra */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_972 /* rsa_asn1.c */,
-			);
-			path = rsa_extra;
-			sourceTree = "<group>";
-		};
-		OBJ_973 /* stack */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_974 /* stack.c */,
-			);
-			path = stack;
-			sourceTree = "<group>";
-		};
-		OBJ_979 /* x509 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_980 /* a_digest.c */,
-				OBJ_981 /* a_sign.c */,
-				OBJ_982 /* a_strex.c */,
-				OBJ_983 /* a_verify.c */,
-				OBJ_984 /* algorithm.c */,
-				OBJ_985 /* asn1_gen.c */,
-				OBJ_986 /* by_dir.c */,
-				OBJ_987 /* by_file.c */,
-				OBJ_988 /* i2d_pr.c */,
-				OBJ_989 /* rsa_pss.c */,
-				OBJ_990 /* t_crl.c */,
-				OBJ_991 /* t_req.c */,
-				OBJ_992 /* t_x509.c */,
-				OBJ_993 /* t_x509a.c */,
-				OBJ_994 /* x509.c */,
-				OBJ_995 /* x509_att.c */,
-				OBJ_996 /* x509_cmp.c */,
-				OBJ_997 /* x509_d2.c */,
-				OBJ_998 /* x509_def.c */,
-				OBJ_999 /* x509_ext.c */,
-				OBJ_1000 /* x509_lu.c */,
-				OBJ_1001 /* x509_obj.c */,
-				OBJ_1002 /* x509_r2x.c */,
-				OBJ_1003 /* x509_req.c */,
-				OBJ_1004 /* x509_set.c */,
-				OBJ_1005 /* x509_trs.c */,
-				OBJ_1006 /* x509_txt.c */,
-				OBJ_1007 /* x509_v3.c */,
-				OBJ_1008 /* x509_vfy.c */,
-				OBJ_1009 /* x509_vpm.c */,
-				OBJ_1010 /* x509cset.c */,
-				OBJ_1011 /* x509name.c */,
-				OBJ_1012 /* x509rset.c */,
-				OBJ_1013 /* x509spki.c */,
-				OBJ_1014 /* x_algor.c */,
-				OBJ_1015 /* x_all.c */,
-				OBJ_1016 /* x_attrib.c */,
-				OBJ_1017 /* x_crl.c */,
-				OBJ_1018 /* x_exten.c */,
-				OBJ_1019 /* x_info.c */,
-				OBJ_1020 /* x_name.c */,
-				OBJ_1021 /* x_pkey.c */,
-				OBJ_1022 /* x_pubkey.c */,
-				OBJ_1023 /* x_req.c */,
-				OBJ_1024 /* x_sig.c */,
-				OBJ_1025 /* x_spki.c */,
-				OBJ_1026 /* x_val.c */,
-				OBJ_1027 /* x_x509.c */,
-				OBJ_1028 /* x_x509a.c */,
-			);
-			path = x509;
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXNativeTarget section */
-		"Bloombox::Bloombox" /* Bloombox */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1308 /* Build configuration list for PBXNativeTarget "Bloombox" */;
-			buildPhases = (
-				OBJ_1311 /* Sources */,
-				OBJ_1331 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_1338 /* PBXTargetDependency */,
-				OBJ_1340 /* PBXTargetDependency */,
-				OBJ_1342 /* PBXTargetDependency */,
-				OBJ_1344 /* PBXTargetDependency */,
-				OBJ_1346 /* PBXTargetDependency */,
-				OBJ_1348 /* PBXTargetDependency */,
-			);
-			name = Bloombox;
-			productName = Bloombox;
-			productReference = "Bloombox::Bloombox::Product" /* Bloombox.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"Bloombox::BloomboxServices" /* BloomboxServices */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1364 /* Build configuration list for PBXNativeTarget "BloomboxServices" */;
-			buildPhases = (
-				OBJ_1367 /* Sources */,
-				OBJ_1378 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_1384 /* PBXTargetDependency */,
-				OBJ_1385 /* PBXTargetDependency */,
-				OBJ_1386 /* PBXTargetDependency */,
-				OBJ_1387 /* PBXTargetDependency */,
-				OBJ_1388 /* PBXTargetDependency */,
-			);
-			name = BloomboxServices;
-			productName = BloomboxServices;
-			productReference = "Bloombox::BloomboxServices::Product" /* BloomboxServices.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"Bloombox::ClientTests" /* ClientTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_2069 /* Build configuration list for PBXNativeTarget "ClientTests" */;
-			buildPhases = (
-				OBJ_2072 /* Sources */,
-				OBJ_2080 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_2088 /* PBXTargetDependency */,
-				OBJ_2089 /* PBXTargetDependency */,
-				OBJ_2090 /* PBXTargetDependency */,
-				OBJ_2091 /* PBXTargetDependency */,
-				OBJ_2092 /* PBXTargetDependency */,
-				OBJ_2093 /* PBXTargetDependency */,
-				OBJ_2094 /* PBXTargetDependency */,
-			);
-			name = ClientTests;
-			productName = ClientTests;
-			productReference = "Bloombox::ClientTests::Product" /* ClientTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		"Bloombox::OpenCannabis" /* OpenCannabis */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_2095 /* Build configuration list for PBXNativeTarget "OpenCannabis" */;
-			buildPhases = (
-				OBJ_2098 /* Sources */,
-				OBJ_2274 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_2276 /* PBXTargetDependency */,
-			);
-			name = OpenCannabis;
-			productName = OpenCannabis;
-			productReference = "Bloombox::OpenCannabis::Product" /* OpenCannabis.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"Bloombox::SchemaTests" /* SchemaTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_2277 /* Build configuration list for PBXNativeTarget "SchemaTests" */;
-			buildPhases = (
-				OBJ_2280 /* Sources */,
-				OBJ_2284 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_2292 /* PBXTargetDependency */,
-				OBJ_2293 /* PBXTargetDependency */,
-				OBJ_2294 /* PBXTargetDependency */,
-				OBJ_2295 /* PBXTargetDependency */,
-				OBJ_2296 /* PBXTargetDependency */,
-				OBJ_2297 /* PBXTargetDependency */,
-				OBJ_2298 /* PBXTargetDependency */,
-			);
-			name = SchemaTests;
-			productName = SchemaTests;
-			productReference = "Bloombox::SchemaTests::Product" /* SchemaTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		"Bloombox::SwiftPMPackageDescription" /* BloomboxPackageDescription */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1351 /* Build configuration list for PBXNativeTarget "BloomboxPackageDescription" */;
-			buildPhases = (
-				OBJ_1354 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = BloomboxPackageDescription;
-			productName = BloomboxPackageDescription;
-			productType = "com.apple.product-type.framework";
-		};
-		"SwiftGRPC::BoringSSL" /* BoringSSL */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1389 /* Build configuration list for PBXNativeTarget "BoringSSL" */;
-			buildPhases = (
-				OBJ_1392 /* Sources */,
-				OBJ_1707 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = BoringSSL;
-			productName = BoringSSL;
-			productReference = "SwiftGRPC::BoringSSL::Product" /* BoringSSL.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"SwiftGRPC::CgRPC" /* CgRPC */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1708 /* Build configuration list for PBXNativeTarget "CgRPC" */;
-			buildPhases = (
-				OBJ_1711 /* Sources */,
-				OBJ_2066 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_2068 /* PBXTargetDependency */,
-			);
-			name = CgRPC;
-			productName = CgRPC;
-			productReference = "SwiftGRPC::CgRPC::Product" /* CgRPC.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"SwiftGRPC::SwiftGRPC" /* SwiftGRPC */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_2299 /* Build configuration list for PBXNativeTarget "SwiftGRPC" */;
-			buildPhases = (
-				OBJ_2302 /* Sources */,
-				OBJ_2335 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				OBJ_2339 /* PBXTargetDependency */,
-				OBJ_2340 /* PBXTargetDependency */,
-				OBJ_2341 /* PBXTargetDependency */,
-			);
-			name = SwiftGRPC;
-			productName = SwiftGRPC;
-			productReference = "SwiftGRPC::SwiftGRPC::Product" /* SwiftGRPC.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		"SwiftGRPC::SwiftPMPackageDescription" /* SwiftGRPCPackageDescription */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_2343 /* Build configuration list for PBXNativeTarget "SwiftGRPCPackageDescription" */;
-			buildPhases = (
-				OBJ_2346 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = SwiftGRPCPackageDescription;
-			productName = SwiftGRPCPackageDescription;
-			productType = "com.apple.product-type.framework";
-		};
-		"SwiftProtobuf::SwiftPMPackageDescription" /* SwiftProtobufPackageDescription */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_2430 /* Build configuration list for PBXNativeTarget "SwiftProtobufPackageDescription" */;
-			buildPhases = (
-				OBJ_2433 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = SwiftProtobufPackageDescription;
-			productName = SwiftProtobufPackageDescription;
-			productType = "com.apple.product-type.framework";
-		};
-		"SwiftProtobuf::SwiftProtobuf" /* SwiftProtobuf */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_2348 /* Build configuration list for PBXNativeTarget "SwiftProtobuf" */;
-			buildPhases = (
-				OBJ_2351 /* Sources */,
-				OBJ_2428 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = SwiftProtobuf;
-			productName = SwiftProtobuf;
-			productReference = "SwiftProtobuf::SwiftProtobuf::Product" /* SwiftProtobuf.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		OBJ_1 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastUpgradeCheck = 9999;
-			};
-			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "Bloombox" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = OBJ_5 /*  */;
-			productRefGroup = OBJ_1297 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				"Bloombox::Bloombox" /* Bloombox */,
-				"Bloombox::SwiftPMPackageDescription" /* BloomboxPackageDescription */,
-				"Bloombox::BloomboxPackageTests::ProductTarget" /* BloomboxPackageTests */,
-				"Bloombox::BloomboxServices" /* BloomboxServices */,
-				"SwiftGRPC::BoringSSL" /* BoringSSL */,
-				"SwiftGRPC::CgRPC" /* CgRPC */,
-				"Bloombox::ClientTests" /* ClientTests */,
-				"Bloombox::OpenCannabis" /* OpenCannabis */,
-				"Bloombox::SchemaTests" /* SchemaTests */,
-				"SwiftGRPC::SwiftGRPC" /* SwiftGRPC */,
-				"SwiftGRPC::SwiftPMPackageDescription" /* SwiftGRPCPackageDescription */,
-				"SwiftProtobuf::SwiftProtobuf" /* SwiftProtobuf */,
-				"SwiftProtobuf::SwiftPMPackageDescription" /* SwiftProtobufPackageDescription */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXSourcesBuildPhase section */
-		OBJ_1311 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				222EF14721C6FBE90008D96B /* IdentityClient.swift in Sources */,
-				OBJ_1312 /* AuthClient.swift in Sources */,
-				OBJ_1313 /* Bindings.swift in Sources */,
-				OBJ_1314 /* Bloombox.swift in Sources */,
-				OBJ_1315 /* DevicesClient.swift in Sources */,
-				OBJ_1316 /* EventCollection.swift in Sources */,
-				OBJ_1317 /* EventContext.swift in Sources */,
-				OBJ_1318 /* MenuClient.swift in Sources */,
-				OBJ_1319 /* POSClient+AuthorizeUser.swift in Sources */,
-				OBJ_1320 /* POSClient+Session.swift in Sources */,
-				OBJ_1321 /* POSClient+VerifyTicketKey.swift in Sources */,
-				OBJ_1322 /* POSClient.swift in Sources */,
-				OBJ_1323 /* PlatformClient.swift in Sources */,
-				OBJ_1324 /* RPCLogic.swift in Sources */,
-				OBJ_1325 /* RemoteService.swift in Sources */,
-				OBJ_1326 /* Services.swift in Sources */,
-				OBJ_1327 /* ShopClient.swift in Sources */,
-				OBJ_1328 /* TelemetryClient.swift in Sources */,
-				OBJ_1329 /* TelemetryService+Generic.swift in Sources */,
-				OBJ_1330 /* Transport.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_1354 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_1355 /* Package.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_1367 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_1368 /* AuthService_Beta1.grpc.swift in Sources */,
-				OBJ_1369 /* DevicesService_Beta1.grpc.swift in Sources */,
-				OBJ_1370 /* IdentityService_Beta1.grpc.swift in Sources */,
-				OBJ_1371 /* MediaService_Beta1.grpc.swift in Sources */,
-				OBJ_1372 /* MenuService_Beta1.grpc.swift in Sources */,
-				OBJ_1373 /* POSService_Beta1.grpc.swift in Sources */,
-				OBJ_1374 /* PlatformService_v1.grpc.swift in Sources */,
-				OBJ_1375 /* ShopService_v1.grpc.swift in Sources */,
-				OBJ_1376 /* TelemetryService_Beta4.grpc.swift in Sources */,
-				OBJ_1377 /* WalletService_v1.grpc.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_1392 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_1393 /* a_bitstr.c in Sources */,
-				OBJ_1394 /* a_bool.c in Sources */,
-				OBJ_1395 /* a_d2i_fp.c in Sources */,
-				OBJ_1396 /* a_dup.c in Sources */,
-				OBJ_1397 /* a_enum.c in Sources */,
-				OBJ_1398 /* a_gentm.c in Sources */,
-				OBJ_1399 /* a_i2d_fp.c in Sources */,
-				OBJ_1400 /* a_int.c in Sources */,
-				OBJ_1401 /* a_mbstr.c in Sources */,
-				OBJ_1402 /* a_object.c in Sources */,
-				OBJ_1403 /* a_octet.c in Sources */,
-				OBJ_1404 /* a_print.c in Sources */,
-				OBJ_1405 /* a_strnid.c in Sources */,
-				OBJ_1406 /* a_time.c in Sources */,
-				OBJ_1407 /* a_type.c in Sources */,
-				OBJ_1408 /* a_utctm.c in Sources */,
-				OBJ_1409 /* a_utf8.c in Sources */,
-				OBJ_1410 /* asn1_lib.c in Sources */,
-				OBJ_1411 /* asn1_par.c in Sources */,
-				OBJ_1412 /* asn_pack.c in Sources */,
-				OBJ_1413 /* f_enum.c in Sources */,
-				OBJ_1414 /* f_int.c in Sources */,
-				OBJ_1415 /* f_string.c in Sources */,
-				OBJ_1416 /* tasn_dec.c in Sources */,
-				OBJ_1417 /* tasn_enc.c in Sources */,
-				OBJ_1418 /* tasn_fre.c in Sources */,
-				OBJ_1419 /* tasn_new.c in Sources */,
-				OBJ_1420 /* tasn_typ.c in Sources */,
-				OBJ_1421 /* tasn_utl.c in Sources */,
-				OBJ_1422 /* time_support.c in Sources */,
-				OBJ_1423 /* base64.c in Sources */,
-				OBJ_1424 /* bio.c in Sources */,
-				OBJ_1425 /* bio_mem.c in Sources */,
-				OBJ_1426 /* connect.c in Sources */,
-				OBJ_1427 /* fd.c in Sources */,
-				OBJ_1428 /* file.c in Sources */,
-				OBJ_1429 /* hexdump.c in Sources */,
-				OBJ_1430 /* pair.c in Sources */,
-				OBJ_1431 /* printf.c in Sources */,
-				OBJ_1432 /* socket.c in Sources */,
-				OBJ_1433 /* socket_helper.c in Sources */,
-				OBJ_1434 /* bn_asn1.c in Sources */,
-				OBJ_1435 /* convert.c in Sources */,
-				OBJ_1436 /* buf.c in Sources */,
-				OBJ_1437 /* asn1_compat.c in Sources */,
-				OBJ_1438 /* ber.c in Sources */,
-				OBJ_1439 /* cbb.c in Sources */,
-				OBJ_1440 /* cbs.c in Sources */,
-				OBJ_1441 /* chacha.c in Sources */,
-				OBJ_1442 /* cipher_extra.c in Sources */,
-				OBJ_1443 /* derive_key.c in Sources */,
-				OBJ_1444 /* e_aesctrhmac.c in Sources */,
-				OBJ_1445 /* e_aesgcmsiv.c in Sources */,
-				OBJ_1446 /* e_chacha20poly1305.c in Sources */,
-				OBJ_1447 /* e_null.c in Sources */,
-				OBJ_1448 /* e_rc2.c in Sources */,
-				OBJ_1449 /* e_rc4.c in Sources */,
-				OBJ_1450 /* e_ssl3.c in Sources */,
-				OBJ_1451 /* e_tls.c in Sources */,
-				OBJ_1452 /* tls_cbc.c in Sources */,
-				OBJ_1453 /* cmac.c in Sources */,
-				OBJ_1454 /* conf.c in Sources */,
-				OBJ_1455 /* cpu-aarch64-linux.c in Sources */,
-				OBJ_1456 /* cpu-arm-linux.c in Sources */,
-				OBJ_1457 /* cpu-arm.c in Sources */,
-				OBJ_1458 /* cpu-intel.c in Sources */,
-				OBJ_1459 /* cpu-ppc64le.c in Sources */,
-				OBJ_1460 /* crypto.c in Sources */,
-				OBJ_1461 /* spake25519.c in Sources */,
-				OBJ_1462 /* x25519-x86_64.c in Sources */,
-				OBJ_1463 /* check.c in Sources */,
-				OBJ_1464 /* dh.c in Sources */,
-				OBJ_1465 /* dh_asn1.c in Sources */,
-				OBJ_1466 /* params.c in Sources */,
-				OBJ_1467 /* digest_extra.c in Sources */,
-				OBJ_1468 /* dsa.c in Sources */,
-				OBJ_1469 /* dsa_asn1.c in Sources */,
-				OBJ_1470 /* ec_asn1.c in Sources */,
-				OBJ_1471 /* ecdh.c in Sources */,
-				OBJ_1472 /* ecdsa_asn1.c in Sources */,
-				OBJ_1473 /* engine.c in Sources */,
-				OBJ_1474 /* err.c in Sources */,
-				OBJ_1475 /* err_data.c in Sources */,
-				OBJ_1476 /* digestsign.c in Sources */,
-				OBJ_1477 /* evp.c in Sources */,
-				OBJ_1478 /* evp_asn1.c in Sources */,
-				OBJ_1479 /* evp_ctx.c in Sources */,
-				OBJ_1480 /* p_dsa_asn1.c in Sources */,
-				OBJ_1481 /* p_ec.c in Sources */,
-				OBJ_1482 /* p_ec_asn1.c in Sources */,
-				OBJ_1483 /* p_ed25519.c in Sources */,
-				OBJ_1484 /* p_ed25519_asn1.c in Sources */,
-				OBJ_1485 /* p_rsa.c in Sources */,
-				OBJ_1486 /* p_rsa_asn1.c in Sources */,
-				OBJ_1487 /* pbkdf.c in Sources */,
-				OBJ_1488 /* print.c in Sources */,
-				OBJ_1489 /* scrypt.c in Sources */,
-				OBJ_1490 /* sign.c in Sources */,
-				OBJ_1491 /* ex_data.c in Sources */,
-				OBJ_1492 /* aes.c in Sources */,
-				OBJ_1493 /* key_wrap.c in Sources */,
-				OBJ_1494 /* mode_wrappers.c in Sources */,
-				OBJ_1495 /* add.c in Sources */,
-				OBJ_1496 /* bn.c in Sources */,
-				OBJ_1497 /* bytes.c in Sources */,
-				OBJ_1498 /* cmp.c in Sources */,
-				OBJ_1499 /* ctx.c in Sources */,
-				OBJ_1500 /* div.c in Sources */,
-				OBJ_1501 /* exponentiation.c in Sources */,
-				OBJ_1502 /* gcd.c in Sources */,
-				OBJ_1503 /* generic.c in Sources */,
-				OBJ_1504 /* jacobi.c in Sources */,
-				OBJ_1505 /* montgomery.c in Sources */,
-				OBJ_1506 /* montgomery_inv.c in Sources */,
-				OBJ_1507 /* mul.c in Sources */,
-				OBJ_1508 /* prime.c in Sources */,
-				OBJ_1509 /* random.c in Sources */,
-				OBJ_1510 /* rsaz_exp.c in Sources */,
-				OBJ_1511 /* shift.c in Sources */,
-				OBJ_1512 /* sqrt.c in Sources */,
-				OBJ_1513 /* aead.c in Sources */,
-				OBJ_1514 /* cipher.c in Sources */,
-				OBJ_1515 /* e_aes.c in Sources */,
-				OBJ_1516 /* e_des.c in Sources */,
-				OBJ_1517 /* des.c in Sources */,
-				OBJ_1518 /* digest.c in Sources */,
-				OBJ_1519 /* digests.c in Sources */,
-				OBJ_1520 /* ec.c in Sources */,
-				OBJ_1521 /* ec_key.c in Sources */,
-				OBJ_1522 /* ec_montgomery.c in Sources */,
-				OBJ_1523 /* oct.c in Sources */,
-				OBJ_1524 /* p224-64.c in Sources */,
-				OBJ_1525 /* p256-64.c in Sources */,
-				OBJ_1526 /* p256-x86_64.c in Sources */,
-				OBJ_1527 /* simple.c in Sources */,
-				OBJ_1528 /* util-64.c in Sources */,
-				OBJ_1529 /* wnaf.c in Sources */,
-				OBJ_1530 /* ecdsa.c in Sources */,
-				OBJ_1531 /* hmac.c in Sources */,
-				OBJ_1532 /* is_fips.c in Sources */,
-				OBJ_1533 /* md4.c in Sources */,
-				OBJ_1534 /* md5.c in Sources */,
-				OBJ_1535 /* cbc.c in Sources */,
-				OBJ_1536 /* cfb.c in Sources */,
-				OBJ_1537 /* ctr.c in Sources */,
-				OBJ_1538 /* gcm.c in Sources */,
-				OBJ_1539 /* ofb.c in Sources */,
-				OBJ_1540 /* polyval.c in Sources */,
-				OBJ_1541 /* ctrdrbg.c in Sources */,
-				OBJ_1542 /* rand.c in Sources */,
-				OBJ_1543 /* urandom.c in Sources */,
-				OBJ_1544 /* blinding.c in Sources */,
-				OBJ_1545 /* padding.c in Sources */,
-				OBJ_1546 /* rsa.c in Sources */,
-				OBJ_1547 /* rsa_impl.c in Sources */,
-				OBJ_1548 /* sha1-altivec.c in Sources */,
-				OBJ_1549 /* sha1.c in Sources */,
-				OBJ_1550 /* sha256.c in Sources */,
-				OBJ_1551 /* sha512.c in Sources */,
-				OBJ_1552 /* hkdf.c in Sources */,
-				OBJ_1553 /* lhash.c in Sources */,
-				OBJ_1554 /* mem.c in Sources */,
-				OBJ_1555 /* obj.c in Sources */,
-				OBJ_1556 /* obj_xref.c in Sources */,
-				OBJ_1557 /* pem_all.c in Sources */,
-				OBJ_1558 /* pem_info.c in Sources */,
-				OBJ_1559 /* pem_lib.c in Sources */,
-				OBJ_1560 /* pem_oth.c in Sources */,
-				OBJ_1561 /* pem_pk8.c in Sources */,
-				OBJ_1562 /* pem_pkey.c in Sources */,
-				OBJ_1563 /* pem_x509.c in Sources */,
-				OBJ_1564 /* pem_xaux.c in Sources */,
-				OBJ_1565 /* pkcs7.c in Sources */,
-				OBJ_1566 /* pkcs7_x509.c in Sources */,
-				OBJ_1567 /* p5_pbev2.c in Sources */,
-				OBJ_1568 /* pkcs8.c in Sources */,
-				OBJ_1569 /* pkcs8_x509.c in Sources */,
-				OBJ_1570 /* poly1305.c in Sources */,
-				OBJ_1571 /* poly1305_arm.c in Sources */,
-				OBJ_1572 /* poly1305_vec.c in Sources */,
-				OBJ_1573 /* pool.c in Sources */,
-				OBJ_1574 /* deterministic.c in Sources */,
-				OBJ_1575 /* forkunsafe.c in Sources */,
-				OBJ_1576 /* fuchsia.c in Sources */,
-				OBJ_1577 /* rand_extra.c in Sources */,
-				OBJ_1578 /* windows.c in Sources */,
-				OBJ_1579 /* rc4.c in Sources */,
-				OBJ_1580 /* refcount_c11.c in Sources */,
-				OBJ_1581 /* refcount_lock.c in Sources */,
-				OBJ_1582 /* rsa_asn1.c in Sources */,
-				OBJ_1583 /* stack.c in Sources */,
-				OBJ_1584 /* thread.c in Sources */,
-				OBJ_1585 /* thread_none.c in Sources */,
-				OBJ_1586 /* thread_pthread.c in Sources */,
-				OBJ_1587 /* thread_win.c in Sources */,
-				OBJ_1588 /* a_digest.c in Sources */,
-				OBJ_1589 /* a_sign.c in Sources */,
-				OBJ_1590 /* a_strex.c in Sources */,
-				OBJ_1591 /* a_verify.c in Sources */,
-				OBJ_1592 /* algorithm.c in Sources */,
-				OBJ_1593 /* asn1_gen.c in Sources */,
-				OBJ_1594 /* by_dir.c in Sources */,
-				OBJ_1595 /* by_file.c in Sources */,
-				OBJ_1596 /* i2d_pr.c in Sources */,
-				OBJ_1597 /* rsa_pss.c in Sources */,
-				OBJ_1598 /* t_crl.c in Sources */,
-				OBJ_1599 /* t_req.c in Sources */,
-				OBJ_1600 /* t_x509.c in Sources */,
-				OBJ_1601 /* t_x509a.c in Sources */,
-				OBJ_1602 /* x509.c in Sources */,
-				OBJ_1603 /* x509_att.c in Sources */,
-				OBJ_1604 /* x509_cmp.c in Sources */,
-				OBJ_1605 /* x509_d2.c in Sources */,
-				OBJ_1606 /* x509_def.c in Sources */,
-				OBJ_1607 /* x509_ext.c in Sources */,
-				OBJ_1608 /* x509_lu.c in Sources */,
-				OBJ_1609 /* x509_obj.c in Sources */,
-				OBJ_1610 /* x509_r2x.c in Sources */,
-				OBJ_1611 /* x509_req.c in Sources */,
-				OBJ_1612 /* x509_set.c in Sources */,
-				OBJ_1613 /* x509_trs.c in Sources */,
-				OBJ_1614 /* x509_txt.c in Sources */,
-				OBJ_1615 /* x509_v3.c in Sources */,
-				OBJ_1616 /* x509_vfy.c in Sources */,
-				OBJ_1617 /* x509_vpm.c in Sources */,
-				OBJ_1618 /* x509cset.c in Sources */,
-				OBJ_1619 /* x509name.c in Sources */,
-				OBJ_1620 /* x509rset.c in Sources */,
-				OBJ_1621 /* x509spki.c in Sources */,
-				OBJ_1622 /* x_algor.c in Sources */,
-				OBJ_1623 /* x_all.c in Sources */,
-				OBJ_1624 /* x_attrib.c in Sources */,
-				OBJ_1625 /* x_crl.c in Sources */,
-				OBJ_1626 /* x_exten.c in Sources */,
-				OBJ_1627 /* x_info.c in Sources */,
-				OBJ_1628 /* x_name.c in Sources */,
-				OBJ_1629 /* x_pkey.c in Sources */,
-				OBJ_1630 /* x_pubkey.c in Sources */,
-				OBJ_1631 /* x_req.c in Sources */,
-				OBJ_1632 /* x_sig.c in Sources */,
-				OBJ_1633 /* x_spki.c in Sources */,
-				OBJ_1634 /* x_val.c in Sources */,
-				OBJ_1635 /* x_x509.c in Sources */,
-				OBJ_1636 /* x_x509a.c in Sources */,
-				OBJ_1637 /* pcy_cache.c in Sources */,
-				OBJ_1638 /* pcy_data.c in Sources */,
-				OBJ_1639 /* pcy_lib.c in Sources */,
-				OBJ_1640 /* pcy_map.c in Sources */,
-				OBJ_1641 /* pcy_node.c in Sources */,
-				OBJ_1642 /* pcy_tree.c in Sources */,
-				OBJ_1643 /* v3_akey.c in Sources */,
-				OBJ_1644 /* v3_akeya.c in Sources */,
-				OBJ_1645 /* v3_alt.c in Sources */,
-				OBJ_1646 /* v3_bcons.c in Sources */,
-				OBJ_1647 /* v3_bitst.c in Sources */,
-				OBJ_1648 /* v3_conf.c in Sources */,
-				OBJ_1649 /* v3_cpols.c in Sources */,
-				OBJ_1650 /* v3_crld.c in Sources */,
-				OBJ_1651 /* v3_enum.c in Sources */,
-				OBJ_1652 /* v3_extku.c in Sources */,
-				OBJ_1653 /* v3_genn.c in Sources */,
-				OBJ_1654 /* v3_ia5.c in Sources */,
-				OBJ_1655 /* v3_info.c in Sources */,
-				OBJ_1656 /* v3_int.c in Sources */,
-				OBJ_1657 /* v3_lib.c in Sources */,
-				OBJ_1658 /* v3_ncons.c in Sources */,
-				OBJ_1659 /* v3_pci.c in Sources */,
-				OBJ_1660 /* v3_pcia.c in Sources */,
-				OBJ_1661 /* v3_pcons.c in Sources */,
-				OBJ_1662 /* v3_pku.c in Sources */,
-				OBJ_1663 /* v3_pmaps.c in Sources */,
-				OBJ_1664 /* v3_prn.c in Sources */,
-				OBJ_1665 /* v3_purp.c in Sources */,
-				OBJ_1666 /* v3_skey.c in Sources */,
-				OBJ_1667 /* v3_sxnet.c in Sources */,
-				OBJ_1668 /* v3_utl.c in Sources */,
-				OBJ_1669 /* err_data.c in Sources */,
-				OBJ_1670 /* bio_ssl.cc in Sources */,
-				OBJ_1671 /* custom_extensions.cc in Sources */,
-				OBJ_1672 /* d1_both.cc in Sources */,
-				OBJ_1673 /* d1_lib.cc in Sources */,
-				OBJ_1674 /* d1_pkt.cc in Sources */,
-				OBJ_1675 /* d1_srtp.cc in Sources */,
-				OBJ_1676 /* dtls_method.cc in Sources */,
-				OBJ_1677 /* dtls_record.cc in Sources */,
-				OBJ_1678 /* handshake.cc in Sources */,
-				OBJ_1679 /* handshake_client.cc in Sources */,
-				OBJ_1680 /* handshake_server.cc in Sources */,
-				OBJ_1681 /* s3_both.cc in Sources */,
-				OBJ_1682 /* s3_lib.cc in Sources */,
-				OBJ_1683 /* s3_pkt.cc in Sources */,
-				OBJ_1684 /* ssl_aead_ctx.cc in Sources */,
-				OBJ_1685 /* ssl_asn1.cc in Sources */,
-				OBJ_1686 /* ssl_buffer.cc in Sources */,
-				OBJ_1687 /* ssl_cert.cc in Sources */,
-				OBJ_1688 /* ssl_cipher.cc in Sources */,
-				OBJ_1689 /* ssl_file.cc in Sources */,
-				OBJ_1690 /* ssl_key_share.cc in Sources */,
-				OBJ_1691 /* ssl_lib.cc in Sources */,
-				OBJ_1692 /* ssl_privkey.cc in Sources */,
-				OBJ_1693 /* ssl_session.cc in Sources */,
-				OBJ_1694 /* ssl_stat.cc in Sources */,
-				OBJ_1695 /* ssl_transcript.cc in Sources */,
-				OBJ_1696 /* ssl_versions.cc in Sources */,
-				OBJ_1697 /* ssl_x509.cc in Sources */,
-				OBJ_1698 /* t1_enc.cc in Sources */,
-				OBJ_1699 /* t1_lib.cc in Sources */,
-				OBJ_1700 /* tls13_both.cc in Sources */,
-				OBJ_1701 /* tls13_client.cc in Sources */,
-				OBJ_1702 /* tls13_enc.cc in Sources */,
-				OBJ_1703 /* tls13_server.cc in Sources */,
-				OBJ_1704 /* tls_method.cc in Sources */,
-				OBJ_1705 /* tls_record.cc in Sources */,
-				OBJ_1706 /* curve25519.c in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_1711 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_1712 /* byte_buffer.c in Sources */,
-				OBJ_1713 /* call.c in Sources */,
-				OBJ_1714 /* channel.c in Sources */,
-				OBJ_1715 /* completion_queue.c in Sources */,
-				OBJ_1716 /* event.c in Sources */,
-				OBJ_1717 /* handler.c in Sources */,
-				OBJ_1718 /* internal.c in Sources */,
-				OBJ_1719 /* metadata.c in Sources */,
-				OBJ_1720 /* mutex.c in Sources */,
-				OBJ_1721 /* observers.c in Sources */,
-				OBJ_1722 /* operations.c in Sources */,
-				OBJ_1723 /* server.c in Sources */,
-				OBJ_1724 /* grpc_context.cc in Sources */,
-				OBJ_1725 /* backup_poller.cc in Sources */,
-				OBJ_1726 /* channel_connectivity.cc in Sources */,
-				OBJ_1727 /* client_channel.cc in Sources */,
-				OBJ_1728 /* client_channel_factory.cc in Sources */,
-				OBJ_1729 /* client_channel_plugin.cc in Sources */,
-				OBJ_1730 /* connector.cc in Sources */,
-				OBJ_1731 /* http_connect_handshaker.cc in Sources */,
-				OBJ_1732 /* http_proxy.cc in Sources */,
-				OBJ_1733 /* lb_policy.cc in Sources */,
-				OBJ_1734 /* client_load_reporting_filter.cc in Sources */,
-				OBJ_1735 /* grpclb.cc in Sources */,
-				OBJ_1736 /* grpclb_channel_secure.cc in Sources */,
-				OBJ_1737 /* grpclb_client_stats.cc in Sources */,
-				OBJ_1738 /* load_balancer_api.cc in Sources */,
-				OBJ_1739 /* load_balancer.pb.c in Sources */,
-				OBJ_1740 /* pick_first.cc in Sources */,
-				OBJ_1741 /* round_robin.cc in Sources */,
-				OBJ_1742 /* lb_policy_factory.cc in Sources */,
-				OBJ_1743 /* lb_policy_registry.cc in Sources */,
-				OBJ_1744 /* method_params.cc in Sources */,
-				OBJ_1745 /* parse_address.cc in Sources */,
-				OBJ_1746 /* proxy_mapper.cc in Sources */,
-				OBJ_1747 /* proxy_mapper_registry.cc in Sources */,
-				OBJ_1748 /* resolver.cc in Sources */,
-				OBJ_1749 /* dns_resolver_ares.cc in Sources */,
-				OBJ_1750 /* grpc_ares_ev_driver_posix.cc in Sources */,
-				OBJ_1751 /* grpc_ares_wrapper.cc in Sources */,
-				OBJ_1752 /* grpc_ares_wrapper_fallback.cc in Sources */,
-				OBJ_1753 /* dns_resolver.cc in Sources */,
-				OBJ_1754 /* fake_resolver.cc in Sources */,
-				OBJ_1755 /* sockaddr_resolver.cc in Sources */,
-				OBJ_1756 /* resolver_registry.cc in Sources */,
-				OBJ_1757 /* retry_throttle.cc in Sources */,
-				OBJ_1758 /* subchannel.cc in Sources */,
-				OBJ_1759 /* subchannel_index.cc in Sources */,
-				OBJ_1760 /* uri_parser.cc in Sources */,
-				OBJ_1761 /* deadline_filter.cc in Sources */,
-				OBJ_1762 /* http_client_filter.cc in Sources */,
-				OBJ_1763 /* client_authority_filter.cc in Sources */,
-				OBJ_1764 /* http_filters_plugin.cc in Sources */,
-				OBJ_1765 /* message_compress_filter.cc in Sources */,
-				OBJ_1766 /* http_server_filter.cc in Sources */,
-				OBJ_1767 /* server_load_reporting_filter.cc in Sources */,
-				OBJ_1768 /* server_load_reporting_plugin.cc in Sources */,
-				OBJ_1769 /* max_age_filter.cc in Sources */,
-				OBJ_1770 /* message_size_filter.cc in Sources */,
-				OBJ_1771 /* workaround_cronet_compression_filter.cc in Sources */,
-				OBJ_1772 /* workaround_utils.cc in Sources */,
-				OBJ_1773 /* alpn.cc in Sources */,
-				OBJ_1774 /* authority.cc in Sources */,
-				OBJ_1775 /* chttp2_connector.cc in Sources */,
-				OBJ_1776 /* channel_create.cc in Sources */,
-				OBJ_1777 /* channel_create_posix.cc in Sources */,
-				OBJ_1778 /* secure_channel_create.cc in Sources */,
-				OBJ_1779 /* chttp2_server.cc in Sources */,
-				OBJ_1780 /* server_chttp2.cc in Sources */,
-				OBJ_1781 /* server_chttp2_posix.cc in Sources */,
-				OBJ_1782 /* server_secure_chttp2.cc in Sources */,
-				OBJ_1783 /* bin_decoder.cc in Sources */,
-				OBJ_1784 /* bin_encoder.cc in Sources */,
-				OBJ_1785 /* chttp2_plugin.cc in Sources */,
-				OBJ_1786 /* chttp2_transport.cc in Sources */,
-				OBJ_1787 /* flow_control.cc in Sources */,
-				OBJ_1788 /* frame_data.cc in Sources */,
-				OBJ_1789 /* frame_goaway.cc in Sources */,
-				OBJ_1790 /* frame_ping.cc in Sources */,
-				OBJ_1791 /* frame_rst_stream.cc in Sources */,
-				OBJ_1792 /* frame_settings.cc in Sources */,
-				OBJ_1793 /* frame_window_update.cc in Sources */,
-				OBJ_1794 /* hpack_encoder.cc in Sources */,
-				OBJ_1795 /* hpack_parser.cc in Sources */,
-				OBJ_1796 /* hpack_table.cc in Sources */,
-				OBJ_1797 /* http2_settings.cc in Sources */,
-				OBJ_1798 /* huffsyms.cc in Sources */,
-				OBJ_1799 /* incoming_metadata.cc in Sources */,
-				OBJ_1800 /* parsing.cc in Sources */,
-				OBJ_1801 /* stream_lists.cc in Sources */,
-				OBJ_1802 /* stream_map.cc in Sources */,
-				OBJ_1803 /* varint.cc in Sources */,
-				OBJ_1804 /* writing.cc in Sources */,
-				OBJ_1805 /* inproc_plugin.cc in Sources */,
-				OBJ_1806 /* inproc_transport.cc in Sources */,
-				OBJ_1807 /* avl.cc in Sources */,
-				OBJ_1808 /* backoff.cc in Sources */,
-				OBJ_1809 /* channel_args.cc in Sources */,
-				OBJ_1810 /* channel_stack.cc in Sources */,
-				OBJ_1811 /* channel_stack_builder.cc in Sources */,
-				OBJ_1812 /* channel_trace.cc in Sources */,
-				OBJ_1813 /* channel_trace_registry.cc in Sources */,
-				OBJ_1814 /* connected_channel.cc in Sources */,
-				OBJ_1815 /* handshaker.cc in Sources */,
-				OBJ_1816 /* handshaker_factory.cc in Sources */,
-				OBJ_1817 /* handshaker_registry.cc in Sources */,
-				OBJ_1818 /* status_util.cc in Sources */,
-				OBJ_1819 /* compression.cc in Sources */,
-				OBJ_1820 /* compression_internal.cc in Sources */,
-				OBJ_1821 /* message_compress.cc in Sources */,
-				OBJ_1822 /* stream_compression.cc in Sources */,
-				OBJ_1823 /* stream_compression_gzip.cc in Sources */,
-				OBJ_1824 /* stream_compression_identity.cc in Sources */,
-				OBJ_1825 /* stats.cc in Sources */,
-				OBJ_1826 /* stats_data.cc in Sources */,
-				OBJ_1827 /* trace.cc in Sources */,
-				OBJ_1828 /* alloc.cc in Sources */,
-				OBJ_1829 /* arena.cc in Sources */,
-				OBJ_1830 /* atm.cc in Sources */,
-				OBJ_1831 /* cpu_iphone.cc in Sources */,
-				OBJ_1832 /* cpu_linux.cc in Sources */,
-				OBJ_1833 /* cpu_posix.cc in Sources */,
-				OBJ_1834 /* cpu_windows.cc in Sources */,
-				OBJ_1835 /* env_linux.cc in Sources */,
-				OBJ_1836 /* env_posix.cc in Sources */,
-				OBJ_1837 /* env_windows.cc in Sources */,
-				OBJ_1838 /* fork.cc in Sources */,
-				OBJ_1839 /* host_port.cc in Sources */,
-				OBJ_1840 /* log.cc in Sources */,
-				OBJ_1841 /* log_android.cc in Sources */,
-				OBJ_1842 /* log_linux.cc in Sources */,
-				OBJ_1843 /* log_posix.cc in Sources */,
-				OBJ_1844 /* log_windows.cc in Sources */,
-				OBJ_1845 /* mpscq.cc in Sources */,
-				OBJ_1846 /* murmur_hash.cc in Sources */,
-				OBJ_1847 /* string.cc in Sources */,
-				OBJ_1848 /* string_posix.cc in Sources */,
-				OBJ_1849 /* string_util_windows.cc in Sources */,
-				OBJ_1850 /* string_windows.cc in Sources */,
-				OBJ_1851 /* sync.cc in Sources */,
-				OBJ_1852 /* sync_posix.cc in Sources */,
-				OBJ_1853 /* sync_windows.cc in Sources */,
-				OBJ_1854 /* time.cc in Sources */,
-				OBJ_1855 /* time_posix.cc in Sources */,
-				OBJ_1856 /* time_precise.cc in Sources */,
-				OBJ_1857 /* time_windows.cc in Sources */,
-				OBJ_1858 /* tls_pthread.cc in Sources */,
-				OBJ_1859 /* tmpfile_msys.cc in Sources */,
-				OBJ_1860 /* tmpfile_posix.cc in Sources */,
-				OBJ_1861 /* tmpfile_windows.cc in Sources */,
-				OBJ_1862 /* wrap_memcpy.cc in Sources */,
-				OBJ_1863 /* thd_posix.cc in Sources */,
-				OBJ_1864 /* thd_windows.cc in Sources */,
-				OBJ_1865 /* format_request.cc in Sources */,
-				OBJ_1866 /* httpcli.cc in Sources */,
-				OBJ_1867 /* httpcli_security_connector.cc in Sources */,
-				OBJ_1868 /* parser.cc in Sources */,
-				OBJ_1869 /* call_combiner.cc in Sources */,
-				OBJ_1870 /* combiner.cc in Sources */,
-				OBJ_1871 /* endpoint.cc in Sources */,
-				OBJ_1872 /* endpoint_pair_posix.cc in Sources */,
-				OBJ_1873 /* endpoint_pair_uv.cc in Sources */,
-				OBJ_1874 /* endpoint_pair_windows.cc in Sources */,
-				OBJ_1875 /* error.cc in Sources */,
-				OBJ_1876 /* ev_epoll1_linux.cc in Sources */,
-				OBJ_1877 /* ev_epollex_linux.cc in Sources */,
-				OBJ_1878 /* ev_epollsig_linux.cc in Sources */,
-				OBJ_1879 /* ev_poll_posix.cc in Sources */,
-				OBJ_1880 /* ev_posix.cc in Sources */,
-				OBJ_1881 /* ev_windows.cc in Sources */,
-				OBJ_1882 /* exec_ctx.cc in Sources */,
-				OBJ_1883 /* executor.cc in Sources */,
-				OBJ_1884 /* fork_posix.cc in Sources */,
-				OBJ_1885 /* fork_windows.cc in Sources */,
-				OBJ_1886 /* gethostname_fallback.cc in Sources */,
-				OBJ_1887 /* gethostname_host_name_max.cc in Sources */,
-				OBJ_1888 /* gethostname_sysconf.cc in Sources */,
-				OBJ_1889 /* iocp_windows.cc in Sources */,
-				OBJ_1890 /* iomgr.cc in Sources */,
-				OBJ_1891 /* iomgr_custom.cc in Sources */,
-				OBJ_1892 /* iomgr_internal.cc in Sources */,
-				OBJ_1893 /* iomgr_posix.cc in Sources */,
-				OBJ_1894 /* iomgr_uv.cc in Sources */,
-				OBJ_1895 /* iomgr_windows.cc in Sources */,
-				OBJ_1896 /* is_epollexclusive_available.cc in Sources */,
-				OBJ_1897 /* load_file.cc in Sources */,
-				OBJ_1898 /* lockfree_event.cc in Sources */,
-				OBJ_1899 /* network_status_tracker.cc in Sources */,
-				OBJ_1900 /* polling_entity.cc in Sources */,
-				OBJ_1901 /* pollset.cc in Sources */,
-				OBJ_1902 /* pollset_custom.cc in Sources */,
-				OBJ_1903 /* pollset_set.cc in Sources */,
-				OBJ_1904 /* pollset_set_custom.cc in Sources */,
-				OBJ_1905 /* pollset_set_windows.cc in Sources */,
-				OBJ_1906 /* pollset_uv.cc in Sources */,
-				OBJ_1907 /* pollset_windows.cc in Sources */,
-				OBJ_1908 /* resolve_address.cc in Sources */,
-				OBJ_1909 /* resolve_address_custom.cc in Sources */,
-				OBJ_1910 /* resolve_address_posix.cc in Sources */,
-				OBJ_1911 /* resolve_address_windows.cc in Sources */,
-				OBJ_1912 /* resource_quota.cc in Sources */,
-				OBJ_1913 /* sockaddr_utils.cc in Sources */,
-				OBJ_1914 /* socket_factory_posix.cc in Sources */,
-				OBJ_1915 /* socket_mutator.cc in Sources */,
-				OBJ_1916 /* socket_utils_common_posix.cc in Sources */,
-				OBJ_1917 /* socket_utils_linux.cc in Sources */,
-				OBJ_1918 /* socket_utils_posix.cc in Sources */,
-				OBJ_1919 /* socket_utils_uv.cc in Sources */,
-				OBJ_1920 /* socket_utils_windows.cc in Sources */,
-				OBJ_1921 /* socket_windows.cc in Sources */,
-				OBJ_1922 /* tcp_client.cc in Sources */,
-				OBJ_1923 /* tcp_client_custom.cc in Sources */,
-				OBJ_1924 /* tcp_client_posix.cc in Sources */,
-				OBJ_1925 /* tcp_client_windows.cc in Sources */,
-				OBJ_1926 /* tcp_custom.cc in Sources */,
-				OBJ_1927 /* tcp_posix.cc in Sources */,
-				OBJ_1928 /* tcp_server.cc in Sources */,
-				OBJ_1929 /* tcp_server_custom.cc in Sources */,
-				OBJ_1930 /* tcp_server_posix.cc in Sources */,
-				OBJ_1931 /* tcp_server_utils_posix_common.cc in Sources */,
-				OBJ_1932 /* tcp_server_utils_posix_ifaddrs.cc in Sources */,
-				OBJ_1933 /* tcp_server_utils_posix_noifaddrs.cc in Sources */,
-				OBJ_1934 /* tcp_server_windows.cc in Sources */,
-				OBJ_1935 /* tcp_uv.cc in Sources */,
-				OBJ_1936 /* tcp_windows.cc in Sources */,
-				OBJ_1937 /* time_averaged_stats.cc in Sources */,
-				OBJ_1938 /* timer.cc in Sources */,
-				OBJ_1939 /* timer_custom.cc in Sources */,
-				OBJ_1940 /* timer_generic.cc in Sources */,
-				OBJ_1941 /* timer_heap.cc in Sources */,
-				OBJ_1942 /* timer_manager.cc in Sources */,
-				OBJ_1943 /* timer_uv.cc in Sources */,
-				OBJ_1944 /* udp_server.cc in Sources */,
-				OBJ_1945 /* unix_sockets_posix.cc in Sources */,
-				OBJ_1946 /* unix_sockets_posix_noop.cc in Sources */,
-				OBJ_1947 /* wakeup_fd_cv.cc in Sources */,
-				OBJ_1948 /* wakeup_fd_eventfd.cc in Sources */,
-				OBJ_1949 /* wakeup_fd_nospecial.cc in Sources */,
-				OBJ_1950 /* wakeup_fd_pipe.cc in Sources */,
-				OBJ_1951 /* wakeup_fd_posix.cc in Sources */,
-				OBJ_1952 /* json.cc in Sources */,
-				OBJ_1953 /* json_reader.cc in Sources */,
-				OBJ_1954 /* json_string.cc in Sources */,
-				OBJ_1955 /* json_writer.cc in Sources */,
-				OBJ_1956 /* basic_timers.cc in Sources */,
-				OBJ_1957 /* stap_timers.cc in Sources */,
-				OBJ_1958 /* security_context.cc in Sources */,
-				OBJ_1959 /* alts_credentials.cc in Sources */,
-				OBJ_1960 /* check_gcp_environment.cc in Sources */,
-				OBJ_1961 /* check_gcp_environment_linux.cc in Sources */,
-				OBJ_1962 /* check_gcp_environment_no_op.cc in Sources */,
-				OBJ_1963 /* check_gcp_environment_windows.cc in Sources */,
-				OBJ_1964 /* grpc_alts_credentials_client_options.cc in Sources */,
-				OBJ_1965 /* grpc_alts_credentials_options.cc in Sources */,
-				OBJ_1966 /* grpc_alts_credentials_server_options.cc in Sources */,
-				OBJ_1967 /* composite_credentials.cc in Sources */,
-				OBJ_1968 /* credentials.cc in Sources */,
-				OBJ_1969 /* credentials_metadata.cc in Sources */,
-				OBJ_1970 /* fake_credentials.cc in Sources */,
-				OBJ_1971 /* credentials_generic.cc in Sources */,
-				OBJ_1972 /* google_default_credentials.cc in Sources */,
-				OBJ_1973 /* iam_credentials.cc in Sources */,
-				OBJ_1974 /* json_token.cc in Sources */,
-				OBJ_1975 /* jwt_credentials.cc in Sources */,
-				OBJ_1976 /* jwt_verifier.cc in Sources */,
-				OBJ_1977 /* oauth2_credentials.cc in Sources */,
-				OBJ_1978 /* plugin_credentials.cc in Sources */,
-				OBJ_1979 /* ssl_credentials.cc in Sources */,
-				OBJ_1980 /* alts_security_connector.cc in Sources */,
-				OBJ_1981 /* security_connector.cc in Sources */,
-				OBJ_1982 /* client_auth_filter.cc in Sources */,
-				OBJ_1983 /* secure_endpoint.cc in Sources */,
-				OBJ_1984 /* security_handshaker.cc in Sources */,
-				OBJ_1985 /* server_auth_filter.cc in Sources */,
-				OBJ_1986 /* target_authority_table.cc in Sources */,
-				OBJ_1987 /* tsi_error.cc in Sources */,
-				OBJ_1988 /* json_util.cc in Sources */,
-				OBJ_1989 /* b64.cc in Sources */,
-				OBJ_1990 /* percent_encoding.cc in Sources */,
-				OBJ_1991 /* slice.cc in Sources */,
-				OBJ_1992 /* slice_buffer.cc in Sources */,
-				OBJ_1993 /* slice_intern.cc in Sources */,
-				OBJ_1994 /* slice_string_helpers.cc in Sources */,
-				OBJ_1995 /* api_trace.cc in Sources */,
-				OBJ_1996 /* byte_buffer.cc in Sources */,
-				OBJ_1997 /* byte_buffer_reader.cc in Sources */,
-				OBJ_1998 /* call.cc in Sources */,
-				OBJ_1999 /* call_details.cc in Sources */,
-				OBJ_2000 /* call_log_batch.cc in Sources */,
-				OBJ_2001 /* channel.cc in Sources */,
-				OBJ_2002 /* channel_init.cc in Sources */,
-				OBJ_2003 /* channel_ping.cc in Sources */,
-				OBJ_2004 /* channel_stack_type.cc in Sources */,
-				OBJ_2005 /* completion_queue.cc in Sources */,
-				OBJ_2006 /* completion_queue_factory.cc in Sources */,
-				OBJ_2007 /* event_string.cc in Sources */,
-				OBJ_2008 /* init.cc in Sources */,
-				OBJ_2009 /* init_secure.cc in Sources */,
-				OBJ_2010 /* lame_client.cc in Sources */,
-				OBJ_2011 /* metadata_array.cc in Sources */,
-				OBJ_2012 /* server.cc in Sources */,
-				OBJ_2013 /* validate_metadata.cc in Sources */,
-				OBJ_2014 /* version.cc in Sources */,
-				OBJ_2015 /* bdp_estimator.cc in Sources */,
-				OBJ_2016 /* byte_stream.cc in Sources */,
-				OBJ_2017 /* connectivity_state.cc in Sources */,
-				OBJ_2018 /* error_utils.cc in Sources */,
-				OBJ_2019 /* metadata.cc in Sources */,
-				OBJ_2020 /* metadata_batch.cc in Sources */,
-				OBJ_2021 /* pid_controller.cc in Sources */,
-				OBJ_2022 /* service_config.cc in Sources */,
-				OBJ_2023 /* static_metadata.cc in Sources */,
-				OBJ_2024 /* status_conversion.cc in Sources */,
-				OBJ_2025 /* status_metadata.cc in Sources */,
-				OBJ_2026 /* timeout_encoding.cc in Sources */,
-				OBJ_2027 /* transport.cc in Sources */,
-				OBJ_2028 /* transport_op_string.cc in Sources */,
-				OBJ_2029 /* grpc_plugin_registry.cc in Sources */,
-				OBJ_2030 /* aes_gcm.cc in Sources */,
-				OBJ_2031 /* gsec.cc in Sources */,
-				OBJ_2032 /* alts_counter.cc in Sources */,
-				OBJ_2033 /* alts_crypter.cc in Sources */,
-				OBJ_2034 /* alts_frame_protector.cc in Sources */,
-				OBJ_2035 /* alts_record_protocol_crypter_common.cc in Sources */,
-				OBJ_2036 /* alts_seal_privacy_integrity_crypter.cc in Sources */,
-				OBJ_2037 /* alts_unseal_privacy_integrity_crypter.cc in Sources */,
-				OBJ_2038 /* frame_handler.cc in Sources */,
-				OBJ_2039 /* alts_handshaker_client.cc in Sources */,
-				OBJ_2040 /* alts_handshaker_service_api.cc in Sources */,
-				OBJ_2041 /* alts_handshaker_service_api_util.cc in Sources */,
-				OBJ_2042 /* alts_tsi_event.cc in Sources */,
-				OBJ_2043 /* alts_tsi_handshaker.cc in Sources */,
-				OBJ_2044 /* alts_tsi_utils.cc in Sources */,
-				OBJ_2045 /* altscontext.pb.c in Sources */,
-				OBJ_2046 /* handshaker.pb.c in Sources */,
-				OBJ_2047 /* transport_security_common.pb.c in Sources */,
-				OBJ_2048 /* transport_security_common_api.cc in Sources */,
-				OBJ_2049 /* alts_grpc_integrity_only_record_protocol.cc in Sources */,
-				OBJ_2050 /* alts_grpc_privacy_integrity_record_protocol.cc in Sources */,
-				OBJ_2051 /* alts_grpc_record_protocol_common.cc in Sources */,
-				OBJ_2052 /* alts_iovec_record_protocol.cc in Sources */,
-				OBJ_2053 /* alts_zero_copy_grpc_protector.cc in Sources */,
-				OBJ_2054 /* alts_transport_security.cc in Sources */,
-				OBJ_2055 /* fake_transport_security.cc in Sources */,
-				OBJ_2056 /* ssl_session_boringssl.cc in Sources */,
-				OBJ_2057 /* ssl_session_cache.cc in Sources */,
-				OBJ_2058 /* ssl_session_openssl.cc in Sources */,
-				OBJ_2059 /* ssl_transport_security.cc in Sources */,
-				OBJ_2060 /* transport_security.cc in Sources */,
-				OBJ_2061 /* transport_security_adapter.cc in Sources */,
-				OBJ_2062 /* transport_security_grpc.cc in Sources */,
-				OBJ_2063 /* pb_common.c in Sources */,
-				OBJ_2064 /* pb_decode.c in Sources */,
-				OBJ_2065 /* pb_encode.c in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2072 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2073 /* AuthClientTests.swift in Sources */,
-				OBJ_2074 /* ClientTests.swift in Sources */,
-				OBJ_2075 /* DeviceClientTests.swift in Sources */,
-				OBJ_2076 /* MenuClientTests.swift in Sources */,
-				OBJ_2077 /* PlatformClientTests.swift in Sources */,
-				OBJ_2078 /* ShopClientTests.swift in Sources */,
-				OBJ_2079 /* TelemetryClientTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2098 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2099 /* accounting_Taxes.pb.swift in Sources */,
-				OBJ_2100 /* analytics_Context.pb.swift in Sources */,
-				OBJ_2101 /* analytics_Scope.pb.swift in Sources */,
-				OBJ_2102 /* analytics_commerce_OrderAnalytics.pb.swift in Sources */,
-				OBJ_2103 /* analytics_commerce_ProductAnalytics.pb.swift in Sources */,
-				OBJ_2104 /* analytics_commerce_SectionAnalytics.pb.swift in Sources */,
-				OBJ_2105 /* analytics_commerce_ShopAnalytics.pb.swift in Sources */,
-				OBJ_2106 /* analytics_consumption_Biodelivery.pb.swift in Sources */,
-				OBJ_2107 /* analytics_context_Application.pb.swift in Sources */,
-				OBJ_2108 /* analytics_context_Browser.pb.swift in Sources */,
-				OBJ_2109 /* analytics_context_Collection.pb.swift in Sources */,
-				OBJ_2110 /* analytics_context_Library.pb.swift in Sources */,
-				OBJ_2111 /* analytics_context_NativeDevice.pb.swift in Sources */,
-				OBJ_2112 /* analytics_context_OS.pb.swift in Sources */,
-				OBJ_2113 /* analytics_generic_Event.pb.swift in Sources */,
-				OBJ_2114 /* analytics_generic_Exception.pb.swift in Sources */,
-				OBJ_2115 /* analytics_identity_UserAnalytics.pb.swift in Sources */,
-				OBJ_2116 /* analytics_search_SearchProperty.pb.swift in Sources */,
-				OBJ_2117 /* analytics_stats_OrderStats.pb.swift in Sources */,
-				222EF14D21C7268D0008D96B /* identity_bioprint_Weights.pb.swift in Sources */,
-				OBJ_2118 /* analytics_stats_SessionStats.pb.swift in Sources */,
-				OBJ_2119 /* analytics_stream_Filter.pb.swift in Sources */,
-				OBJ_2120 /* auth_v1beta1_AuthService_Beta1.pb.swift in Sources */,
-				OBJ_2121 /* base_Compression.pb.swift in Sources */,
-				OBJ_2122 /* base_Language.pb.swift in Sources */,
-				OBJ_2123 /* base_ProductKey.pb.swift in Sources */,
-				OBJ_2124 /* base_ProductKind.pb.swift in Sources */,
-				OBJ_2126 /* commerce_Currency.pb.swift in Sources */,
-				222EF14F21C7268D0008D96B /* identity_bioprint_Bioprint.pb.swift in Sources */,
-				OBJ_2127 /* commerce_Customer.pb.swift in Sources */,
-				OBJ_2128 /* commerce_Delivery.pb.swift in Sources */,
-				OBJ_2129 /* commerce_Discounts.pb.swift in Sources */,
-				OBJ_2130 /* commerce_Item.pb.swift in Sources */,
-				OBJ_2131 /* commerce_Order.pb.swift in Sources */,
-				OBJ_2132 /* commerce_Purchase.pb.swift in Sources */,
-				OBJ_2133 /* commerce_payments_Payment.pb.swift in Sources */,
-				OBJ_2134 /* comms_Comms.pb.swift in Sources */,
-				OBJ_2135 /* comms_CommsTask.pb.swift in Sources */,
-				OBJ_2136 /* comms_Email.pb.swift in Sources */,
-				OBJ_2137 /* comms_SMS.pb.swift in Sources */,
-				OBJ_2138 /* contact_ContactInfo.pb.swift in Sources */,
-				OBJ_2139 /* contact_EmailAddress.pb.swift in Sources */,
-				OBJ_2140 /* contact_PhoneNumber.pb.swift in Sources */,
-				OBJ_2141 /* contact_Website.pb.swift in Sources */,
-				OBJ_2142 /* content_Brand.pb.swift in Sources */,
-				OBJ_2143 /* content_Colors.pb.swift in Sources */,
-				OBJ_2144 /* content_Content.pb.swift in Sources */,
-				OBJ_2145 /* content_MaterialsData.pb.swift in Sources */,
-				OBJ_2146 /* content_Name.pb.swift in Sources */,
-				OBJ_2147 /* content_ProductContent.pb.swift in Sources */,
-				OBJ_2148 /* core_Datamodel.pb.swift in Sources */,
-				OBJ_2149 /* crypto_Container.pb.swift in Sources */,
-				OBJ_2150 /* crypto_Signature.pb.swift in Sources */,
-				OBJ_2151 /* crypto_primitives_Integrity.pb.swift in Sources */,
-				OBJ_2152 /* crypto_primitives_Keys.pb.swift in Sources */,
-				OBJ_2154 /* device_Device.pb.swift in Sources */,
-				OBJ_2155 /* devices_v1beta1_DevicesService_Beta1.pb.swift in Sources */,
-				OBJ_2156 /* geo_Address.pb.swift in Sources */,
-				OBJ_2157 /* geo_Country.pb.swift in Sources */,
-				OBJ_2158 /* geo_Distance.pb.swift in Sources */,
-				OBJ_2159 /* geo_Geohash.pb.swift in Sources */,
-				OBJ_2160 /* geo_Location.pb.swift in Sources */,
-				OBJ_2161 /* geo_Point.pb.swift in Sources */,
-				OBJ_2162 /* geo_Province.pb.swift in Sources */,
-				OBJ_2163 /* geo_USState.pb.swift in Sources */,
-				OBJ_2164 /* geo_usa_ca_CACounty.pb.swift in Sources */,
-				OBJ_2165 /* google_api_annotations.pb.swift in Sources */,
-				OBJ_2166 /* google_api_http.pb.swift in Sources */,
-				OBJ_2167 /* google_protobuf_descriptor.pb.swift in Sources */,
-				OBJ_2168 /* identity_ID.pb.swift in Sources */,
-				OBJ_2169 /* identity_IDMedia.pb.swift in Sources */,
-				OBJ_2170 /* identity_Membership.pb.swift in Sources */,
-				OBJ_2171 /* identity_MembershipKey.pb.swift in Sources */,
-				OBJ_2172 /* identity_StaffUser.pb.swift in Sources */,
-				OBJ_2173 /* identity_User.pb.swift in Sources */,
-				OBJ_2174 /* identity_UserKey.pb.swift in Sources */,
-				OBJ_2179 /* identity_ids_Passport.pb.swift in Sources */,
-				OBJ_2180 /* identity_ids_USDL.pb.swift in Sources */,
-				OBJ_2181 /* identity_ids_UserDoctorRec.pb.swift in Sources */,
-				OBJ_2182 /* identity_industry_DashboardStaffSettings.pb.swift in Sources */,
-				OBJ_2183 /* identity_industry_POSStaffSettings.pb.swift in Sources */,
-				OBJ_2184 /* identity_industry_StaffSettings.pb.swift in Sources */,
-				OBJ_2185 /* identity_pass_Pass.pb.swift in Sources */,
-				OBJ_2186 /* identity_pass_PassKey.pb.swift in Sources */,
-				OBJ_2187 /* identity_v1beta1_IdentityService_Beta1.pb.swift in Sources */,
-				OBJ_2188 /* inventory_InventoryLocation.pb.swift in Sources */,
-				OBJ_2189 /* inventory_InventoryProduct.pb.swift in Sources */,
-				OBJ_2190 /* ledger_Account.pb.swift in Sources */,
-				OBJ_2191 /* ledger_Asset.pb.swift in Sources */,
-				OBJ_2192 /* ledger_Transaction.pb.swift in Sources */,
-				OBJ_2194 /* licensing_Licensure.pb.swift in Sources */,
-				OBJ_2195 /* marketing_Campaign.pb.swift in Sources */,
-				OBJ_2196 /* marketing_Targeting.pb.swift in Sources */,
-				OBJ_2198 /* media_MediaItem.pb.swift in Sources */,
-				OBJ_2199 /* media_MediaKey.pb.swift in Sources */,
-				OBJ_2200 /* media_MediaOrientation.pb.swift in Sources */,
-				OBJ_2201 /* media_MediaType.pb.swift in Sources */,
-				OBJ_2202 /* media_v1beta1_MediaService_Beta1.pb.swift in Sources */,
-				OBJ_2203 /* media_v1beta1_MediaTask.pb.swift in Sources */,
-				OBJ_2204 /* menu_v1beta1_MenuService_Beta1.pb.swift in Sources */,
-				OBJ_2205 /* oauth_AuthorizationScope.pb.swift in Sources */,
-				OBJ_2206 /* oauth_Client.pb.swift in Sources */,
-				OBJ_2207 /* partner_LocationKey.pb.swift in Sources */,
-				OBJ_2208 /* partner_Partner.pb.swift in Sources */,
-				OBJ_2209 /* partner_PartnerDevice.pb.swift in Sources */,
-				OBJ_2210 /* partner_PartnerFlags.pb.swift in Sources */,
-				OBJ_2211 /* partner_PartnerKey.pb.swift in Sources */,
-				OBJ_2212 /* partner_PartnerLocation.pb.swift in Sources */,
-				OBJ_2213 /* partner_PartnerScope.pb.swift in Sources */,
-				OBJ_2214 /* partner_integrations_GSuiteSettings.pb.swift in Sources */,
-				OBJ_2215 /* partner_integrations_GreenbitsSettings.pb.swift in Sources */,
-				OBJ_2216 /* partner_integrations_IntegrationSettings.pb.swift in Sources */,
-				OBJ_2217 /* partner_integrations_MailchimpSettings.pb.swift in Sources */,
-				OBJ_2218 /* partner_integrations_OnFleetSettings.pb.swift in Sources */,
-				OBJ_2219 /* partner_integrations_SendgridSettings.pb.swift in Sources */,
-				OBJ_2220 /* partner_integrations_TreezSettings.pb.swift in Sources */,
-				OBJ_2221 /* partner_integrations_TwilioSettings.pb.swift in Sources */,
-				OBJ_2222 /* partner_settings_PartnerLocationSettings.pb.swift in Sources */,
-				OBJ_2223 /* partner_settings_PartnerSettings.pb.swift in Sources */,
-				OBJ_2225 /* person_Person.pb.swift in Sources */,
-				OBJ_2226 /* person_PersonName.pb.swift in Sources */,
-				OBJ_2227 /* platform_v1_PlatformService_v1.pb.swift in Sources */,
-				OBJ_2228 /* pos_PointOfSale.pb.swift in Sources */,
-				OBJ_2229 /* pos_v1beta1_POSService_Beta1.pb.swift in Sources */,
-				OBJ_2230 /* products_Apothecary.pb.swift in Sources */,
-				OBJ_2231 /* products_Cartridge.pb.swift in Sources */,
-				222EF14E21C7268D0008D96B /* identity_bioprint_Affinities.pb.swift in Sources */,
-				OBJ_2232 /* products_Edible.pb.swift in Sources */,
-				OBJ_2233 /* products_Extract.pb.swift in Sources */,
-				222EF14C21C7268D0008D96B /* identity_bioprint_Aspects.pb.swift in Sources */,
-				OBJ_2234 /* products_Flower.pb.swift in Sources */,
-				OBJ_2235 /* products_Merchandise.pb.swift in Sources */,
-				OBJ_2236 /* products_Plant.pb.swift in Sources */,
-				OBJ_2237 /* products_Preroll.pb.swift in Sources */,
-				OBJ_2238 /* products_distribution_DistributionChannel.pb.swift in Sources */,
-				OBJ_2239 /* products_menu_Menu.pb.swift in Sources */,
-				OBJ_2240 /* products_menu_Section.pb.swift in Sources */,
-				OBJ_2241 /* protoc-gen-swagger_options_openapiv2.pb.swift in Sources */,
-				OBJ_2242 /* protoc-gen-swagger_options_swagger.pb.swift in Sources */,
-				OBJ_2243 /* proximity_BluetoothBeacon.pb.swift in Sources */,
-				OBJ_2244 /* regulatory_usa_ca_CAAgency.pb.swift in Sources */,
-				OBJ_2245 /* search_SearchResult.pb.swift in Sources */,
-				OBJ_2246 /* search_SearchSpec.pb.swift in Sources */,
-				OBJ_2247 /* security_DeviceTicket.pb.swift in Sources */,
-				OBJ_2248 /* security_IdentityToken.pb.swift in Sources */,
-				OBJ_2249 /* security_Token.pb.swift in Sources */,
-				OBJ_2250 /* security_access_PartnerPermissions.pb.swift in Sources */,
-				OBJ_2251 /* services_ServiceStatus.pb.swift in Sources */,
-				OBJ_2252 /* shop_v1_ShopService_v1.pb.swift in Sources */,
-				OBJ_2253 /* structs_Genetics.pb.swift in Sources */,
-				OBJ_2254 /* structs_Grow.pb.swift in Sources */,
-				OBJ_2255 /* structs_ProductFlags.pb.swift in Sources */,
-				OBJ_2256 /* structs_Shelf.pb.swift in Sources */,
-				OBJ_2257 /* structs_Species.pb.swift in Sources */,
-				OBJ_2258 /* structs_Version.pb.swift in Sources */,
-				OBJ_2259 /* structs_labtesting_TestResults.pb.swift in Sources */,
-				OBJ_2260 /* structs_labtesting_TestValue.pb.swift in Sources */,
-				OBJ_2261 /* structs_pricing_PricingDescriptor.pb.swift in Sources */,
-				OBJ_2262 /* structs_pricing_SaleDescriptor.pb.swift in Sources */,
-				OBJ_2263 /* telemetry_v1beta4_GenericEvents_Beta4.pb.swift in Sources */,
-				OBJ_2264 /* telemetry_v1beta4_TelemetryEvent_Beta4.pb.swift in Sources */,
-				OBJ_2265 /* telemetry_v1beta4_TelemetryService_Beta4.pb.swift in Sources */,
-				OBJ_2266 /* temporal_Date.pb.swift in Sources */,
-				OBJ_2267 /* temporal_Duration.pb.swift in Sources */,
-				OBJ_2268 /* temporal_Instant.pb.swift in Sources */,
-				OBJ_2269 /* temporal_Interval.pb.swift in Sources */,
-				OBJ_2270 /* temporal_Schedule.pb.swift in Sources */,
-				OBJ_2271 /* temporal_Time.pb.swift in Sources */,
-				OBJ_2272 /* temporal_Timehash.pb.swift in Sources */,
-				OBJ_2273 /* wallet_v1_WalletService_v1.pb.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2280 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2281 /* ModelTool.swift in Sources */,
-				OBJ_2282 /* SchemaTests+Codec.swift in Sources */,
-				OBJ_2283 /* SchemaTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2302 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2303 /* ByteBuffer.swift in Sources */,
-				OBJ_2304 /* Call.swift in Sources */,
-				OBJ_2305 /* CallError.swift in Sources */,
-				OBJ_2306 /* CallResult.swift in Sources */,
-				OBJ_2307 /* Channel.swift in Sources */,
-				OBJ_2308 /* ChannelArgument.swift in Sources */,
-				OBJ_2309 /* CompletionQueue.swift in Sources */,
-				OBJ_2310 /* Handler.swift in Sources */,
-				OBJ_2311 /* Metadata.swift in Sources */,
-				OBJ_2312 /* Mutex.swift in Sources */,
-				OBJ_2313 /* Operation.swift in Sources */,
-				OBJ_2314 /* OperationGroup.swift in Sources */,
-				OBJ_2315 /* Roots.swift in Sources */,
-				OBJ_2316 /* Server.swift in Sources */,
-				OBJ_2317 /* ServerStatus.swift in Sources */,
-				OBJ_2318 /* gRPC.swift in Sources */,
-				OBJ_2319 /* ClientCall.swift in Sources */,
-				OBJ_2320 /* ClientCallBidirectionalStreaming.swift in Sources */,
-				OBJ_2321 /* ClientCallClientStreaming.swift in Sources */,
-				OBJ_2322 /* ClientCallServerStreaming.swift in Sources */,
-				OBJ_2323 /* ClientCallUnary.swift in Sources */,
-				OBJ_2324 /* RPCError.swift in Sources */,
-				OBJ_2325 /* ServerSession.swift in Sources */,
-				OBJ_2326 /* ServerSessionBidirectionalStreaming.swift in Sources */,
-				OBJ_2327 /* ServerSessionClientStreaming.swift in Sources */,
-				OBJ_2328 /* ServerSessionServerStreaming.swift in Sources */,
-				OBJ_2329 /* ServerSessionUnary.swift in Sources */,
-				OBJ_2330 /* ServiceClient.swift in Sources */,
-				OBJ_2331 /* ServiceProvider.swift in Sources */,
-				OBJ_2332 /* ServiceServer.swift in Sources */,
-				OBJ_2333 /* StreamReceiving.swift in Sources */,
-				OBJ_2334 /* StreamSending.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2346 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2347 /* Package.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2351 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2352 /* AnyMessageStorage.swift in Sources */,
-				OBJ_2353 /* AnyUnpackError.swift in Sources */,
-				OBJ_2354 /* BinaryDecoder.swift in Sources */,
-				OBJ_2355 /* BinaryDecodingError.swift in Sources */,
-				OBJ_2356 /* BinaryDecodingOptions.swift in Sources */,
-				OBJ_2357 /* BinaryDelimited.swift in Sources */,
-				OBJ_2358 /* BinaryEncoder.swift in Sources */,
-				OBJ_2359 /* BinaryEncodingError.swift in Sources */,
-				OBJ_2360 /* BinaryEncodingSizeVisitor.swift in Sources */,
-				OBJ_2361 /* BinaryEncodingVisitor.swift in Sources */,
-				OBJ_2362 /* CustomJSONCodable.swift in Sources */,
-				OBJ_2363 /* Decoder.swift in Sources */,
-				OBJ_2364 /* DoubleFormatter.swift in Sources */,
-				OBJ_2365 /* Enum.swift in Sources */,
-				OBJ_2366 /* ExtensibleMessage.swift in Sources */,
-				OBJ_2367 /* ExtensionFieldValueSet.swift in Sources */,
-				OBJ_2368 /* ExtensionFields.swift in Sources */,
-				OBJ_2369 /* ExtensionMap.swift in Sources */,
-				OBJ_2370 /* FieldTag.swift in Sources */,
-				OBJ_2371 /* FieldTypes.swift in Sources */,
-				OBJ_2372 /* Google_Protobuf_Any+Extensions.swift in Sources */,
-				OBJ_2373 /* Google_Protobuf_Any+Registry.swift in Sources */,
-				OBJ_2374 /* Google_Protobuf_Duration+Extensions.swift in Sources */,
-				OBJ_2375 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */,
-				OBJ_2376 /* Google_Protobuf_ListValue+Extensions.swift in Sources */,
-				OBJ_2377 /* Google_Protobuf_Struct+Extensions.swift in Sources */,
-				OBJ_2378 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */,
-				OBJ_2379 /* Google_Protobuf_Value+Extensions.swift in Sources */,
-				OBJ_2380 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
-				OBJ_2381 /* HashVisitor.swift in Sources */,
-				OBJ_2382 /* Internal.swift in Sources */,
-				OBJ_2383 /* JSONDecoder.swift in Sources */,
-				OBJ_2384 /* JSONDecodingError.swift in Sources */,
-				OBJ_2385 /* JSONDecodingOptions.swift in Sources */,
-				OBJ_2386 /* JSONEncoder.swift in Sources */,
-				OBJ_2387 /* JSONEncodingError.swift in Sources */,
-				OBJ_2388 /* JSONEncodingVisitor.swift in Sources */,
-				OBJ_2389 /* JSONMapEncodingVisitor.swift in Sources */,
-				OBJ_2390 /* JSONScanner.swift in Sources */,
-				OBJ_2391 /* MathUtils.swift in Sources */,
-				OBJ_2392 /* Message+AnyAdditions.swift in Sources */,
-				OBJ_2393 /* Message+BinaryAdditions.swift in Sources */,
-				OBJ_2394 /* Message+JSONAdditions.swift in Sources */,
-				OBJ_2395 /* Message+JSONArrayAdditions.swift in Sources */,
-				OBJ_2396 /* Message+TextFormatAdditions.swift in Sources */,
-				OBJ_2397 /* Message.swift in Sources */,
-				OBJ_2398 /* MessageExtension.swift in Sources */,
-				OBJ_2399 /* NameMap.swift in Sources */,
-				OBJ_2400 /* ProtoNameProviding.swift in Sources */,
-				OBJ_2401 /* ProtobufAPIVersionCheck.swift in Sources */,
-				OBJ_2402 /* ProtobufMap.swift in Sources */,
-				OBJ_2403 /* SelectiveVisitor.swift in Sources */,
-				OBJ_2404 /* SimpleExtensionMap.swift in Sources */,
-				OBJ_2405 /* StringUtils.swift in Sources */,
-				OBJ_2406 /* TextFormatDecoder.swift in Sources */,
-				OBJ_2407 /* TextFormatDecodingError.swift in Sources */,
-				OBJ_2408 /* TextFormatEncoder.swift in Sources */,
-				OBJ_2409 /* TextFormatEncodingVisitor.swift in Sources */,
-				OBJ_2410 /* TextFormatScanner.swift in Sources */,
-				OBJ_2411 /* TimeUtils.swift in Sources */,
-				OBJ_2412 /* UnknownStorage.swift in Sources */,
-				OBJ_2413 /* Varint.swift in Sources */,
-				OBJ_2414 /* Version.swift in Sources */,
-				OBJ_2415 /* Visitor.swift in Sources */,
-				OBJ_2416 /* WireFormat.swift in Sources */,
-				OBJ_2417 /* ZigZag.swift in Sources */,
-				OBJ_2418 /* any.pb.swift in Sources */,
-				OBJ_2419 /* api.pb.swift in Sources */,
-				OBJ_2420 /* duration.pb.swift in Sources */,
-				OBJ_2421 /* empty.pb.swift in Sources */,
-				OBJ_2422 /* field_mask.pb.swift in Sources */,
-				OBJ_2423 /* source_context.pb.swift in Sources */,
-				OBJ_2424 /* struct.pb.swift in Sources */,
-				OBJ_2425 /* timestamp.pb.swift in Sources */,
-				OBJ_2426 /* type.pb.swift in Sources */,
-				OBJ_2427 /* wrappers.pb.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_2433 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_2434 /* Package.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		OBJ_1338 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::BloomboxServices" /* BloomboxServices */;
-			targetProxy = 222EF12621C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1340 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::SwiftGRPC" /* SwiftGRPC */;
-			targetProxy = 222EF13121C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1342 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::CgRPC" /* CgRPC */;
-			targetProxy = 222EF13221C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1344 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::BoringSSL" /* BoringSSL */;
-			targetProxy = 222EF13321C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1346 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::OpenCannabis" /* OpenCannabis */;
-			targetProxy = 222EF13421C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1348 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftProtobuf::SwiftProtobuf" /* SwiftProtobuf */;
-			targetProxy = 222EF13521C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1360 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::SchemaTests" /* SchemaTests */;
-			targetProxy = 222EF14421C6F81F0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1362 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::ClientTests" /* ClientTests */;
-			targetProxy = 222EF14521C6F81F0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1384 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::SwiftGRPC" /* SwiftGRPC */;
-			targetProxy = 222EF12721C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1385 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::CgRPC" /* CgRPC */;
-			targetProxy = 222EF12C21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1386 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::BoringSSL" /* BoringSSL */;
-			targetProxy = 222EF12D21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1387 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::OpenCannabis" /* OpenCannabis */;
-			targetProxy = 222EF12E21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_1388 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftProtobuf::SwiftProtobuf" /* SwiftProtobuf */;
-			targetProxy = 222EF13021C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2068 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::BoringSSL" /* BoringSSL */;
-			targetProxy = 222EF12A21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2088 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::Bloombox" /* Bloombox */;
-			targetProxy = 222EF13621C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2089 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::BloomboxServices" /* BloomboxServices */;
-			targetProxy = 222EF13721C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2090 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::SwiftGRPC" /* SwiftGRPC */;
-			targetProxy = 222EF13821C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2091 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::CgRPC" /* CgRPC */;
-			targetProxy = 222EF13921C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2092 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::BoringSSL" /* BoringSSL */;
-			targetProxy = 222EF13A21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2093 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::OpenCannabis" /* OpenCannabis */;
-			targetProxy = 222EF13B21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2094 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftProtobuf::SwiftProtobuf" /* SwiftProtobuf */;
-			targetProxy = 222EF13C21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2276 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftProtobuf::SwiftProtobuf" /* SwiftProtobuf */;
-			targetProxy = 222EF12F21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2292 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::Bloombox" /* Bloombox */;
-			targetProxy = 222EF13D21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2293 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::BloomboxServices" /* BloomboxServices */;
-			targetProxy = 222EF13E21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2294 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::SwiftGRPC" /* SwiftGRPC */;
-			targetProxy = 222EF13F21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2295 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::CgRPC" /* CgRPC */;
-			targetProxy = 222EF14021C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2296 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::BoringSSL" /* BoringSSL */;
-			targetProxy = 222EF14121C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2297 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Bloombox::OpenCannabis" /* OpenCannabis */;
-			targetProxy = 222EF14221C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2298 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftProtobuf::SwiftProtobuf" /* SwiftProtobuf */;
-			targetProxy = 222EF14321C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2339 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftProtobuf::SwiftProtobuf" /* SwiftProtobuf */;
-			targetProxy = 222EF12821C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2340 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::CgRPC" /* CgRPC */;
-			targetProxy = 222EF12921C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-		OBJ_2341 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "SwiftGRPC::BoringSSL" /* BoringSSL */;
-			targetProxy = 222EF12B21C6F81E0008D96B /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin XCBuildConfiguration section */
-		OBJ_1309 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-					"$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/Bloombox_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
-				PRODUCT_BUNDLE_IDENTIFIER = Bloombox;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = Bloombox;
-			};
-			name = Debug;
-		};
-		OBJ_1310 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-					"$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/Bloombox_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
-				PRODUCT_BUNDLE_IDENTIFIER = Bloombox;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = Bloombox;
-			};
-			name = Release;
-		};
-		OBJ_1352 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Debug;
-		};
-		OBJ_1353 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Release;
-		};
-		OBJ_1358 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		OBJ_1359 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		OBJ_1365 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-					"$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/BloomboxServices_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
-				PRODUCT_BUNDLE_IDENTIFIER = BloomboxServices;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = BloomboxServices;
-			};
-			name = Debug;
-		};
-		OBJ_1366 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-					"$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/BloomboxServices_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
-				PRODUCT_BUNDLE_IDENTIFIER = BloomboxServices;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = BloomboxServices;
-			};
-			name = Release;
-		};
-		OBJ_1390 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
-				DEFINES_MODULE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/BoringSSL_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = BoringSSL;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				TARGET_NAME = BoringSSL;
-			};
-			name = Debug;
-		};
-		OBJ_1391 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
-				DEFINES_MODULE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/BoringSSL_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = BoringSSL;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				TARGET_NAME = BoringSSL;
-			};
-			name = Release;
-		};
-		OBJ_1709 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
-				DEFINES_MODULE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/CgRPC_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = CgRPC;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				TARGET_NAME = CgRPC;
-			};
-			name = Debug;
-		};
-		OBJ_1710 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
-				DEFINES_MODULE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/CgRPC_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = CgRPC;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				TARGET_NAME = CgRPC;
-			};
-			name = Release;
-		};
-		OBJ_2070 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-					"$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/ClientTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = ClientTests;
-			};
-			name = Debug;
-		};
-		OBJ_2071 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-					"$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/ClientTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = ClientTests;
-			};
-			name = Release;
-		};
-		OBJ_2096 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = Bloombox.xcodeproj/OpenCannabis_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = OpenCannabis;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = OpenCannabis;
-			};
-			name = Debug;
-		};
-		OBJ_2097 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = Bloombox.xcodeproj/OpenCannabis_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = OpenCannabis;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = OpenCannabis;
-			};
-			name = Release;
-		};
-		OBJ_2278 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-					"$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/SchemaTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = SchemaTests;
-			};
-			name = Debug;
-		};
-		OBJ_2279 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-					"$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/SchemaTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = SchemaTests;
-			};
-			name = Release;
-		};
-		OBJ_2300 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-					"$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/SwiftGRPC_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
-				PRODUCT_BUNDLE_IDENTIFIER = SwiftGRPC;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = SwiftGRPC;
-			};
-			name = Debug;
-		};
-		OBJ_2301 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
-					"$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
-					"$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
-					"$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL",
-				);
-				INFOPLIST_FILE = Bloombox.xcodeproj/SwiftGRPC_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lz",
-				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -Xcc -fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap -Xcc -fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
-				PRODUCT_BUNDLE_IDENTIFIER = SwiftGRPC;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = SwiftGRPC;
-			};
-			name = Release;
-		};
-		OBJ_2344 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Debug;
-		};
-		OBJ_2345 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Release;
-		};
-		OBJ_2349 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = Bloombox.xcodeproj/SwiftProtobuf_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = SwiftProtobuf;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = SwiftProtobuf;
-			};
-			name = Debug;
-		};
-		OBJ_2350 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = Bloombox.xcodeproj/SwiftProtobuf_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				OTHER_CFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = "$(inherited)";
-				OTHER_SWIFT_FLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = SwiftProtobuf;
-				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 4.2;
-				TARGET_NAME = SwiftProtobuf;
-			};
-			name = Release;
-		};
-		OBJ_2431 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Debug;
-		};
-		OBJ_2432 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
-				SWIFT_VERSION = 4.2;
-			};
-			name = Release;
-		};
-		OBJ_3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = YES;
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_NS_ASSERTIONS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-DXcode";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE DEBUG";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		OBJ_4 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = YES;
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = YES;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_OPTIMIZATION_LEVEL = s;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_SWIFT_FLAGS = "-DXcode";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		OBJ_1308 /* Build configuration list for PBXNativeTarget "Bloombox" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_1309 /* Debug */,
-				OBJ_1310 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_1351 /* Build configuration list for PBXNativeTarget "BloomboxPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_1352 /* Debug */,
-				OBJ_1353 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_1357 /* Build configuration list for PBXAggregateTarget "BloomboxPackageTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_1358 /* Debug */,
-				OBJ_1359 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_1364 /* Build configuration list for PBXNativeTarget "BloomboxServices" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_1365 /* Debug */,
-				OBJ_1366 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_1389 /* Build configuration list for PBXNativeTarget "BoringSSL" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_1390 /* Debug */,
-				OBJ_1391 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_1708 /* Build configuration list for PBXNativeTarget "CgRPC" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_1709 /* Debug */,
-				OBJ_1710 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_2 /* Build configuration list for PBXProject "Bloombox" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_3 /* Debug */,
-				OBJ_4 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_2069 /* Build configuration list for PBXNativeTarget "ClientTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_2070 /* Debug */,
-				OBJ_2071 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_2095 /* Build configuration list for PBXNativeTarget "OpenCannabis" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_2096 /* Debug */,
-				OBJ_2097 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_2277 /* Build configuration list for PBXNativeTarget "SchemaTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_2278 /* Debug */,
-				OBJ_2279 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_2299 /* Build configuration list for PBXNativeTarget "SwiftGRPC" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_2300 /* Debug */,
-				OBJ_2301 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_2343 /* Build configuration list for PBXNativeTarget "SwiftGRPCPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_2344 /* Debug */,
-				OBJ_2345 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_2348 /* Build configuration list for PBXNativeTarget "SwiftProtobuf" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_2349 /* Debug */,
-				OBJ_2350 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		OBJ_2430 /* Build configuration list for PBXNativeTarget "SwiftProtobufPackageDescription" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				OBJ_2431 /* Debug */,
-				OBJ_2432 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = OBJ_1 /* Project object */;
+   archiveVersion = "1";
+   objectVersion = "46";
+   objects = {
+      "Bloombox::Bloombox" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1304";
+         buildPhases = (
+            "OBJ_1307",
+            "OBJ_1328"
+         );
+         dependencies = (
+            "OBJ_1335",
+            "OBJ_1337",
+            "OBJ_1339",
+            "OBJ_1341",
+            "OBJ_1343",
+            "OBJ_1345"
+         );
+         name = "Bloombox";
+         productName = "Bloombox";
+         productReference = "Bloombox::Bloombox::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "Bloombox::Bloombox::Product" = {
+         isa = "PBXFileReference";
+         path = "Bloombox.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "Bloombox::BloomboxPackageTests::ProductTarget" = {
+         isa = "PBXAggregateTarget";
+         buildConfigurationList = "OBJ_1354";
+         buildPhases = (
+         );
+         dependencies = (
+            "OBJ_1357",
+            "OBJ_1359"
+         );
+         name = "BloomboxPackageTests";
+         productName = "BloomboxPackageTests";
+      };
+      "Bloombox::BloomboxServices" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1361";
+         buildPhases = (
+            "OBJ_1364",
+            "OBJ_1375"
+         );
+         dependencies = (
+            "OBJ_1381",
+            "OBJ_1382",
+            "OBJ_1383",
+            "OBJ_1384",
+            "OBJ_1385"
+         );
+         name = "BloomboxServices";
+         productName = "BloomboxServices";
+         productReference = "Bloombox::BloomboxServices::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "Bloombox::BloomboxServices::Product" = {
+         isa = "PBXFileReference";
+         path = "BloomboxServices.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "Bloombox::ClientTests" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_2066";
+         buildPhases = (
+            "OBJ_2069",
+            "OBJ_2077"
+         );
+         dependencies = (
+            "OBJ_2085",
+            "OBJ_2086",
+            "OBJ_2087",
+            "OBJ_2088",
+            "OBJ_2089",
+            "OBJ_2090",
+            "OBJ_2091"
+         );
+         name = "ClientTests";
+         productName = "ClientTests";
+         productReference = "Bloombox::ClientTests::Product";
+         productType = "com.apple.product-type.bundle.unit-test";
+      };
+      "Bloombox::ClientTests::Product" = {
+         isa = "PBXFileReference";
+         path = "ClientTests.xctest";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "Bloombox::OpenCannabis" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_2092";
+         buildPhases = (
+            "OBJ_2095",
+            "OBJ_2266"
+         );
+         dependencies = (
+            "OBJ_2268"
+         );
+         name = "OpenCannabis";
+         productName = "OpenCannabis";
+         productReference = "Bloombox::OpenCannabis::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "Bloombox::OpenCannabis::Product" = {
+         isa = "PBXFileReference";
+         path = "OpenCannabis.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "Bloombox::SchemaTests" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_2269";
+         buildPhases = (
+            "OBJ_2272",
+            "OBJ_2276"
+         );
+         dependencies = (
+            "OBJ_2284",
+            "OBJ_2285",
+            "OBJ_2286",
+            "OBJ_2287",
+            "OBJ_2288",
+            "OBJ_2289",
+            "OBJ_2290"
+         );
+         name = "SchemaTests";
+         productName = "SchemaTests";
+         productReference = "Bloombox::SchemaTests::Product";
+         productType = "com.apple.product-type.bundle.unit-test";
+      };
+      "Bloombox::SchemaTests::Product" = {
+         isa = "PBXFileReference";
+         path = "SchemaTests.xctest";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "Bloombox::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1348";
+         buildPhases = (
+            "OBJ_1351"
+         );
+         dependencies = (
+         );
+         name = "BloomboxPackageDescription";
+         productName = "BloomboxPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "OBJ_1" = {
+         isa = "PBXProject";
+         attributes = {
+            LastUpgradeCheck = "9999";
+         };
+         buildConfigurationList = "OBJ_2";
+         compatibilityVersion = "Xcode 3.2";
+         developmentRegion = "English";
+         hasScannedForEncodings = "0";
+         knownRegions = (
+            "en"
+         );
+         mainGroup = "OBJ_5";
+         productRefGroup = "OBJ_1293";
+         projectDirPath = ".";
+         targets = (
+            "Bloombox::Bloombox",
+            "Bloombox::SwiftPMPackageDescription",
+            "Bloombox::BloomboxPackageTests::ProductTarget",
+            "Bloombox::BloomboxServices",
+            "SwiftGRPC::BoringSSL",
+            "SwiftGRPC::CgRPC",
+            "Bloombox::ClientTests",
+            "Bloombox::OpenCannabis",
+            "Bloombox::SchemaTests",
+            "SwiftGRPC::SwiftGRPC",
+            "SwiftGRPC::SwiftPMPackageDescription",
+            "SwiftProtobuf::SwiftProtobuf",
+            "SwiftProtobuf::SwiftPMPackageDescription"
+         );
+      };
+      "OBJ_10" = {
+         isa = "PBXFileReference";
+         path = "analytics_Context.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_100" = {
+         isa = "PBXFileReference";
+         path = "ledger_Transaction.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1000" = {
+         isa = "PBXFileReference";
+         path = "wakeup_fd_nospecial.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1001" = {
+         isa = "PBXFileReference";
+         path = "wakeup_fd_pipe.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1002" = {
+         isa = "PBXFileReference";
+         path = "wakeup_fd_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1003" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1004",
+            "OBJ_1005",
+            "OBJ_1006",
+            "OBJ_1007"
+         );
+         name = "json";
+         path = "json";
+         sourceTree = "<group>";
+      };
+      "OBJ_1004" = {
+         isa = "PBXFileReference";
+         path = "json.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1005" = {
+         isa = "PBXFileReference";
+         path = "json_reader.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1006" = {
+         isa = "PBXFileReference";
+         path = "json_string.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1007" = {
+         isa = "PBXFileReference";
+         path = "json_writer.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1008" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1009",
+            "OBJ_1010"
+         );
+         name = "profiling";
+         path = "profiling";
+         sourceTree = "<group>";
+      };
+      "OBJ_1009" = {
+         isa = "PBXFileReference";
+         path = "basic_timers.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_101" = {
+         isa = "PBXFileReference";
+         path = "licensing_Licensure.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1010" = {
+         isa = "PBXFileReference";
+         path = "stap_timers.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1011" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1012",
+            "OBJ_1014",
+            "OBJ_1045",
+            "OBJ_1048",
+            "OBJ_1055"
+         );
+         name = "security";
+         path = "security";
+         sourceTree = "<group>";
+      };
+      "OBJ_1012" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1013"
+         );
+         name = "context";
+         path = "context";
+         sourceTree = "<group>";
+      };
+      "OBJ_1013" = {
+         isa = "PBXFileReference";
+         path = "security_context.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1014" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1015",
+            "OBJ_1024",
+            "OBJ_1026",
+            "OBJ_1027",
+            "OBJ_1028",
+            "OBJ_1030",
+            "OBJ_1033",
+            "OBJ_1035",
+            "OBJ_1039",
+            "OBJ_1041",
+            "OBJ_1043"
+         );
+         name = "credentials";
+         path = "credentials";
+         sourceTree = "<group>";
+      };
+      "OBJ_1015" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1016",
+            "OBJ_1017",
+            "OBJ_1018",
+            "OBJ_1019",
+            "OBJ_1020",
+            "OBJ_1021",
+            "OBJ_1022",
+            "OBJ_1023"
+         );
+         name = "alts";
+         path = "alts";
+         sourceTree = "<group>";
+      };
+      "OBJ_1016" = {
+         isa = "PBXFileReference";
+         path = "alts_credentials.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1017" = {
+         isa = "PBXFileReference";
+         path = "check_gcp_environment.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1018" = {
+         isa = "PBXFileReference";
+         path = "check_gcp_environment_linux.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1019" = {
+         isa = "PBXFileReference";
+         path = "check_gcp_environment_no_op.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_102" = {
+         isa = "PBXFileReference";
+         path = "marketing_Campaign.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1020" = {
+         isa = "PBXFileReference";
+         path = "check_gcp_environment_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1021" = {
+         isa = "PBXFileReference";
+         path = "grpc_alts_credentials_client_options.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1022" = {
+         isa = "PBXFileReference";
+         path = "grpc_alts_credentials_options.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1023" = {
+         isa = "PBXFileReference";
+         path = "grpc_alts_credentials_server_options.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1024" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1025"
+         );
+         name = "composite";
+         path = "composite";
+         sourceTree = "<group>";
+      };
+      "OBJ_1025" = {
+         isa = "PBXFileReference";
+         path = "composite_credentials.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1026" = {
+         isa = "PBXFileReference";
+         path = "credentials.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1027" = {
+         isa = "PBXFileReference";
+         path = "credentials_metadata.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1028" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1029"
+         );
+         name = "fake";
+         path = "fake";
+         sourceTree = "<group>";
+      };
+      "OBJ_1029" = {
+         isa = "PBXFileReference";
+         path = "fake_credentials.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_103" = {
+         isa = "PBXFileReference";
+         path = "marketing_Targeting.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1030" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1031",
+            "OBJ_1032"
+         );
+         name = "google_default";
+         path = "google_default";
+         sourceTree = "<group>";
+      };
+      "OBJ_1031" = {
+         isa = "PBXFileReference";
+         path = "credentials_generic.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1032" = {
+         isa = "PBXFileReference";
+         path = "google_default_credentials.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1033" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1034"
+         );
+         name = "iam";
+         path = "iam";
+         sourceTree = "<group>";
+      };
+      "OBJ_1034" = {
+         isa = "PBXFileReference";
+         path = "iam_credentials.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1035" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1036",
+            "OBJ_1037",
+            "OBJ_1038"
+         );
+         name = "jwt";
+         path = "jwt";
+         sourceTree = "<group>";
+      };
+      "OBJ_1036" = {
+         isa = "PBXFileReference";
+         path = "json_token.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1037" = {
+         isa = "PBXFileReference";
+         path = "jwt_credentials.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1038" = {
+         isa = "PBXFileReference";
+         path = "jwt_verifier.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1039" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1040"
+         );
+         name = "oauth2";
+         path = "oauth2";
+         sourceTree = "<group>";
+      };
+      "OBJ_104" = {
+         isa = "PBXFileReference";
+         path = "media_MediaItem.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1040" = {
+         isa = "PBXFileReference";
+         path = "oauth2_credentials.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1041" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1042"
+         );
+         name = "plugin";
+         path = "plugin";
+         sourceTree = "<group>";
+      };
+      "OBJ_1042" = {
+         isa = "PBXFileReference";
+         path = "plugin_credentials.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1043" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1044"
+         );
+         name = "ssl";
+         path = "ssl";
+         sourceTree = "<group>";
+      };
+      "OBJ_1044" = {
+         isa = "PBXFileReference";
+         path = "ssl_credentials.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1045" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1046",
+            "OBJ_1047"
+         );
+         name = "security_connector";
+         path = "security_connector";
+         sourceTree = "<group>";
+      };
+      "OBJ_1046" = {
+         isa = "PBXFileReference";
+         path = "alts_security_connector.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1047" = {
+         isa = "PBXFileReference";
+         path = "security_connector.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1048" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1049",
+            "OBJ_1050",
+            "OBJ_1051",
+            "OBJ_1052",
+            "OBJ_1053",
+            "OBJ_1054"
+         );
+         name = "transport";
+         path = "transport";
+         sourceTree = "<group>";
+      };
+      "OBJ_1049" = {
+         isa = "PBXFileReference";
+         path = "client_auth_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_105" = {
+         isa = "PBXFileReference";
+         path = "media_MediaKey.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1050" = {
+         isa = "PBXFileReference";
+         path = "secure_endpoint.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1051" = {
+         isa = "PBXFileReference";
+         path = "security_handshaker.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1052" = {
+         isa = "PBXFileReference";
+         path = "server_auth_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1053" = {
+         isa = "PBXFileReference";
+         path = "target_authority_table.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1054" = {
+         isa = "PBXFileReference";
+         path = "tsi_error.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1055" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1056"
+         );
+         name = "util";
+         path = "util";
+         sourceTree = "<group>";
+      };
+      "OBJ_1056" = {
+         isa = "PBXFileReference";
+         path = "json_util.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1057" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1058",
+            "OBJ_1059",
+            "OBJ_1060",
+            "OBJ_1061",
+            "OBJ_1062",
+            "OBJ_1063"
+         );
+         name = "slice";
+         path = "slice";
+         sourceTree = "<group>";
+      };
+      "OBJ_1058" = {
+         isa = "PBXFileReference";
+         path = "b64.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1059" = {
+         isa = "PBXFileReference";
+         path = "percent_encoding.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_106" = {
+         isa = "PBXFileReference";
+         path = "media_MediaOrientation.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1060" = {
+         isa = "PBXFileReference";
+         path = "slice.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1061" = {
+         isa = "PBXFileReference";
+         path = "slice_buffer.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1062" = {
+         isa = "PBXFileReference";
+         path = "slice_intern.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1063" = {
+         isa = "PBXFileReference";
+         path = "slice_string_helpers.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1064" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1065",
+            "OBJ_1066",
+            "OBJ_1067",
+            "OBJ_1068",
+            "OBJ_1069",
+            "OBJ_1070",
+            "OBJ_1071",
+            "OBJ_1072",
+            "OBJ_1073",
+            "OBJ_1074",
+            "OBJ_1075",
+            "OBJ_1076",
+            "OBJ_1077",
+            "OBJ_1078",
+            "OBJ_1079",
+            "OBJ_1080",
+            "OBJ_1081",
+            "OBJ_1082",
+            "OBJ_1083",
+            "OBJ_1084"
+         );
+         name = "surface";
+         path = "surface";
+         sourceTree = "<group>";
+      };
+      "OBJ_1065" = {
+         isa = "PBXFileReference";
+         path = "api_trace.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1066" = {
+         isa = "PBXFileReference";
+         path = "byte_buffer.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1067" = {
+         isa = "PBXFileReference";
+         path = "byte_buffer_reader.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1068" = {
+         isa = "PBXFileReference";
+         path = "call.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1069" = {
+         isa = "PBXFileReference";
+         path = "call_details.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_107" = {
+         isa = "PBXFileReference";
+         path = "media_MediaType.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1070" = {
+         isa = "PBXFileReference";
+         path = "call_log_batch.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1071" = {
+         isa = "PBXFileReference";
+         path = "channel.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1072" = {
+         isa = "PBXFileReference";
+         path = "channel_init.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1073" = {
+         isa = "PBXFileReference";
+         path = "channel_ping.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1074" = {
+         isa = "PBXFileReference";
+         path = "channel_stack_type.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1075" = {
+         isa = "PBXFileReference";
+         path = "completion_queue.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1076" = {
+         isa = "PBXFileReference";
+         path = "completion_queue_factory.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1077" = {
+         isa = "PBXFileReference";
+         path = "event_string.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1078" = {
+         isa = "PBXFileReference";
+         path = "init.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1079" = {
+         isa = "PBXFileReference";
+         path = "init_secure.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_108" = {
+         isa = "PBXFileReference";
+         path = "media_v1beta1_MediaService_Beta1.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1080" = {
+         isa = "PBXFileReference";
+         path = "lame_client.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1081" = {
+         isa = "PBXFileReference";
+         path = "metadata_array.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1082" = {
+         isa = "PBXFileReference";
+         path = "server.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1083" = {
+         isa = "PBXFileReference";
+         path = "validate_metadata.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1084" = {
+         isa = "PBXFileReference";
+         path = "version.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1085" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1086",
+            "OBJ_1087",
+            "OBJ_1088",
+            "OBJ_1089",
+            "OBJ_1090",
+            "OBJ_1091",
+            "OBJ_1092",
+            "OBJ_1093",
+            "OBJ_1094",
+            "OBJ_1095",
+            "OBJ_1096",
+            "OBJ_1097",
+            "OBJ_1098",
+            "OBJ_1099"
+         );
+         name = "transport";
+         path = "transport";
+         sourceTree = "<group>";
+      };
+      "OBJ_1086" = {
+         isa = "PBXFileReference";
+         path = "bdp_estimator.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1087" = {
+         isa = "PBXFileReference";
+         path = "byte_stream.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1088" = {
+         isa = "PBXFileReference";
+         path = "connectivity_state.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1089" = {
+         isa = "PBXFileReference";
+         path = "error_utils.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_109" = {
+         isa = "PBXFileReference";
+         path = "media_v1beta1_MediaTask.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1090" = {
+         isa = "PBXFileReference";
+         path = "metadata.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1091" = {
+         isa = "PBXFileReference";
+         path = "metadata_batch.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1092" = {
+         isa = "PBXFileReference";
+         path = "pid_controller.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1093" = {
+         isa = "PBXFileReference";
+         path = "service_config.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1094" = {
+         isa = "PBXFileReference";
+         path = "static_metadata.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1095" = {
+         isa = "PBXFileReference";
+         path = "status_conversion.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1096" = {
+         isa = "PBXFileReference";
+         path = "status_metadata.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1097" = {
+         isa = "PBXFileReference";
+         path = "timeout_encoding.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1098" = {
+         isa = "PBXFileReference";
+         path = "transport.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1099" = {
+         isa = "PBXFileReference";
+         path = "transport_op_string.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_11" = {
+         isa = "PBXFileReference";
+         path = "analytics_Scope.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_110" = {
+         isa = "PBXFileReference";
+         path = "menu_v1beta1_MenuService_Beta1.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1100" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1101"
+         );
+         name = "plugin_registry";
+         path = "plugin_registry";
+         sourceTree = "<group>";
+      };
+      "OBJ_1101" = {
+         isa = "PBXFileReference";
+         path = "grpc_plugin_registry.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1102" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1103",
+            "OBJ_1132",
+            "OBJ_1133",
+            "OBJ_1134",
+            "OBJ_1139",
+            "OBJ_1140",
+            "OBJ_1141",
+            "OBJ_1142"
+         );
+         name = "tsi";
+         path = "tsi";
+         sourceTree = "<group>";
+      };
+      "OBJ_1103" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1104",
+            "OBJ_1107",
+            "OBJ_1115",
+            "OBJ_1126"
+         );
+         name = "alts";
+         path = "alts";
+         sourceTree = "<group>";
+      };
+      "OBJ_1104" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1105",
+            "OBJ_1106"
+         );
+         name = "crypt";
+         path = "crypt";
+         sourceTree = "<group>";
+      };
+      "OBJ_1105" = {
+         isa = "PBXFileReference";
+         path = "aes_gcm.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1106" = {
+         isa = "PBXFileReference";
+         path = "gsec.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1107" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1108",
+            "OBJ_1109",
+            "OBJ_1110",
+            "OBJ_1111",
+            "OBJ_1112",
+            "OBJ_1113",
+            "OBJ_1114"
+         );
+         name = "frame_protector";
+         path = "frame_protector";
+         sourceTree = "<group>";
+      };
+      "OBJ_1108" = {
+         isa = "PBXFileReference";
+         path = "alts_counter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1109" = {
+         isa = "PBXFileReference";
+         path = "alts_crypter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_111" = {
+         isa = "PBXFileReference";
+         path = "oauth_AuthorizationScope.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1110" = {
+         isa = "PBXFileReference";
+         path = "alts_frame_protector.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1111" = {
+         isa = "PBXFileReference";
+         path = "alts_record_protocol_crypter_common.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1112" = {
+         isa = "PBXFileReference";
+         path = "alts_seal_privacy_integrity_crypter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1113" = {
+         isa = "PBXFileReference";
+         path = "alts_unseal_privacy_integrity_crypter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1114" = {
+         isa = "PBXFileReference";
+         path = "frame_handler.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1115" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1116",
+            "OBJ_1117",
+            "OBJ_1118",
+            "OBJ_1119",
+            "OBJ_1120",
+            "OBJ_1121",
+            "OBJ_1122",
+            "OBJ_1123",
+            "OBJ_1124",
+            "OBJ_1125"
+         );
+         name = "handshaker";
+         path = "handshaker";
+         sourceTree = "<group>";
+      };
+      "OBJ_1116" = {
+         isa = "PBXFileReference";
+         path = "alts_handshaker_client.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1117" = {
+         isa = "PBXFileReference";
+         path = "alts_handshaker_service_api.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1118" = {
+         isa = "PBXFileReference";
+         path = "alts_handshaker_service_api_util.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1119" = {
+         isa = "PBXFileReference";
+         path = "alts_tsi_event.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_112" = {
+         isa = "PBXFileReference";
+         path = "oauth_Client.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1120" = {
+         isa = "PBXFileReference";
+         path = "alts_tsi_handshaker.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1121" = {
+         isa = "PBXFileReference";
+         path = "alts_tsi_utils.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1122" = {
+         isa = "PBXFileReference";
+         path = "altscontext.pb.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_1123" = {
+         isa = "PBXFileReference";
+         path = "handshaker.pb.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_1124" = {
+         isa = "PBXFileReference";
+         path = "transport_security_common.pb.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_1125" = {
+         isa = "PBXFileReference";
+         path = "transport_security_common_api.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1126" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1127",
+            "OBJ_1128",
+            "OBJ_1129",
+            "OBJ_1130",
+            "OBJ_1131"
+         );
+         name = "zero_copy_frame_protector";
+         path = "zero_copy_frame_protector";
+         sourceTree = "<group>";
+      };
+      "OBJ_1127" = {
+         isa = "PBXFileReference";
+         path = "alts_grpc_integrity_only_record_protocol.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1128" = {
+         isa = "PBXFileReference";
+         path = "alts_grpc_privacy_integrity_record_protocol.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1129" = {
+         isa = "PBXFileReference";
+         path = "alts_grpc_record_protocol_common.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_113" = {
+         isa = "PBXFileReference";
+         path = "partner_LocationKey.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1130" = {
+         isa = "PBXFileReference";
+         path = "alts_iovec_record_protocol.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1131" = {
+         isa = "PBXFileReference";
+         path = "alts_zero_copy_grpc_protector.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1132" = {
+         isa = "PBXFileReference";
+         path = "alts_transport_security.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1133" = {
+         isa = "PBXFileReference";
+         path = "fake_transport_security.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1134" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1135"
+         );
+         name = "ssl";
+         path = "ssl";
+         sourceTree = "<group>";
+      };
+      "OBJ_1135" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1136",
+            "OBJ_1137",
+            "OBJ_1138"
+         );
+         name = "session_cache";
+         path = "session_cache";
+         sourceTree = "<group>";
+      };
+      "OBJ_1136" = {
+         isa = "PBXFileReference";
+         path = "ssl_session_boringssl.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1137" = {
+         isa = "PBXFileReference";
+         path = "ssl_session_cache.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1138" = {
+         isa = "PBXFileReference";
+         path = "ssl_session_openssl.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1139" = {
+         isa = "PBXFileReference";
+         path = "ssl_transport_security.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_114" = {
+         isa = "PBXFileReference";
+         path = "partner_Partner.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1140" = {
+         isa = "PBXFileReference";
+         path = "transport_security.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1141" = {
+         isa = "PBXFileReference";
+         path = "transport_security_adapter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1142" = {
+         isa = "PBXFileReference";
+         path = "transport_security_grpc.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1143" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1144"
+         );
+         name = "third_party";
+         path = "third_party";
+         sourceTree = "<group>";
+      };
+      "OBJ_1144" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1145",
+            "OBJ_1146",
+            "OBJ_1147"
+         );
+         name = "nanopb";
+         path = "nanopb";
+         sourceTree = "<group>";
+      };
+      "OBJ_1145" = {
+         isa = "PBXFileReference";
+         path = "pb_common.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_1146" = {
+         isa = "PBXFileReference";
+         path = "pb_decode.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_1147" = {
+         isa = "PBXFileReference";
+         path = "pb_encode.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_1148" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1149",
+            "OBJ_1150",
+            "OBJ_1206"
+         );
+         name = "include";
+         path = "include";
+         sourceTree = "<group>";
+      };
+      "OBJ_1149" = {
+         isa = "PBXFileReference";
+         path = "cgrpc.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_115" = {
+         isa = "PBXFileReference";
+         path = "partner_PartnerDevice.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1150" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1151",
+            "OBJ_1152",
+            "OBJ_1153",
+            "OBJ_1154",
+            "OBJ_1155",
+            "OBJ_1156",
+            "OBJ_1157",
+            "OBJ_1158",
+            "OBJ_1159",
+            "OBJ_1160",
+            "OBJ_1161",
+            "OBJ_1162",
+            "OBJ_1163",
+            "OBJ_1164",
+            "OBJ_1183"
+         );
+         name = "grpc";
+         path = "grpc";
+         sourceTree = "<group>";
+      };
+      "OBJ_1151" = {
+         isa = "PBXFileReference";
+         path = "grpc.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1152" = {
+         isa = "PBXFileReference";
+         path = "status.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1153" = {
+         isa = "PBXFileReference";
+         path = "census.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1154" = {
+         isa = "PBXFileReference";
+         path = "slice.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1155" = {
+         isa = "PBXFileReference";
+         path = "compression.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1156" = {
+         isa = "PBXFileReference";
+         path = "fork.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1157" = {
+         isa = "PBXFileReference";
+         path = "byte_buffer_reader.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1158" = {
+         isa = "PBXFileReference";
+         path = "grpc_security_constants.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1159" = {
+         isa = "PBXFileReference";
+         path = "byte_buffer.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_116" = {
+         isa = "PBXFileReference";
+         path = "partner_PartnerFlags.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1160" = {
+         isa = "PBXFileReference";
+         path = "slice_buffer.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1161" = {
+         isa = "PBXFileReference";
+         path = "grpc_posix.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1162" = {
+         isa = "PBXFileReference";
+         path = "grpc_security.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1163" = {
+         isa = "PBXFileReference";
+         path = "load_reporting.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1164" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1165",
+            "OBJ_1166",
+            "OBJ_1167",
+            "OBJ_1168",
+            "OBJ_1169",
+            "OBJ_1170",
+            "OBJ_1171",
+            "OBJ_1172",
+            "OBJ_1173",
+            "OBJ_1174",
+            "OBJ_1175",
+            "OBJ_1176",
+            "OBJ_1177",
+            "OBJ_1178",
+            "OBJ_1179",
+            "OBJ_1180",
+            "OBJ_1181",
+            "OBJ_1182"
+         );
+         name = "support";
+         path = "support";
+         sourceTree = "<group>";
+      };
+      "OBJ_1165" = {
+         isa = "PBXFileReference";
+         path = "time.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1166" = {
+         isa = "PBXFileReference";
+         path = "port_platform.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1167" = {
+         isa = "PBXFileReference";
+         path = "log_windows.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1168" = {
+         isa = "PBXFileReference";
+         path = "sync.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1169" = {
+         isa = "PBXFileReference";
+         path = "string_util.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_117" = {
+         isa = "PBXFileReference";
+         path = "partner_PartnerKey.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1170" = {
+         isa = "PBXFileReference";
+         path = "sync_custom.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1171" = {
+         isa = "PBXFileReference";
+         path = "thd_id.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1172" = {
+         isa = "PBXFileReference";
+         path = "workaround_list.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1173" = {
+         isa = "PBXFileReference";
+         path = "atm_gcc_sync.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1174" = {
+         isa = "PBXFileReference";
+         path = "atm_gcc_atomic.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1175" = {
+         isa = "PBXFileReference";
+         path = "atm.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1176" = {
+         isa = "PBXFileReference";
+         path = "sync_generic.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1177" = {
+         isa = "PBXFileReference";
+         path = "log.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1178" = {
+         isa = "PBXFileReference";
+         path = "cpu.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1179" = {
+         isa = "PBXFileReference";
+         path = "sync_posix.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_118" = {
+         isa = "PBXFileReference";
+         path = "partner_PartnerLocation.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1180" = {
+         isa = "PBXFileReference";
+         path = "atm_windows.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1181" = {
+         isa = "PBXFileReference";
+         path = "sync_windows.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1182" = {
+         isa = "PBXFileReference";
+         path = "alloc.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1183" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1184"
+         );
+         name = "impl";
+         path = "impl";
+         sourceTree = "<group>";
+      };
+      "OBJ_1184" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1185",
+            "OBJ_1186",
+            "OBJ_1187",
+            "OBJ_1188",
+            "OBJ_1189",
+            "OBJ_1190",
+            "OBJ_1191",
+            "OBJ_1192",
+            "OBJ_1193",
+            "OBJ_1194",
+            "OBJ_1195",
+            "OBJ_1196",
+            "OBJ_1197",
+            "OBJ_1198",
+            "OBJ_1199",
+            "OBJ_1200",
+            "OBJ_1201",
+            "OBJ_1202",
+            "OBJ_1203",
+            "OBJ_1204",
+            "OBJ_1205"
+         );
+         name = "codegen";
+         path = "codegen";
+         sourceTree = "<group>";
+      };
+      "OBJ_1185" = {
+         isa = "PBXFileReference";
+         path = "port_platform.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1186" = {
+         isa = "PBXFileReference";
+         path = "status.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1187" = {
+         isa = "PBXFileReference";
+         path = "gpr_types.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1188" = {
+         isa = "PBXFileReference";
+         path = "sync.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1189" = {
+         isa = "PBXFileReference";
+         path = "grpc_types.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_119" = {
+         isa = "PBXFileReference";
+         path = "partner_PartnerScope.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1190" = {
+         isa = "PBXFileReference";
+         path = "sync_custom.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1191" = {
+         isa = "PBXFileReference";
+         path = "gpr_slice.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1192" = {
+         isa = "PBXFileReference";
+         path = "slice.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1193" = {
+         isa = "PBXFileReference";
+         path = "compression_types.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1194" = {
+         isa = "PBXFileReference";
+         path = "atm_gcc_sync.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1195" = {
+         isa = "PBXFileReference";
+         path = "atm_gcc_atomic.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1196" = {
+         isa = "PBXFileReference";
+         path = "atm.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1197" = {
+         isa = "PBXFileReference";
+         path = "sync_generic.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1198" = {
+         isa = "PBXFileReference";
+         path = "fork.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1199" = {
+         isa = "PBXFileReference";
+         path = "byte_buffer_reader.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_12" = {
+         isa = "PBXFileReference";
+         path = "analytics_commerce_OrderAnalytics.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_120" = {
+         isa = "PBXFileReference";
+         path = "partner_integrations_GSuiteSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1200" = {
+         isa = "PBXFileReference";
+         path = "sync_posix.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1201" = {
+         isa = "PBXFileReference";
+         path = "atm_windows.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1202" = {
+         isa = "PBXFileReference";
+         path = "propagation_bits.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1203" = {
+         isa = "PBXFileReference";
+         path = "byte_buffer.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1204" = {
+         isa = "PBXFileReference";
+         path = "connectivity_state.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1205" = {
+         isa = "PBXFileReference";
+         path = "sync_windows.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_1206" = {
+         isa = "PBXFileReference";
+         name = "module.modulemap";
+         path = "/Volumes/PITBULL/Vault/Bloombox/Client/Swift/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap";
+         sourceTree = "<group>";
+      };
+      "OBJ_1207" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "protoc-gen-swiftgrpc";
+         path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/protoc-gen-swiftgrpc";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_1208" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "Simple";
+         path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/Examples/Simple";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_1209" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "Echo";
+         path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/Examples/Echo";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_121" = {
+         isa = "PBXFileReference";
+         path = "partner_integrations_GreenbitsSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1210" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         name = "Package.swift";
+         path = "/Volumes/PITBULL/Vault/Bloombox/Client/Swift/.build/checkouts/grpc-swift.git--2568890431933451096/Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1211" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1212",
+            "OBJ_1213",
+            "OBJ_1290",
+            "OBJ_1291",
+            "OBJ_1292"
+         );
+         name = "SwiftProtobuf 1.1.2";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_1212" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "SwiftProtobufPluginLibrary";
+         path = ".build/checkouts/swift-protobuf.git-7923261648679470216/Sources/SwiftProtobufPluginLibrary";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_1213" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_1214",
+            "OBJ_1215",
+            "OBJ_1216",
+            "OBJ_1217",
+            "OBJ_1218",
+            "OBJ_1219",
+            "OBJ_1220",
+            "OBJ_1221",
+            "OBJ_1222",
+            "OBJ_1223",
+            "OBJ_1224",
+            "OBJ_1225",
+            "OBJ_1226",
+            "OBJ_1227",
+            "OBJ_1228",
+            "OBJ_1229",
+            "OBJ_1230",
+            "OBJ_1231",
+            "OBJ_1232",
+            "OBJ_1233",
+            "OBJ_1234",
+            "OBJ_1235",
+            "OBJ_1236",
+            "OBJ_1237",
+            "OBJ_1238",
+            "OBJ_1239",
+            "OBJ_1240",
+            "OBJ_1241",
+            "OBJ_1242",
+            "OBJ_1243",
+            "OBJ_1244",
+            "OBJ_1245",
+            "OBJ_1246",
+            "OBJ_1247",
+            "OBJ_1248",
+            "OBJ_1249",
+            "OBJ_1250",
+            "OBJ_1251",
+            "OBJ_1252",
+            "OBJ_1253",
+            "OBJ_1254",
+            "OBJ_1255",
+            "OBJ_1256",
+            "OBJ_1257",
+            "OBJ_1258",
+            "OBJ_1259",
+            "OBJ_1260",
+            "OBJ_1261",
+            "OBJ_1262",
+            "OBJ_1263",
+            "OBJ_1264",
+            "OBJ_1265",
+            "OBJ_1266",
+            "OBJ_1267",
+            "OBJ_1268",
+            "OBJ_1269",
+            "OBJ_1270",
+            "OBJ_1271",
+            "OBJ_1272",
+            "OBJ_1273",
+            "OBJ_1274",
+            "OBJ_1275",
+            "OBJ_1276",
+            "OBJ_1277",
+            "OBJ_1278",
+            "OBJ_1279",
+            "OBJ_1280",
+            "OBJ_1281",
+            "OBJ_1282",
+            "OBJ_1283",
+            "OBJ_1284",
+            "OBJ_1285",
+            "OBJ_1286",
+            "OBJ_1287",
+            "OBJ_1288",
+            "OBJ_1289"
+         );
+         name = "SwiftProtobuf";
+         path = ".build/checkouts/swift-protobuf.git-7923261648679470216/Sources/SwiftProtobuf";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_1214" = {
+         isa = "PBXFileReference";
+         path = "AnyMessageStorage.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1215" = {
+         isa = "PBXFileReference";
+         path = "AnyUnpackError.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1216" = {
+         isa = "PBXFileReference";
+         path = "BinaryDecoder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1217" = {
+         isa = "PBXFileReference";
+         path = "BinaryDecodingError.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1218" = {
+         isa = "PBXFileReference";
+         path = "BinaryDecodingOptions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1219" = {
+         isa = "PBXFileReference";
+         path = "BinaryDelimited.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_122" = {
+         isa = "PBXFileReference";
+         path = "partner_integrations_IntegrationSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1220" = {
+         isa = "PBXFileReference";
+         path = "BinaryEncoder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1221" = {
+         isa = "PBXFileReference";
+         path = "BinaryEncodingError.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1222" = {
+         isa = "PBXFileReference";
+         path = "BinaryEncodingSizeVisitor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1223" = {
+         isa = "PBXFileReference";
+         path = "BinaryEncodingVisitor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1224" = {
+         isa = "PBXFileReference";
+         path = "CustomJSONCodable.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1225" = {
+         isa = "PBXFileReference";
+         path = "Decoder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1226" = {
+         isa = "PBXFileReference";
+         path = "DoubleFormatter.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1227" = {
+         isa = "PBXFileReference";
+         path = "Enum.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1228" = {
+         isa = "PBXFileReference";
+         path = "ExtensibleMessage.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1229" = {
+         isa = "PBXFileReference";
+         path = "ExtensionFieldValueSet.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_123" = {
+         isa = "PBXFileReference";
+         path = "partner_integrations_MailchimpSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1230" = {
+         isa = "PBXFileReference";
+         path = "ExtensionFields.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1231" = {
+         isa = "PBXFileReference";
+         path = "ExtensionMap.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1232" = {
+         isa = "PBXFileReference";
+         path = "FieldTag.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1233" = {
+         isa = "PBXFileReference";
+         path = "FieldTypes.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1234" = {
+         isa = "PBXFileReference";
+         path = "Google_Protobuf_Any+Extensions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1235" = {
+         isa = "PBXFileReference";
+         path = "Google_Protobuf_Any+Registry.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1236" = {
+         isa = "PBXFileReference";
+         path = "Google_Protobuf_Duration+Extensions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1237" = {
+         isa = "PBXFileReference";
+         path = "Google_Protobuf_FieldMask+Extensions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1238" = {
+         isa = "PBXFileReference";
+         path = "Google_Protobuf_ListValue+Extensions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1239" = {
+         isa = "PBXFileReference";
+         path = "Google_Protobuf_Struct+Extensions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_124" = {
+         isa = "PBXFileReference";
+         path = "partner_integrations_OnFleetSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1240" = {
+         isa = "PBXFileReference";
+         path = "Google_Protobuf_Timestamp+Extensions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1241" = {
+         isa = "PBXFileReference";
+         path = "Google_Protobuf_Value+Extensions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1242" = {
+         isa = "PBXFileReference";
+         path = "Google_Protobuf_Wrappers+Extensions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1243" = {
+         isa = "PBXFileReference";
+         path = "HashVisitor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1244" = {
+         isa = "PBXFileReference";
+         path = "Internal.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1245" = {
+         isa = "PBXFileReference";
+         path = "JSONDecoder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1246" = {
+         isa = "PBXFileReference";
+         path = "JSONDecodingError.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1247" = {
+         isa = "PBXFileReference";
+         path = "JSONDecodingOptions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1248" = {
+         isa = "PBXFileReference";
+         path = "JSONEncoder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1249" = {
+         isa = "PBXFileReference";
+         path = "JSONEncodingError.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_125" = {
+         isa = "PBXFileReference";
+         path = "partner_integrations_SendgridSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1250" = {
+         isa = "PBXFileReference";
+         path = "JSONEncodingVisitor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1251" = {
+         isa = "PBXFileReference";
+         path = "JSONMapEncodingVisitor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1252" = {
+         isa = "PBXFileReference";
+         path = "JSONScanner.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1253" = {
+         isa = "PBXFileReference";
+         path = "MathUtils.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1254" = {
+         isa = "PBXFileReference";
+         path = "Message+AnyAdditions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1255" = {
+         isa = "PBXFileReference";
+         path = "Message+BinaryAdditions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1256" = {
+         isa = "PBXFileReference";
+         path = "Message+JSONAdditions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1257" = {
+         isa = "PBXFileReference";
+         path = "Message+JSONArrayAdditions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1258" = {
+         isa = "PBXFileReference";
+         path = "Message+TextFormatAdditions.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1259" = {
+         isa = "PBXFileReference";
+         path = "Message.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_126" = {
+         isa = "PBXFileReference";
+         path = "partner_integrations_TreezSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1260" = {
+         isa = "PBXFileReference";
+         path = "MessageExtension.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1261" = {
+         isa = "PBXFileReference";
+         path = "NameMap.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1262" = {
+         isa = "PBXFileReference";
+         path = "ProtoNameProviding.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1263" = {
+         isa = "PBXFileReference";
+         path = "ProtobufAPIVersionCheck.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1264" = {
+         isa = "PBXFileReference";
+         path = "ProtobufMap.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1265" = {
+         isa = "PBXFileReference";
+         path = "SelectiveVisitor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1266" = {
+         isa = "PBXFileReference";
+         path = "SimpleExtensionMap.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1267" = {
+         isa = "PBXFileReference";
+         path = "StringUtils.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1268" = {
+         isa = "PBXFileReference";
+         path = "TextFormatDecoder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1269" = {
+         isa = "PBXFileReference";
+         path = "TextFormatDecodingError.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_127" = {
+         isa = "PBXFileReference";
+         path = "partner_integrations_TwilioSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1270" = {
+         isa = "PBXFileReference";
+         path = "TextFormatEncoder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1271" = {
+         isa = "PBXFileReference";
+         path = "TextFormatEncodingVisitor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1272" = {
+         isa = "PBXFileReference";
+         path = "TextFormatScanner.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1273" = {
+         isa = "PBXFileReference";
+         path = "TimeUtils.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1274" = {
+         isa = "PBXFileReference";
+         path = "UnknownStorage.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1275" = {
+         isa = "PBXFileReference";
+         path = "Varint.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1276" = {
+         isa = "PBXFileReference";
+         path = "Version.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1277" = {
+         isa = "PBXFileReference";
+         path = "Visitor.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1278" = {
+         isa = "PBXFileReference";
+         path = "WireFormat.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1279" = {
+         isa = "PBXFileReference";
+         path = "ZigZag.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_128" = {
+         isa = "PBXFileReference";
+         path = "partner_settings_PartnerLocationSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1280" = {
+         isa = "PBXFileReference";
+         path = "any.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1281" = {
+         isa = "PBXFileReference";
+         path = "api.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1282" = {
+         isa = "PBXFileReference";
+         path = "duration.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1283" = {
+         isa = "PBXFileReference";
+         path = "empty.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1284" = {
+         isa = "PBXFileReference";
+         path = "field_mask.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1285" = {
+         isa = "PBXFileReference";
+         path = "source_context.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1286" = {
+         isa = "PBXFileReference";
+         path = "struct.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1287" = {
+         isa = "PBXFileReference";
+         path = "timestamp.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1288" = {
+         isa = "PBXFileReference";
+         path = "type.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1289" = {
+         isa = "PBXFileReference";
+         path = "wrappers.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_129" = {
+         isa = "PBXFileReference";
+         path = "partner_settings_PartnerSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1290" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "Conformance";
+         path = ".build/checkouts/swift-protobuf.git-7923261648679470216/Sources/Conformance";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_1291" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "protoc-gen-swift";
+         path = ".build/checkouts/swift-protobuf.git-7923261648679470216/Sources/protoc-gen-swift";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_1292" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         name = "Package.swift";
+         path = "/Volumes/PITBULL/Vault/Bloombox/Client/Swift/.build/checkouts/swift-protobuf.git-7923261648679470216/Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1293" = {
+         isa = "PBXGroup";
+         children = (
+            "Bloombox::BloomboxServices::Product",
+            "Bloombox::SchemaTests::Product",
+            "Bloombox::ClientTests::Product",
+            "SwiftGRPC::BoringSSL::Product",
+            "SwiftGRPC::SwiftGRPC::Product",
+            "Bloombox::OpenCannabis::Product",
+            "SwiftProtobuf::SwiftProtobuf::Product",
+            "SwiftGRPC::CgRPC::Product",
+            "Bloombox::Bloombox::Product"
+         );
+         name = "Products";
+         path = "";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "OBJ_13" = {
+         isa = "PBXFileReference";
+         path = "analytics_commerce_ProductAnalytics.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_130" = {
+         isa = "PBXFileReference";
+         path = "person_Person.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1304" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1305",
+            "OBJ_1306"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1305" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
+               "$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/Bloombox_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "Bloombox";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "Bloombox";
+         };
+         name = "Debug";
+      };
+      "OBJ_1306" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
+               "$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/Bloombox_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "Bloombox";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "Bloombox";
+         };
+         name = "Release";
+      };
+      "OBJ_1307" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1308",
+            "OBJ_1309",
+            "OBJ_1310",
+            "OBJ_1311",
+            "OBJ_1312",
+            "OBJ_1313",
+            "OBJ_1314",
+            "OBJ_1315",
+            "OBJ_1316",
+            "OBJ_1317",
+            "OBJ_1318",
+            "OBJ_1319",
+            "OBJ_1320",
+            "OBJ_1321",
+            "OBJ_1322",
+            "OBJ_1323",
+            "OBJ_1324",
+            "OBJ_1325",
+            "OBJ_1326",
+            "OBJ_1327"
+         );
+      };
+      "OBJ_1308" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_191";
+      };
+      "OBJ_1309" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_192";
+      };
+      "OBJ_131" = {
+         isa = "PBXFileReference";
+         path = "person_PersonName.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1310" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_193";
+      };
+      "OBJ_1311" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_194";
+      };
+      "OBJ_1312" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_195";
+      };
+      "OBJ_1313" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_196";
+      };
+      "OBJ_1314" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_197";
+      };
+      "OBJ_1315" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_198";
+      };
+      "OBJ_1316" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_199";
+      };
+      "OBJ_1317" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_200";
+      };
+      "OBJ_1318" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_201";
+      };
+      "OBJ_1319" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_202";
+      };
+      "OBJ_132" = {
+         isa = "PBXFileReference";
+         path = "platform_v1_PlatformService_v1.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1320" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_203";
+      };
+      "OBJ_1321" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_204";
+      };
+      "OBJ_1322" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_205";
+      };
+      "OBJ_1323" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_206";
+      };
+      "OBJ_1324" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_207";
+      };
+      "OBJ_1325" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_208";
+      };
+      "OBJ_1326" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_209";
+      };
+      "OBJ_1327" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_210";
+      };
+      "OBJ_1328" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_1329",
+            "OBJ_1330",
+            "OBJ_1331",
+            "OBJ_1332",
+            "OBJ_1333",
+            "OBJ_1334"
+         );
+      };
+      "OBJ_1329" = {
+         isa = "PBXBuildFile";
+         fileRef = "Bloombox::BloomboxServices::Product";
+      };
+      "OBJ_133" = {
+         isa = "PBXFileReference";
+         path = "pos_PointOfSale.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1330" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::SwiftGRPC::Product";
+      };
+      "OBJ_1331" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::CgRPC::Product";
+      };
+      "OBJ_1332" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::BoringSSL::Product";
+      };
+      "OBJ_1333" = {
+         isa = "PBXBuildFile";
+         fileRef = "Bloombox::OpenCannabis::Product";
+      };
+      "OBJ_1334" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftProtobuf::SwiftProtobuf::Product";
+      };
+      "OBJ_1335" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::BloomboxServices";
+      };
+      "OBJ_1337" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::SwiftGRPC";
+      };
+      "OBJ_1339" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::CgRPC";
+      };
+      "OBJ_134" = {
+         isa = "PBXFileReference";
+         path = "pos_v1beta1_POSService_Beta1.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1341" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::BoringSSL";
+      };
+      "OBJ_1343" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::OpenCannabis";
+      };
+      "OBJ_1345" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftProtobuf::SwiftProtobuf";
+      };
+      "OBJ_1348" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1349",
+            "OBJ_1350"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1349" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
+            );
+            SWIFT_VERSION = "4.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_135" = {
+         isa = "PBXFileReference";
+         path = "products_Apothecary.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1350" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
+            );
+            SWIFT_VERSION = "4.0";
+         };
+         name = "Release";
+      };
+      "OBJ_1351" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1352"
+         );
+      };
+      "OBJ_1352" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_6";
+      };
+      "OBJ_1354" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1355",
+            "OBJ_1356"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1355" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+         };
+         name = "Debug";
+      };
+      "OBJ_1356" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+         };
+         name = "Release";
+      };
+      "OBJ_1357" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::SchemaTests";
+      };
+      "OBJ_1359" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::ClientTests";
+      };
+      "OBJ_136" = {
+         isa = "PBXFileReference";
+         path = "products_Cartridge.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1361" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1362",
+            "OBJ_1363"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1362" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
+               "$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/BloomboxServices_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "BloomboxServices";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "BloomboxServices";
+         };
+         name = "Debug";
+      };
+      "OBJ_1363" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
+               "$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/BloomboxServices_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "BloomboxServices";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "BloomboxServices";
+         };
+         name = "Release";
+      };
+      "OBJ_1364" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1365",
+            "OBJ_1366",
+            "OBJ_1367",
+            "OBJ_1368",
+            "OBJ_1369",
+            "OBJ_1370",
+            "OBJ_1371",
+            "OBJ_1372",
+            "OBJ_1373",
+            "OBJ_1374"
+         );
+      };
+      "OBJ_1365" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_180";
+      };
+      "OBJ_1366" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_181";
+      };
+      "OBJ_1367" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_182";
+      };
+      "OBJ_1368" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_183";
+      };
+      "OBJ_1369" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_184";
+      };
+      "OBJ_137" = {
+         isa = "PBXFileReference";
+         path = "products_Edible.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1370" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_185";
+      };
+      "OBJ_1371" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_186";
+      };
+      "OBJ_1372" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_187";
+      };
+      "OBJ_1373" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_188";
+      };
+      "OBJ_1374" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_189";
+      };
+      "OBJ_1375" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_1376",
+            "OBJ_1377",
+            "OBJ_1378",
+            "OBJ_1379",
+            "OBJ_1380"
+         );
+      };
+      "OBJ_1376" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::SwiftGRPC::Product";
+      };
+      "OBJ_1377" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::CgRPC::Product";
+      };
+      "OBJ_1378" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::BoringSSL::Product";
+      };
+      "OBJ_1379" = {
+         isa = "PBXBuildFile";
+         fileRef = "Bloombox::OpenCannabis::Product";
+      };
+      "OBJ_138" = {
+         isa = "PBXFileReference";
+         path = "products_Extract.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1380" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftProtobuf::SwiftProtobuf::Product";
+      };
+      "OBJ_1381" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::SwiftGRPC";
+      };
+      "OBJ_1382" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::CgRPC";
+      };
+      "OBJ_1383" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::BoringSSL";
+      };
+      "OBJ_1384" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::OpenCannabis";
+      };
+      "OBJ_1385" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftProtobuf::SwiftProtobuf";
+      };
+      "OBJ_1386" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1387",
+            "OBJ_1388"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1387" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+            DEFINES_MODULE = "NO";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            GCC_C_LANGUAGE_STANDARD = "gnu11";
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/BoringSSL_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "BoringSSL";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "BoringSSL";
+         };
+         name = "Debug";
+      };
+      "OBJ_1388" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+            DEFINES_MODULE = "NO";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            GCC_C_LANGUAGE_STANDARD = "gnu11";
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/BoringSSL_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "BoringSSL";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "BoringSSL";
+         };
+         name = "Release";
+      };
+      "OBJ_1389" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1390",
+            "OBJ_1391",
+            "OBJ_1392",
+            "OBJ_1393",
+            "OBJ_1394",
+            "OBJ_1395",
+            "OBJ_1396",
+            "OBJ_1397",
+            "OBJ_1398",
+            "OBJ_1399",
+            "OBJ_1400",
+            "OBJ_1401",
+            "OBJ_1402",
+            "OBJ_1403",
+            "OBJ_1404",
+            "OBJ_1405",
+            "OBJ_1406",
+            "OBJ_1407",
+            "OBJ_1408",
+            "OBJ_1409",
+            "OBJ_1410",
+            "OBJ_1411",
+            "OBJ_1412",
+            "OBJ_1413",
+            "OBJ_1414",
+            "OBJ_1415",
+            "OBJ_1416",
+            "OBJ_1417",
+            "OBJ_1418",
+            "OBJ_1419",
+            "OBJ_1420",
+            "OBJ_1421",
+            "OBJ_1422",
+            "OBJ_1423",
+            "OBJ_1424",
+            "OBJ_1425",
+            "OBJ_1426",
+            "OBJ_1427",
+            "OBJ_1428",
+            "OBJ_1429",
+            "OBJ_1430",
+            "OBJ_1431",
+            "OBJ_1432",
+            "OBJ_1433",
+            "OBJ_1434",
+            "OBJ_1435",
+            "OBJ_1436",
+            "OBJ_1437",
+            "OBJ_1438",
+            "OBJ_1439",
+            "OBJ_1440",
+            "OBJ_1441",
+            "OBJ_1442",
+            "OBJ_1443",
+            "OBJ_1444",
+            "OBJ_1445",
+            "OBJ_1446",
+            "OBJ_1447",
+            "OBJ_1448",
+            "OBJ_1449",
+            "OBJ_1450",
+            "OBJ_1451",
+            "OBJ_1452",
+            "OBJ_1453",
+            "OBJ_1454",
+            "OBJ_1455",
+            "OBJ_1456",
+            "OBJ_1457",
+            "OBJ_1458",
+            "OBJ_1459",
+            "OBJ_1460",
+            "OBJ_1461",
+            "OBJ_1462",
+            "OBJ_1463",
+            "OBJ_1464",
+            "OBJ_1465",
+            "OBJ_1466",
+            "OBJ_1467",
+            "OBJ_1468",
+            "OBJ_1469",
+            "OBJ_1470",
+            "OBJ_1471",
+            "OBJ_1472",
+            "OBJ_1473",
+            "OBJ_1474",
+            "OBJ_1475",
+            "OBJ_1476",
+            "OBJ_1477",
+            "OBJ_1478",
+            "OBJ_1479",
+            "OBJ_1480",
+            "OBJ_1481",
+            "OBJ_1482",
+            "OBJ_1483",
+            "OBJ_1484",
+            "OBJ_1485",
+            "OBJ_1486",
+            "OBJ_1487",
+            "OBJ_1488",
+            "OBJ_1489",
+            "OBJ_1490",
+            "OBJ_1491",
+            "OBJ_1492",
+            "OBJ_1493",
+            "OBJ_1494",
+            "OBJ_1495",
+            "OBJ_1496",
+            "OBJ_1497",
+            "OBJ_1498",
+            "OBJ_1499",
+            "OBJ_1500",
+            "OBJ_1501",
+            "OBJ_1502",
+            "OBJ_1503",
+            "OBJ_1504",
+            "OBJ_1505",
+            "OBJ_1506",
+            "OBJ_1507",
+            "OBJ_1508",
+            "OBJ_1509",
+            "OBJ_1510",
+            "OBJ_1511",
+            "OBJ_1512",
+            "OBJ_1513",
+            "OBJ_1514",
+            "OBJ_1515",
+            "OBJ_1516",
+            "OBJ_1517",
+            "OBJ_1518",
+            "OBJ_1519",
+            "OBJ_1520",
+            "OBJ_1521",
+            "OBJ_1522",
+            "OBJ_1523",
+            "OBJ_1524",
+            "OBJ_1525",
+            "OBJ_1526",
+            "OBJ_1527",
+            "OBJ_1528",
+            "OBJ_1529",
+            "OBJ_1530",
+            "OBJ_1531",
+            "OBJ_1532",
+            "OBJ_1533",
+            "OBJ_1534",
+            "OBJ_1535",
+            "OBJ_1536",
+            "OBJ_1537",
+            "OBJ_1538",
+            "OBJ_1539",
+            "OBJ_1540",
+            "OBJ_1541",
+            "OBJ_1542",
+            "OBJ_1543",
+            "OBJ_1544",
+            "OBJ_1545",
+            "OBJ_1546",
+            "OBJ_1547",
+            "OBJ_1548",
+            "OBJ_1549",
+            "OBJ_1550",
+            "OBJ_1551",
+            "OBJ_1552",
+            "OBJ_1553",
+            "OBJ_1554",
+            "OBJ_1555",
+            "OBJ_1556",
+            "OBJ_1557",
+            "OBJ_1558",
+            "OBJ_1559",
+            "OBJ_1560",
+            "OBJ_1561",
+            "OBJ_1562",
+            "OBJ_1563",
+            "OBJ_1564",
+            "OBJ_1565",
+            "OBJ_1566",
+            "OBJ_1567",
+            "OBJ_1568",
+            "OBJ_1569",
+            "OBJ_1570",
+            "OBJ_1571",
+            "OBJ_1572",
+            "OBJ_1573",
+            "OBJ_1574",
+            "OBJ_1575",
+            "OBJ_1576",
+            "OBJ_1577",
+            "OBJ_1578",
+            "OBJ_1579",
+            "OBJ_1580",
+            "OBJ_1581",
+            "OBJ_1582",
+            "OBJ_1583",
+            "OBJ_1584",
+            "OBJ_1585",
+            "OBJ_1586",
+            "OBJ_1587",
+            "OBJ_1588",
+            "OBJ_1589",
+            "OBJ_1590",
+            "OBJ_1591",
+            "OBJ_1592",
+            "OBJ_1593",
+            "OBJ_1594",
+            "OBJ_1595",
+            "OBJ_1596",
+            "OBJ_1597",
+            "OBJ_1598",
+            "OBJ_1599",
+            "OBJ_1600",
+            "OBJ_1601",
+            "OBJ_1602",
+            "OBJ_1603",
+            "OBJ_1604",
+            "OBJ_1605",
+            "OBJ_1606",
+            "OBJ_1607",
+            "OBJ_1608",
+            "OBJ_1609",
+            "OBJ_1610",
+            "OBJ_1611",
+            "OBJ_1612",
+            "OBJ_1613",
+            "OBJ_1614",
+            "OBJ_1615",
+            "OBJ_1616",
+            "OBJ_1617",
+            "OBJ_1618",
+            "OBJ_1619",
+            "OBJ_1620",
+            "OBJ_1621",
+            "OBJ_1622",
+            "OBJ_1623",
+            "OBJ_1624",
+            "OBJ_1625",
+            "OBJ_1626",
+            "OBJ_1627",
+            "OBJ_1628",
+            "OBJ_1629",
+            "OBJ_1630",
+            "OBJ_1631",
+            "OBJ_1632",
+            "OBJ_1633",
+            "OBJ_1634",
+            "OBJ_1635",
+            "OBJ_1636",
+            "OBJ_1637",
+            "OBJ_1638",
+            "OBJ_1639",
+            "OBJ_1640",
+            "OBJ_1641",
+            "OBJ_1642",
+            "OBJ_1643",
+            "OBJ_1644",
+            "OBJ_1645",
+            "OBJ_1646",
+            "OBJ_1647",
+            "OBJ_1648",
+            "OBJ_1649",
+            "OBJ_1650",
+            "OBJ_1651",
+            "OBJ_1652",
+            "OBJ_1653",
+            "OBJ_1654",
+            "OBJ_1655",
+            "OBJ_1656",
+            "OBJ_1657",
+            "OBJ_1658",
+            "OBJ_1659",
+            "OBJ_1660",
+            "OBJ_1661",
+            "OBJ_1662",
+            "OBJ_1663",
+            "OBJ_1664",
+            "OBJ_1665",
+            "OBJ_1666",
+            "OBJ_1667",
+            "OBJ_1668",
+            "OBJ_1669",
+            "OBJ_1670",
+            "OBJ_1671",
+            "OBJ_1672",
+            "OBJ_1673",
+            "OBJ_1674",
+            "OBJ_1675",
+            "OBJ_1676",
+            "OBJ_1677",
+            "OBJ_1678",
+            "OBJ_1679",
+            "OBJ_1680",
+            "OBJ_1681",
+            "OBJ_1682",
+            "OBJ_1683",
+            "OBJ_1684",
+            "OBJ_1685",
+            "OBJ_1686",
+            "OBJ_1687",
+            "OBJ_1688",
+            "OBJ_1689",
+            "OBJ_1690",
+            "OBJ_1691",
+            "OBJ_1692",
+            "OBJ_1693",
+            "OBJ_1694",
+            "OBJ_1695",
+            "OBJ_1696",
+            "OBJ_1697",
+            "OBJ_1698",
+            "OBJ_1699",
+            "OBJ_1700",
+            "OBJ_1701",
+            "OBJ_1702",
+            "OBJ_1703"
+         );
+      };
+      "OBJ_139" = {
+         isa = "PBXFileReference";
+         path = "products_Flower.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1390" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_234";
+      };
+      "OBJ_1391" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_235";
+      };
+      "OBJ_1392" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_236";
+      };
+      "OBJ_1393" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_237";
+      };
+      "OBJ_1394" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_238";
+      };
+      "OBJ_1395" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_239";
+      };
+      "OBJ_1396" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_240";
+      };
+      "OBJ_1397" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_241";
+      };
+      "OBJ_1398" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_242";
+      };
+      "OBJ_1399" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_243";
+      };
+      "OBJ_14" = {
+         isa = "PBXFileReference";
+         path = "analytics_commerce_SectionAnalytics.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_140" = {
+         isa = "PBXFileReference";
+         path = "products_Merchandise.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1400" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_244";
+      };
+      "OBJ_1401" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_245";
+      };
+      "OBJ_1402" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_246";
+      };
+      "OBJ_1403" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_247";
+      };
+      "OBJ_1404" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_248";
+      };
+      "OBJ_1405" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_249";
+      };
+      "OBJ_1406" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_250";
+      };
+      "OBJ_1407" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_251";
+      };
+      "OBJ_1408" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_252";
+      };
+      "OBJ_1409" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_253";
+      };
+      "OBJ_141" = {
+         isa = "PBXFileReference";
+         path = "products_Plant.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1410" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_254";
+      };
+      "OBJ_1411" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_255";
+      };
+      "OBJ_1412" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_256";
+      };
+      "OBJ_1413" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_257";
+      };
+      "OBJ_1414" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_258";
+      };
+      "OBJ_1415" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_259";
+      };
+      "OBJ_1416" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_260";
+      };
+      "OBJ_1417" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_261";
+      };
+      "OBJ_1418" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_262";
+      };
+      "OBJ_1419" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_263";
+      };
+      "OBJ_142" = {
+         isa = "PBXFileReference";
+         path = "products_Preroll.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1420" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_265";
+      };
+      "OBJ_1421" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_267";
+      };
+      "OBJ_1422" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_268";
+      };
+      "OBJ_1423" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_269";
+      };
+      "OBJ_1424" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_270";
+      };
+      "OBJ_1425" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_271";
+      };
+      "OBJ_1426" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_272";
+      };
+      "OBJ_1427" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_273";
+      };
+      "OBJ_1428" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_274";
+      };
+      "OBJ_1429" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_275";
+      };
+      "OBJ_143" = {
+         isa = "PBXFileReference";
+         path = "products_distribution_DistributionChannel.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1430" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_276";
+      };
+      "OBJ_1431" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_278";
+      };
+      "OBJ_1432" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_279";
+      };
+      "OBJ_1433" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_281";
+      };
+      "OBJ_1434" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_283";
+      };
+      "OBJ_1435" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_284";
+      };
+      "OBJ_1436" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_285";
+      };
+      "OBJ_1437" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_286";
+      };
+      "OBJ_1438" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_288";
+      };
+      "OBJ_1439" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_290";
+      };
+      "OBJ_144" = {
+         isa = "PBXFileReference";
+         path = "products_menu_Menu.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1440" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_291";
+      };
+      "OBJ_1441" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_292";
+      };
+      "OBJ_1442" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_293";
+      };
+      "OBJ_1443" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_294";
+      };
+      "OBJ_1444" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_295";
+      };
+      "OBJ_1445" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_296";
+      };
+      "OBJ_1446" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_297";
+      };
+      "OBJ_1447" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_298";
+      };
+      "OBJ_1448" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_299";
+      };
+      "OBJ_1449" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_300";
+      };
+      "OBJ_145" = {
+         isa = "PBXFileReference";
+         path = "products_menu_Section.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1450" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_302";
+      };
+      "OBJ_1451" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_304";
+      };
+      "OBJ_1452" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_305";
+      };
+      "OBJ_1453" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_306";
+      };
+      "OBJ_1454" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_307";
+      };
+      "OBJ_1455" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_308";
+      };
+      "OBJ_1456" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_309";
+      };
+      "OBJ_1457" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_310";
+      };
+      "OBJ_1458" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_312";
+      };
+      "OBJ_1459" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_313";
+      };
+      "OBJ_146" = {
+         isa = "PBXFileReference";
+         path = "protoc-gen-swagger_options_openapiv2.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1460" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_315";
+      };
+      "OBJ_1461" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_316";
+      };
+      "OBJ_1462" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_317";
+      };
+      "OBJ_1463" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_318";
+      };
+      "OBJ_1464" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_320";
+      };
+      "OBJ_1465" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_322";
+      };
+      "OBJ_1466" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_323";
+      };
+      "OBJ_1467" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_325";
+      };
+      "OBJ_1468" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_327";
+      };
+      "OBJ_1469" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_329";
+      };
+      "OBJ_147" = {
+         isa = "PBXFileReference";
+         path = "protoc-gen-swagger_options_swagger.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1470" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_331";
+      };
+      "OBJ_1471" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_333";
+      };
+      "OBJ_1472" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_334";
+      };
+      "OBJ_1473" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_336";
+      };
+      "OBJ_1474" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_337";
+      };
+      "OBJ_1475" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_338";
+      };
+      "OBJ_1476" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_339";
+      };
+      "OBJ_1477" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_340";
+      };
+      "OBJ_1478" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_341";
+      };
+      "OBJ_1479" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_342";
+      };
+      "OBJ_148" = {
+         isa = "PBXFileReference";
+         path = "proximity_BluetoothBeacon.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1480" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_343";
+      };
+      "OBJ_1481" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_344";
+      };
+      "OBJ_1482" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_345";
+      };
+      "OBJ_1483" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_346";
+      };
+      "OBJ_1484" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_347";
+      };
+      "OBJ_1485" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_348";
+      };
+      "OBJ_1486" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_349";
+      };
+      "OBJ_1487" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_350";
+      };
+      "OBJ_1488" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_351";
+      };
+      "OBJ_1489" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_354";
+      };
+      "OBJ_149" = {
+         isa = "PBXFileReference";
+         path = "regulatory_usa_ca_CAAgency.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1490" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_355";
+      };
+      "OBJ_1491" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_356";
+      };
+      "OBJ_1492" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_358";
+      };
+      "OBJ_1493" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_359";
+      };
+      "OBJ_1494" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_360";
+      };
+      "OBJ_1495" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_361";
+      };
+      "OBJ_1496" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_362";
+      };
+      "OBJ_1497" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_363";
+      };
+      "OBJ_1498" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_364";
+      };
+      "OBJ_1499" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_365";
+      };
+      "OBJ_15" = {
+         isa = "PBXFileReference";
+         path = "analytics_commerce_ShopAnalytics.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_150" = {
+         isa = "PBXFileReference";
+         path = "search_SearchResult.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1500" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_366";
+      };
+      "OBJ_1501" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_367";
+      };
+      "OBJ_1502" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_368";
+      };
+      "OBJ_1503" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_369";
+      };
+      "OBJ_1504" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_370";
+      };
+      "OBJ_1505" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_371";
+      };
+      "OBJ_1506" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_372";
+      };
+      "OBJ_1507" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_373";
+      };
+      "OBJ_1508" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_374";
+      };
+      "OBJ_1509" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_375";
+      };
+      "OBJ_151" = {
+         isa = "PBXFileReference";
+         path = "search_SearchSpec.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1510" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_377";
+      };
+      "OBJ_1511" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_378";
+      };
+      "OBJ_1512" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_379";
+      };
+      "OBJ_1513" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_380";
+      };
+      "OBJ_1514" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_382";
+      };
+      "OBJ_1515" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_384";
+      };
+      "OBJ_1516" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_385";
+      };
+      "OBJ_1517" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_387";
+      };
+      "OBJ_1518" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_388";
+      };
+      "OBJ_1519" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_389";
+      };
+      "OBJ_152" = {
+         isa = "PBXFileReference";
+         path = "security_DeviceTicket.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1520" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_390";
+      };
+      "OBJ_1521" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_391";
+      };
+      "OBJ_1522" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_392";
+      };
+      "OBJ_1523" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_393";
+      };
+      "OBJ_1524" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_394";
+      };
+      "OBJ_1525" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_395";
+      };
+      "OBJ_1526" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_396";
+      };
+      "OBJ_1527" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_398";
+      };
+      "OBJ_1528" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_400";
+      };
+      "OBJ_1529" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_401";
+      };
+      "OBJ_153" = {
+         isa = "PBXFileReference";
+         path = "security_IdentityToken.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1530" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_403";
+      };
+      "OBJ_1531" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_405";
+      };
+      "OBJ_1532" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_407";
+      };
+      "OBJ_1533" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_408";
+      };
+      "OBJ_1534" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_409";
+      };
+      "OBJ_1535" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_410";
+      };
+      "OBJ_1536" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_411";
+      };
+      "OBJ_1537" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_412";
+      };
+      "OBJ_1538" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_414";
+      };
+      "OBJ_1539" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_415";
+      };
+      "OBJ_154" = {
+         isa = "PBXFileReference";
+         path = "security_Token.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1540" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_416";
+      };
+      "OBJ_1541" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_418";
+      };
+      "OBJ_1542" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_419";
+      };
+      "OBJ_1543" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_420";
+      };
+      "OBJ_1544" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_421";
+      };
+      "OBJ_1545" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_423";
+      };
+      "OBJ_1546" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_424";
+      };
+      "OBJ_1547" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_425";
+      };
+      "OBJ_1548" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_426";
+      };
+      "OBJ_1549" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_428";
+      };
+      "OBJ_155" = {
+         isa = "PBXFileReference";
+         path = "security_access_PartnerPermissions.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1550" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_430";
+      };
+      "OBJ_1551" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_431";
+      };
+      "OBJ_1552" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_433";
+      };
+      "OBJ_1553" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_434";
+      };
+      "OBJ_1554" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_436";
+      };
+      "OBJ_1555" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_437";
+      };
+      "OBJ_1556" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_438";
+      };
+      "OBJ_1557" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_439";
+      };
+      "OBJ_1558" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_440";
+      };
+      "OBJ_1559" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_441";
+      };
+      "OBJ_156" = {
+         isa = "PBXFileReference";
+         path = "services_ServiceStatus.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1560" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_442";
+      };
+      "OBJ_1561" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_443";
+      };
+      "OBJ_1562" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_445";
+      };
+      "OBJ_1563" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_446";
+      };
+      "OBJ_1564" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_448";
+      };
+      "OBJ_1565" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_449";
+      };
+      "OBJ_1566" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_450";
+      };
+      "OBJ_1567" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_452";
+      };
+      "OBJ_1568" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_453";
+      };
+      "OBJ_1569" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_454";
+      };
+      "OBJ_157" = {
+         isa = "PBXFileReference";
+         path = "shop_v1_ShopService_v1.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1570" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_456";
+      };
+      "OBJ_1571" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_458";
+      };
+      "OBJ_1572" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_459";
+      };
+      "OBJ_1573" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_460";
+      };
+      "OBJ_1574" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_461";
+      };
+      "OBJ_1575" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_462";
+      };
+      "OBJ_1576" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_464";
+      };
+      "OBJ_1577" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_465";
+      };
+      "OBJ_1578" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_466";
+      };
+      "OBJ_1579" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_468";
+      };
+      "OBJ_158" = {
+         isa = "PBXFileReference";
+         path = "structs_Genetics.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1580" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_470";
+      };
+      "OBJ_1581" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_471";
+      };
+      "OBJ_1582" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_472";
+      };
+      "OBJ_1583" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_473";
+      };
+      "OBJ_1584" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_474";
+      };
+      "OBJ_1585" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_476";
+      };
+      "OBJ_1586" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_477";
+      };
+      "OBJ_1587" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_478";
+      };
+      "OBJ_1588" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_479";
+      };
+      "OBJ_1589" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_480";
+      };
+      "OBJ_159" = {
+         isa = "PBXFileReference";
+         path = "structs_Grow.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1590" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_481";
+      };
+      "OBJ_1591" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_482";
+      };
+      "OBJ_1592" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_483";
+      };
+      "OBJ_1593" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_484";
+      };
+      "OBJ_1594" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_485";
+      };
+      "OBJ_1595" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_486";
+      };
+      "OBJ_1596" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_487";
+      };
+      "OBJ_1597" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_488";
+      };
+      "OBJ_1598" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_489";
+      };
+      "OBJ_1599" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_490";
+      };
+      "OBJ_16" = {
+         isa = "PBXFileReference";
+         path = "analytics_consumption_Biodelivery.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_160" = {
+         isa = "PBXFileReference";
+         path = "structs_ProductFlags.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1600" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_491";
+      };
+      "OBJ_1601" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_492";
+      };
+      "OBJ_1602" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_493";
+      };
+      "OBJ_1603" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_494";
+      };
+      "OBJ_1604" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_495";
+      };
+      "OBJ_1605" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_496";
+      };
+      "OBJ_1606" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_497";
+      };
+      "OBJ_1607" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_498";
+      };
+      "OBJ_1608" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_499";
+      };
+      "OBJ_1609" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_500";
+      };
+      "OBJ_161" = {
+         isa = "PBXFileReference";
+         path = "structs_Shelf.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1610" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_501";
+      };
+      "OBJ_1611" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_502";
+      };
+      "OBJ_1612" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_503";
+      };
+      "OBJ_1613" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_504";
+      };
+      "OBJ_1614" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_505";
+      };
+      "OBJ_1615" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_506";
+      };
+      "OBJ_1616" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_507";
+      };
+      "OBJ_1617" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_508";
+      };
+      "OBJ_1618" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_509";
+      };
+      "OBJ_1619" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_510";
+      };
+      "OBJ_162" = {
+         isa = "PBXFileReference";
+         path = "structs_Species.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1620" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_511";
+      };
+      "OBJ_1621" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_512";
+      };
+      "OBJ_1622" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_513";
+      };
+      "OBJ_1623" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_514";
+      };
+      "OBJ_1624" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_515";
+      };
+      "OBJ_1625" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_516";
+      };
+      "OBJ_1626" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_517";
+      };
+      "OBJ_1627" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_518";
+      };
+      "OBJ_1628" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_519";
+      };
+      "OBJ_1629" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_520";
+      };
+      "OBJ_163" = {
+         isa = "PBXFileReference";
+         path = "structs_Version.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1630" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_521";
+      };
+      "OBJ_1631" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_522";
+      };
+      "OBJ_1632" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_523";
+      };
+      "OBJ_1633" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_524";
+      };
+      "OBJ_1634" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_526";
+      };
+      "OBJ_1635" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_527";
+      };
+      "OBJ_1636" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_528";
+      };
+      "OBJ_1637" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_529";
+      };
+      "OBJ_1638" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_530";
+      };
+      "OBJ_1639" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_531";
+      };
+      "OBJ_164" = {
+         isa = "PBXFileReference";
+         path = "structs_labtesting_TestResults.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1640" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_532";
+      };
+      "OBJ_1641" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_533";
+      };
+      "OBJ_1642" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_534";
+      };
+      "OBJ_1643" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_535";
+      };
+      "OBJ_1644" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_536";
+      };
+      "OBJ_1645" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_537";
+      };
+      "OBJ_1646" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_538";
+      };
+      "OBJ_1647" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_539";
+      };
+      "OBJ_1648" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_540";
+      };
+      "OBJ_1649" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_541";
+      };
+      "OBJ_165" = {
+         isa = "PBXFileReference";
+         path = "structs_labtesting_TestValue.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1650" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_542";
+      };
+      "OBJ_1651" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_543";
+      };
+      "OBJ_1652" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_544";
+      };
+      "OBJ_1653" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_545";
+      };
+      "OBJ_1654" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_546";
+      };
+      "OBJ_1655" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_547";
+      };
+      "OBJ_1656" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_548";
+      };
+      "OBJ_1657" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_549";
+      };
+      "OBJ_1658" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_550";
+      };
+      "OBJ_1659" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_551";
+      };
+      "OBJ_166" = {
+         isa = "PBXFileReference";
+         path = "structs_pricing_PricingDescriptor.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1660" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_552";
+      };
+      "OBJ_1661" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_553";
+      };
+      "OBJ_1662" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_554";
+      };
+      "OBJ_1663" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_555";
+      };
+      "OBJ_1664" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_556";
+      };
+      "OBJ_1665" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_557";
+      };
+      "OBJ_1666" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_558";
+      };
+      "OBJ_1667" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_560";
+      };
+      "OBJ_1668" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_561";
+      };
+      "OBJ_1669" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_562";
+      };
+      "OBJ_167" = {
+         isa = "PBXFileReference";
+         path = "structs_pricing_SaleDescriptor.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1670" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_563";
+      };
+      "OBJ_1671" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_564";
+      };
+      "OBJ_1672" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_565";
+      };
+      "OBJ_1673" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_566";
+      };
+      "OBJ_1674" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_567";
+      };
+      "OBJ_1675" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_568";
+      };
+      "OBJ_1676" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_569";
+      };
+      "OBJ_1677" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_570";
+      };
+      "OBJ_1678" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_571";
+      };
+      "OBJ_1679" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_572";
+      };
+      "OBJ_168" = {
+         isa = "PBXFileReference";
+         path = "telemetry_v1beta4_GenericEvents_Beta4.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1680" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_573";
+      };
+      "OBJ_1681" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_574";
+      };
+      "OBJ_1682" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_575";
+      };
+      "OBJ_1683" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_576";
+      };
+      "OBJ_1684" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_577";
+      };
+      "OBJ_1685" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_578";
+      };
+      "OBJ_1686" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_579";
+      };
+      "OBJ_1687" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_580";
+      };
+      "OBJ_1688" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_581";
+      };
+      "OBJ_1689" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_582";
+      };
+      "OBJ_169" = {
+         isa = "PBXFileReference";
+         path = "telemetry_v1beta4_TelemetryEvent_Beta4.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1690" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_583";
+      };
+      "OBJ_1691" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_584";
+      };
+      "OBJ_1692" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_585";
+      };
+      "OBJ_1693" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_586";
+      };
+      "OBJ_1694" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_587";
+      };
+      "OBJ_1695" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_588";
+      };
+      "OBJ_1696" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_589";
+      };
+      "OBJ_1697" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_590";
+      };
+      "OBJ_1698" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_591";
+      };
+      "OBJ_1699" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_592";
+      };
+      "OBJ_17" = {
+         isa = "PBXFileReference";
+         path = "analytics_context_Application.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_170" = {
+         isa = "PBXFileReference";
+         path = "telemetry_v1beta4_TelemetryService_Beta4.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1700" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_593";
+      };
+      "OBJ_1701" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_594";
+      };
+      "OBJ_1702" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_595";
+      };
+      "OBJ_1703" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_598";
+      };
+      "OBJ_1704" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_1705" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_1706",
+            "OBJ_1707"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_1706" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+            DEFINES_MODULE = "NO";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            GCC_C_LANGUAGE_STANDARD = "gnu11";
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/CgRPC_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "CgRPC";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "CgRPC";
+         };
+         name = "Debug";
+      };
+      "OBJ_1707" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+            DEFINES_MODULE = "NO";
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            GCC_C_LANGUAGE_STANDARD = "gnu11";
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/CgRPC_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "CgRPC";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            TARGET_NAME = "CgRPC";
+         };
+         name = "Release";
+      };
+      "OBJ_1708" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_1709",
+            "OBJ_1710",
+            "OBJ_1711",
+            "OBJ_1712",
+            "OBJ_1713",
+            "OBJ_1714",
+            "OBJ_1715",
+            "OBJ_1716",
+            "OBJ_1717",
+            "OBJ_1718",
+            "OBJ_1719",
+            "OBJ_1720",
+            "OBJ_1721",
+            "OBJ_1722",
+            "OBJ_1723",
+            "OBJ_1724",
+            "OBJ_1725",
+            "OBJ_1726",
+            "OBJ_1727",
+            "OBJ_1728",
+            "OBJ_1729",
+            "OBJ_1730",
+            "OBJ_1731",
+            "OBJ_1732",
+            "OBJ_1733",
+            "OBJ_1734",
+            "OBJ_1735",
+            "OBJ_1736",
+            "OBJ_1737",
+            "OBJ_1738",
+            "OBJ_1739",
+            "OBJ_1740",
+            "OBJ_1741",
+            "OBJ_1742",
+            "OBJ_1743",
+            "OBJ_1744",
+            "OBJ_1745",
+            "OBJ_1746",
+            "OBJ_1747",
+            "OBJ_1748",
+            "OBJ_1749",
+            "OBJ_1750",
+            "OBJ_1751",
+            "OBJ_1752",
+            "OBJ_1753",
+            "OBJ_1754",
+            "OBJ_1755",
+            "OBJ_1756",
+            "OBJ_1757",
+            "OBJ_1758",
+            "OBJ_1759",
+            "OBJ_1760",
+            "OBJ_1761",
+            "OBJ_1762",
+            "OBJ_1763",
+            "OBJ_1764",
+            "OBJ_1765",
+            "OBJ_1766",
+            "OBJ_1767",
+            "OBJ_1768",
+            "OBJ_1769",
+            "OBJ_1770",
+            "OBJ_1771",
+            "OBJ_1772",
+            "OBJ_1773",
+            "OBJ_1774",
+            "OBJ_1775",
+            "OBJ_1776",
+            "OBJ_1777",
+            "OBJ_1778",
+            "OBJ_1779",
+            "OBJ_1780",
+            "OBJ_1781",
+            "OBJ_1782",
+            "OBJ_1783",
+            "OBJ_1784",
+            "OBJ_1785",
+            "OBJ_1786",
+            "OBJ_1787",
+            "OBJ_1788",
+            "OBJ_1789",
+            "OBJ_1790",
+            "OBJ_1791",
+            "OBJ_1792",
+            "OBJ_1793",
+            "OBJ_1794",
+            "OBJ_1795",
+            "OBJ_1796",
+            "OBJ_1797",
+            "OBJ_1798",
+            "OBJ_1799",
+            "OBJ_1800",
+            "OBJ_1801",
+            "OBJ_1802",
+            "OBJ_1803",
+            "OBJ_1804",
+            "OBJ_1805",
+            "OBJ_1806",
+            "OBJ_1807",
+            "OBJ_1808",
+            "OBJ_1809",
+            "OBJ_1810",
+            "OBJ_1811",
+            "OBJ_1812",
+            "OBJ_1813",
+            "OBJ_1814",
+            "OBJ_1815",
+            "OBJ_1816",
+            "OBJ_1817",
+            "OBJ_1818",
+            "OBJ_1819",
+            "OBJ_1820",
+            "OBJ_1821",
+            "OBJ_1822",
+            "OBJ_1823",
+            "OBJ_1824",
+            "OBJ_1825",
+            "OBJ_1826",
+            "OBJ_1827",
+            "OBJ_1828",
+            "OBJ_1829",
+            "OBJ_1830",
+            "OBJ_1831",
+            "OBJ_1832",
+            "OBJ_1833",
+            "OBJ_1834",
+            "OBJ_1835",
+            "OBJ_1836",
+            "OBJ_1837",
+            "OBJ_1838",
+            "OBJ_1839",
+            "OBJ_1840",
+            "OBJ_1841",
+            "OBJ_1842",
+            "OBJ_1843",
+            "OBJ_1844",
+            "OBJ_1845",
+            "OBJ_1846",
+            "OBJ_1847",
+            "OBJ_1848",
+            "OBJ_1849",
+            "OBJ_1850",
+            "OBJ_1851",
+            "OBJ_1852",
+            "OBJ_1853",
+            "OBJ_1854",
+            "OBJ_1855",
+            "OBJ_1856",
+            "OBJ_1857",
+            "OBJ_1858",
+            "OBJ_1859",
+            "OBJ_1860",
+            "OBJ_1861",
+            "OBJ_1862",
+            "OBJ_1863",
+            "OBJ_1864",
+            "OBJ_1865",
+            "OBJ_1866",
+            "OBJ_1867",
+            "OBJ_1868",
+            "OBJ_1869",
+            "OBJ_1870",
+            "OBJ_1871",
+            "OBJ_1872",
+            "OBJ_1873",
+            "OBJ_1874",
+            "OBJ_1875",
+            "OBJ_1876",
+            "OBJ_1877",
+            "OBJ_1878",
+            "OBJ_1879",
+            "OBJ_1880",
+            "OBJ_1881",
+            "OBJ_1882",
+            "OBJ_1883",
+            "OBJ_1884",
+            "OBJ_1885",
+            "OBJ_1886",
+            "OBJ_1887",
+            "OBJ_1888",
+            "OBJ_1889",
+            "OBJ_1890",
+            "OBJ_1891",
+            "OBJ_1892",
+            "OBJ_1893",
+            "OBJ_1894",
+            "OBJ_1895",
+            "OBJ_1896",
+            "OBJ_1897",
+            "OBJ_1898",
+            "OBJ_1899",
+            "OBJ_1900",
+            "OBJ_1901",
+            "OBJ_1902",
+            "OBJ_1903",
+            "OBJ_1904",
+            "OBJ_1905",
+            "OBJ_1906",
+            "OBJ_1907",
+            "OBJ_1908",
+            "OBJ_1909",
+            "OBJ_1910",
+            "OBJ_1911",
+            "OBJ_1912",
+            "OBJ_1913",
+            "OBJ_1914",
+            "OBJ_1915",
+            "OBJ_1916",
+            "OBJ_1917",
+            "OBJ_1918",
+            "OBJ_1919",
+            "OBJ_1920",
+            "OBJ_1921",
+            "OBJ_1922",
+            "OBJ_1923",
+            "OBJ_1924",
+            "OBJ_1925",
+            "OBJ_1926",
+            "OBJ_1927",
+            "OBJ_1928",
+            "OBJ_1929",
+            "OBJ_1930",
+            "OBJ_1931",
+            "OBJ_1932",
+            "OBJ_1933",
+            "OBJ_1934",
+            "OBJ_1935",
+            "OBJ_1936",
+            "OBJ_1937",
+            "OBJ_1938",
+            "OBJ_1939",
+            "OBJ_1940",
+            "OBJ_1941",
+            "OBJ_1942",
+            "OBJ_1943",
+            "OBJ_1944",
+            "OBJ_1945",
+            "OBJ_1946",
+            "OBJ_1947",
+            "OBJ_1948",
+            "OBJ_1949",
+            "OBJ_1950",
+            "OBJ_1951",
+            "OBJ_1952",
+            "OBJ_1953",
+            "OBJ_1954",
+            "OBJ_1955",
+            "OBJ_1956",
+            "OBJ_1957",
+            "OBJ_1958",
+            "OBJ_1959",
+            "OBJ_1960",
+            "OBJ_1961",
+            "OBJ_1962",
+            "OBJ_1963",
+            "OBJ_1964",
+            "OBJ_1965",
+            "OBJ_1966",
+            "OBJ_1967",
+            "OBJ_1968",
+            "OBJ_1969",
+            "OBJ_1970",
+            "OBJ_1971",
+            "OBJ_1972",
+            "OBJ_1973",
+            "OBJ_1974",
+            "OBJ_1975",
+            "OBJ_1976",
+            "OBJ_1977",
+            "OBJ_1978",
+            "OBJ_1979",
+            "OBJ_1980",
+            "OBJ_1981",
+            "OBJ_1982",
+            "OBJ_1983",
+            "OBJ_1984",
+            "OBJ_1985",
+            "OBJ_1986",
+            "OBJ_1987",
+            "OBJ_1988",
+            "OBJ_1989",
+            "OBJ_1990",
+            "OBJ_1991",
+            "OBJ_1992",
+            "OBJ_1993",
+            "OBJ_1994",
+            "OBJ_1995",
+            "OBJ_1996",
+            "OBJ_1997",
+            "OBJ_1998",
+            "OBJ_1999",
+            "OBJ_2000",
+            "OBJ_2001",
+            "OBJ_2002",
+            "OBJ_2003",
+            "OBJ_2004",
+            "OBJ_2005",
+            "OBJ_2006",
+            "OBJ_2007",
+            "OBJ_2008",
+            "OBJ_2009",
+            "OBJ_2010",
+            "OBJ_2011",
+            "OBJ_2012",
+            "OBJ_2013",
+            "OBJ_2014",
+            "OBJ_2015",
+            "OBJ_2016",
+            "OBJ_2017",
+            "OBJ_2018",
+            "OBJ_2019",
+            "OBJ_2020",
+            "OBJ_2021",
+            "OBJ_2022",
+            "OBJ_2023",
+            "OBJ_2024",
+            "OBJ_2025",
+            "OBJ_2026",
+            "OBJ_2027",
+            "OBJ_2028",
+            "OBJ_2029",
+            "OBJ_2030",
+            "OBJ_2031",
+            "OBJ_2032",
+            "OBJ_2033",
+            "OBJ_2034",
+            "OBJ_2035",
+            "OBJ_2036",
+            "OBJ_2037",
+            "OBJ_2038",
+            "OBJ_2039",
+            "OBJ_2040",
+            "OBJ_2041",
+            "OBJ_2042",
+            "OBJ_2043",
+            "OBJ_2044",
+            "OBJ_2045",
+            "OBJ_2046",
+            "OBJ_2047",
+            "OBJ_2048",
+            "OBJ_2049",
+            "OBJ_2050",
+            "OBJ_2051",
+            "OBJ_2052",
+            "OBJ_2053",
+            "OBJ_2054",
+            "OBJ_2055",
+            "OBJ_2056",
+            "OBJ_2057",
+            "OBJ_2058",
+            "OBJ_2059",
+            "OBJ_2060",
+            "OBJ_2061",
+            "OBJ_2062"
+         );
+      };
+      "OBJ_1709" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_713";
+      };
+      "OBJ_171" = {
+         isa = "PBXFileReference";
+         path = "temporal_Date.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1710" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_714";
+      };
+      "OBJ_1711" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_715";
+      };
+      "OBJ_1712" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_716";
+      };
+      "OBJ_1713" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_717";
+      };
+      "OBJ_1714" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_718";
+      };
+      "OBJ_1715" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_719";
+      };
+      "OBJ_1716" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_720";
+      };
+      "OBJ_1717" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_721";
+      };
+      "OBJ_1718" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_722";
+      };
+      "OBJ_1719" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_723";
+      };
+      "OBJ_172" = {
+         isa = "PBXFileReference";
+         path = "temporal_Duration.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1720" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_724";
+      };
+      "OBJ_1721" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_729";
+      };
+      "OBJ_1722" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_732";
+      };
+      "OBJ_1723" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_733";
+      };
+      "OBJ_1724" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_734";
+      };
+      "OBJ_1725" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_735";
+      };
+      "OBJ_1726" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_736";
+      };
+      "OBJ_1727" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_737";
+      };
+      "OBJ_1728" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_738";
+      };
+      "OBJ_1729" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_739";
+      };
+      "OBJ_173" = {
+         isa = "PBXFileReference";
+         path = "temporal_Instant.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1730" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_740";
+      };
+      "OBJ_1731" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_743";
+      };
+      "OBJ_1732" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_744";
+      };
+      "OBJ_1733" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_745";
+      };
+      "OBJ_1734" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_746";
+      };
+      "OBJ_1735" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_747";
+      };
+      "OBJ_1736" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_752";
+      };
+      "OBJ_1737" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_754";
+      };
+      "OBJ_1738" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_756";
+      };
+      "OBJ_1739" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_757";
+      };
+      "OBJ_174" = {
+         isa = "PBXFileReference";
+         path = "temporal_Interval.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1740" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_758";
+      };
+      "OBJ_1741" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_759";
+      };
+      "OBJ_1742" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_760";
+      };
+      "OBJ_1743" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_761";
+      };
+      "OBJ_1744" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_762";
+      };
+      "OBJ_1745" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_763";
+      };
+      "OBJ_1746" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_767";
+      };
+      "OBJ_1747" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_768";
+      };
+      "OBJ_1748" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_769";
+      };
+      "OBJ_1749" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_770";
+      };
+      "OBJ_175" = {
+         isa = "PBXFileReference";
+         path = "temporal_Schedule.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1750" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_772";
+      };
+      "OBJ_1751" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_774";
+      };
+      "OBJ_1752" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_776";
+      };
+      "OBJ_1753" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_777";
+      };
+      "OBJ_1754" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_778";
+      };
+      "OBJ_1755" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_779";
+      };
+      "OBJ_1756" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_780";
+      };
+      "OBJ_1757" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_781";
+      };
+      "OBJ_1758" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_783";
+      };
+      "OBJ_1759" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_786";
+      };
+      "OBJ_176" = {
+         isa = "PBXFileReference";
+         path = "temporal_Time.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1760" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_787";
+      };
+      "OBJ_1761" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_788";
+      };
+      "OBJ_1762" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_790";
+      };
+      "OBJ_1763" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_792";
+      };
+      "OBJ_1764" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_794";
+      };
+      "OBJ_1765" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_795";
+      };
+      "OBJ_1766" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_797";
+      };
+      "OBJ_1767" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_799";
+      };
+      "OBJ_1768" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_801";
+      };
+      "OBJ_1769" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_802";
+      };
+      "OBJ_177" = {
+         isa = "PBXFileReference";
+         path = "temporal_Timehash.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1770" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_806";
+      };
+      "OBJ_1771" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_808";
+      };
+      "OBJ_1772" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_809";
+      };
+      "OBJ_1773" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_811";
+      };
+      "OBJ_1774" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_812";
+      };
+      "OBJ_1775" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_814";
+      };
+      "OBJ_1776" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_816";
+      };
+      "OBJ_1777" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_818";
+      };
+      "OBJ_1778" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_819";
+      };
+      "OBJ_1779" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_821";
+      };
+      "OBJ_178" = {
+         isa = "PBXFileReference";
+         path = "wallet_v1_WalletService_v1.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1780" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_823";
+      };
+      "OBJ_1781" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_824";
+      };
+      "OBJ_1782" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_825";
+      };
+      "OBJ_1783" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_826";
+      };
+      "OBJ_1784" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_827";
+      };
+      "OBJ_1785" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_828";
+      };
+      "OBJ_1786" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_829";
+      };
+      "OBJ_1787" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_830";
+      };
+      "OBJ_1788" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_831";
+      };
+      "OBJ_1789" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_832";
+      };
+      "OBJ_179" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_180",
+            "OBJ_181",
+            "OBJ_182",
+            "OBJ_183",
+            "OBJ_184",
+            "OBJ_185",
+            "OBJ_186",
+            "OBJ_187",
+            "OBJ_188",
+            "OBJ_189"
+         );
+         name = "BloomboxServices";
+         path = "Sources/Services";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_1790" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_833";
+      };
+      "OBJ_1791" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_834";
+      };
+      "OBJ_1792" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_835";
+      };
+      "OBJ_1793" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_836";
+      };
+      "OBJ_1794" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_837";
+      };
+      "OBJ_1795" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_838";
+      };
+      "OBJ_1796" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_839";
+      };
+      "OBJ_1797" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_840";
+      };
+      "OBJ_1798" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_841";
+      };
+      "OBJ_1799" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_842";
+      };
+      "OBJ_18" = {
+         isa = "PBXFileReference";
+         path = "analytics_context_Browser.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_180" = {
+         isa = "PBXFileReference";
+         path = "AuthService_Beta1.grpc.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1800" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_843";
+      };
+      "OBJ_1801" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_844";
+      };
+      "OBJ_1802" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_846";
+      };
+      "OBJ_1803" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_847";
+      };
+      "OBJ_1804" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_850";
+      };
+      "OBJ_1805" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_852";
+      };
+      "OBJ_1806" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_854";
+      };
+      "OBJ_1807" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_855";
+      };
+      "OBJ_1808" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_856";
+      };
+      "OBJ_1809" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_857";
+      };
+      "OBJ_181" = {
+         isa = "PBXFileReference";
+         path = "DevicesService_Beta1.grpc.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1810" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_858";
+      };
+      "OBJ_1811" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_859";
+      };
+      "OBJ_1812" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_860";
+      };
+      "OBJ_1813" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_861";
+      };
+      "OBJ_1814" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_862";
+      };
+      "OBJ_1815" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_863";
+      };
+      "OBJ_1816" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_865";
+      };
+      "OBJ_1817" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_866";
+      };
+      "OBJ_1818" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_867";
+      };
+      "OBJ_1819" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_868";
+      };
+      "OBJ_182" = {
+         isa = "PBXFileReference";
+         path = "IdentityService_Beta1.grpc.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1820" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_869";
+      };
+      "OBJ_1821" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_870";
+      };
+      "OBJ_1822" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_872";
+      };
+      "OBJ_1823" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_873";
+      };
+      "OBJ_1824" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_874";
+      };
+      "OBJ_1825" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_876";
+      };
+      "OBJ_1826" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_877";
+      };
+      "OBJ_1827" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_878";
+      };
+      "OBJ_1828" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_879";
+      };
+      "OBJ_1829" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_880";
+      };
+      "OBJ_183" = {
+         isa = "PBXFileReference";
+         path = "MediaService_Beta1.grpc.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1830" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_881";
+      };
+      "OBJ_1831" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_882";
+      };
+      "OBJ_1832" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_883";
+      };
+      "OBJ_1833" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_884";
+      };
+      "OBJ_1834" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_885";
+      };
+      "OBJ_1835" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_886";
+      };
+      "OBJ_1836" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_887";
+      };
+      "OBJ_1837" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_888";
+      };
+      "OBJ_1838" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_889";
+      };
+      "OBJ_1839" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_890";
+      };
+      "OBJ_184" = {
+         isa = "PBXFileReference";
+         path = "MenuService_Beta1.grpc.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1840" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_891";
+      };
+      "OBJ_1841" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_892";
+      };
+      "OBJ_1842" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_893";
+      };
+      "OBJ_1843" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_894";
+      };
+      "OBJ_1844" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_895";
+      };
+      "OBJ_1845" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_896";
+      };
+      "OBJ_1846" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_897";
+      };
+      "OBJ_1847" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_898";
+      };
+      "OBJ_1848" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_899";
+      };
+      "OBJ_1849" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_900";
+      };
+      "OBJ_185" = {
+         isa = "PBXFileReference";
+         path = "POSService_Beta1.grpc.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1850" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_901";
+      };
+      "OBJ_1851" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_902";
+      };
+      "OBJ_1852" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_903";
+      };
+      "OBJ_1853" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_904";
+      };
+      "OBJ_1854" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_905";
+      };
+      "OBJ_1855" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_906";
+      };
+      "OBJ_1856" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_907";
+      };
+      "OBJ_1857" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_908";
+      };
+      "OBJ_1858" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_909";
+      };
+      "OBJ_1859" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_910";
+      };
+      "OBJ_186" = {
+         isa = "PBXFileReference";
+         path = "PlatformService_v1.grpc.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1860" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_912";
+      };
+      "OBJ_1861" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_913";
+      };
+      "OBJ_1862" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_915";
+      };
+      "OBJ_1863" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_916";
+      };
+      "OBJ_1864" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_917";
+      };
+      "OBJ_1865" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_918";
+      };
+      "OBJ_1866" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_920";
+      };
+      "OBJ_1867" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_921";
+      };
+      "OBJ_1868" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_922";
+      };
+      "OBJ_1869" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_923";
+      };
+      "OBJ_187" = {
+         isa = "PBXFileReference";
+         path = "ShopService_v1.grpc.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1870" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_924";
+      };
+      "OBJ_1871" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_925";
+      };
+      "OBJ_1872" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_926";
+      };
+      "OBJ_1873" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_927";
+      };
+      "OBJ_1874" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_928";
+      };
+      "OBJ_1875" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_929";
+      };
+      "OBJ_1876" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_930";
+      };
+      "OBJ_1877" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_931";
+      };
+      "OBJ_1878" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_932";
+      };
+      "OBJ_1879" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_933";
+      };
+      "OBJ_188" = {
+         isa = "PBXFileReference";
+         path = "TelemetryService_Beta4.grpc.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1880" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_934";
+      };
+      "OBJ_1881" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_935";
+      };
+      "OBJ_1882" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_936";
+      };
+      "OBJ_1883" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_937";
+      };
+      "OBJ_1884" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_938";
+      };
+      "OBJ_1885" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_939";
+      };
+      "OBJ_1886" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_940";
+      };
+      "OBJ_1887" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_941";
+      };
+      "OBJ_1888" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_942";
+      };
+      "OBJ_1889" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_943";
+      };
+      "OBJ_189" = {
+         isa = "PBXFileReference";
+         path = "WalletService_v1.grpc.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1890" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_944";
+      };
+      "OBJ_1891" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_945";
+      };
+      "OBJ_1892" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_946";
+      };
+      "OBJ_1893" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_947";
+      };
+      "OBJ_1894" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_948";
+      };
+      "OBJ_1895" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_949";
+      };
+      "OBJ_1896" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_950";
+      };
+      "OBJ_1897" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_951";
+      };
+      "OBJ_1898" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_952";
+      };
+      "OBJ_1899" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_953";
+      };
+      "OBJ_19" = {
+         isa = "PBXFileReference";
+         path = "analytics_context_Collection.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_190" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_191",
+            "OBJ_192",
+            "OBJ_193",
+            "OBJ_194",
+            "OBJ_195",
+            "OBJ_196",
+            "OBJ_197",
+            "OBJ_198",
+            "OBJ_199",
+            "OBJ_200",
+            "OBJ_201",
+            "OBJ_202",
+            "OBJ_203",
+            "OBJ_204",
+            "OBJ_205",
+            "OBJ_206",
+            "OBJ_207",
+            "OBJ_208",
+            "OBJ_209",
+            "OBJ_210"
+         );
+         name = "Bloombox";
+         path = "Sources/Client";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_1900" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_954";
+      };
+      "OBJ_1901" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_955";
+      };
+      "OBJ_1902" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_956";
+      };
+      "OBJ_1903" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_957";
+      };
+      "OBJ_1904" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_958";
+      };
+      "OBJ_1905" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_959";
+      };
+      "OBJ_1906" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_960";
+      };
+      "OBJ_1907" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_961";
+      };
+      "OBJ_1908" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_962";
+      };
+      "OBJ_1909" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_963";
+      };
+      "OBJ_191" = {
+         isa = "PBXFileReference";
+         path = "AuthClient.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1910" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_964";
+      };
+      "OBJ_1911" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_965";
+      };
+      "OBJ_1912" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_966";
+      };
+      "OBJ_1913" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_967";
+      };
+      "OBJ_1914" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_968";
+      };
+      "OBJ_1915" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_969";
+      };
+      "OBJ_1916" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_970";
+      };
+      "OBJ_1917" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_971";
+      };
+      "OBJ_1918" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_972";
+      };
+      "OBJ_1919" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_973";
+      };
+      "OBJ_192" = {
+         isa = "PBXFileReference";
+         path = "Bindings.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1920" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_974";
+      };
+      "OBJ_1921" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_975";
+      };
+      "OBJ_1922" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_976";
+      };
+      "OBJ_1923" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_977";
+      };
+      "OBJ_1924" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_978";
+      };
+      "OBJ_1925" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_979";
+      };
+      "OBJ_1926" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_980";
+      };
+      "OBJ_1927" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_981";
+      };
+      "OBJ_1928" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_982";
+      };
+      "OBJ_1929" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_983";
+      };
+      "OBJ_193" = {
+         isa = "PBXFileReference";
+         path = "Bloombox.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1930" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_984";
+      };
+      "OBJ_1931" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_985";
+      };
+      "OBJ_1932" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_986";
+      };
+      "OBJ_1933" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_987";
+      };
+      "OBJ_1934" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_988";
+      };
+      "OBJ_1935" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_989";
+      };
+      "OBJ_1936" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_990";
+      };
+      "OBJ_1937" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_991";
+      };
+      "OBJ_1938" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_992";
+      };
+      "OBJ_1939" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_993";
+      };
+      "OBJ_194" = {
+         isa = "PBXFileReference";
+         path = "DevicesClient.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1940" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_994";
+      };
+      "OBJ_1941" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_995";
+      };
+      "OBJ_1942" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_996";
+      };
+      "OBJ_1943" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_997";
+      };
+      "OBJ_1944" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_998";
+      };
+      "OBJ_1945" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_999";
+      };
+      "OBJ_1946" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1000";
+      };
+      "OBJ_1947" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1001";
+      };
+      "OBJ_1948" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1002";
+      };
+      "OBJ_1949" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1004";
+      };
+      "OBJ_195" = {
+         isa = "PBXFileReference";
+         path = "EventCollection.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1950" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1005";
+      };
+      "OBJ_1951" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1006";
+      };
+      "OBJ_1952" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1007";
+      };
+      "OBJ_1953" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1009";
+      };
+      "OBJ_1954" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1010";
+      };
+      "OBJ_1955" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1013";
+      };
+      "OBJ_1956" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1016";
+      };
+      "OBJ_1957" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1017";
+      };
+      "OBJ_1958" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1018";
+      };
+      "OBJ_1959" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1019";
+      };
+      "OBJ_196" = {
+         isa = "PBXFileReference";
+         path = "EventContext.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1960" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1020";
+      };
+      "OBJ_1961" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1021";
+      };
+      "OBJ_1962" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1022";
+      };
+      "OBJ_1963" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1023";
+      };
+      "OBJ_1964" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1025";
+      };
+      "OBJ_1965" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1026";
+      };
+      "OBJ_1966" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1027";
+      };
+      "OBJ_1967" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1029";
+      };
+      "OBJ_1968" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1031";
+      };
+      "OBJ_1969" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1032";
+      };
+      "OBJ_197" = {
+         isa = "PBXFileReference";
+         path = "IdentityClient.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1970" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1034";
+      };
+      "OBJ_1971" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1036";
+      };
+      "OBJ_1972" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1037";
+      };
+      "OBJ_1973" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1038";
+      };
+      "OBJ_1974" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1040";
+      };
+      "OBJ_1975" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1042";
+      };
+      "OBJ_1976" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1044";
+      };
+      "OBJ_1977" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1046";
+      };
+      "OBJ_1978" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1047";
+      };
+      "OBJ_1979" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1049";
+      };
+      "OBJ_198" = {
+         isa = "PBXFileReference";
+         path = "MenuClient.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1980" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1050";
+      };
+      "OBJ_1981" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1051";
+      };
+      "OBJ_1982" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1052";
+      };
+      "OBJ_1983" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1053";
+      };
+      "OBJ_1984" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1054";
+      };
+      "OBJ_1985" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1056";
+      };
+      "OBJ_1986" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1058";
+      };
+      "OBJ_1987" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1059";
+      };
+      "OBJ_1988" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1060";
+      };
+      "OBJ_1989" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1061";
+      };
+      "OBJ_199" = {
+         isa = "PBXFileReference";
+         path = "POSClient+AuthorizeUser.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_1990" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1062";
+      };
+      "OBJ_1991" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1063";
+      };
+      "OBJ_1992" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1065";
+      };
+      "OBJ_1993" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1066";
+      };
+      "OBJ_1994" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1067";
+      };
+      "OBJ_1995" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1068";
+      };
+      "OBJ_1996" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1069";
+      };
+      "OBJ_1997" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1070";
+      };
+      "OBJ_1998" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1071";
+      };
+      "OBJ_1999" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1072";
+      };
+      "OBJ_2" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_3",
+            "OBJ_4"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_20" = {
+         isa = "PBXFileReference";
+         path = "analytics_context_Library.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_200" = {
+         isa = "PBXFileReference";
+         path = "POSClient+Session.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2000" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1073";
+      };
+      "OBJ_2001" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1074";
+      };
+      "OBJ_2002" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1075";
+      };
+      "OBJ_2003" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1076";
+      };
+      "OBJ_2004" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1077";
+      };
+      "OBJ_2005" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1078";
+      };
+      "OBJ_2006" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1079";
+      };
+      "OBJ_2007" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1080";
+      };
+      "OBJ_2008" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1081";
+      };
+      "OBJ_2009" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1082";
+      };
+      "OBJ_201" = {
+         isa = "PBXFileReference";
+         path = "POSClient+VerifyTicketKey.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2010" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1083";
+      };
+      "OBJ_2011" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1084";
+      };
+      "OBJ_2012" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1086";
+      };
+      "OBJ_2013" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1087";
+      };
+      "OBJ_2014" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1088";
+      };
+      "OBJ_2015" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1089";
+      };
+      "OBJ_2016" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1090";
+      };
+      "OBJ_2017" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1091";
+      };
+      "OBJ_2018" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1092";
+      };
+      "OBJ_2019" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1093";
+      };
+      "OBJ_202" = {
+         isa = "PBXFileReference";
+         path = "POSClient.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2020" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1094";
+      };
+      "OBJ_2021" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1095";
+      };
+      "OBJ_2022" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1096";
+      };
+      "OBJ_2023" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1097";
+      };
+      "OBJ_2024" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1098";
+      };
+      "OBJ_2025" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1099";
+      };
+      "OBJ_2026" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1101";
+      };
+      "OBJ_2027" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1105";
+      };
+      "OBJ_2028" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1106";
+      };
+      "OBJ_2029" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1108";
+      };
+      "OBJ_203" = {
+         isa = "PBXFileReference";
+         path = "PlatformClient.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2030" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1109";
+      };
+      "OBJ_2031" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1110";
+      };
+      "OBJ_2032" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1111";
+      };
+      "OBJ_2033" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1112";
+      };
+      "OBJ_2034" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1113";
+      };
+      "OBJ_2035" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1114";
+      };
+      "OBJ_2036" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1116";
+      };
+      "OBJ_2037" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1117";
+      };
+      "OBJ_2038" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1118";
+      };
+      "OBJ_2039" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1119";
+      };
+      "OBJ_204" = {
+         isa = "PBXFileReference";
+         path = "RPCLogic.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2040" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1120";
+      };
+      "OBJ_2041" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1121";
+      };
+      "OBJ_2042" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1122";
+      };
+      "OBJ_2043" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1123";
+      };
+      "OBJ_2044" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1124";
+      };
+      "OBJ_2045" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1125";
+      };
+      "OBJ_2046" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1127";
+      };
+      "OBJ_2047" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1128";
+      };
+      "OBJ_2048" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1129";
+      };
+      "OBJ_2049" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1130";
+      };
+      "OBJ_205" = {
+         isa = "PBXFileReference";
+         path = "RemoteService.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2050" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1131";
+      };
+      "OBJ_2051" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1132";
+      };
+      "OBJ_2052" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1133";
+      };
+      "OBJ_2053" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1136";
+      };
+      "OBJ_2054" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1137";
+      };
+      "OBJ_2055" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1138";
+      };
+      "OBJ_2056" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1139";
+      };
+      "OBJ_2057" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1140";
+      };
+      "OBJ_2058" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1141";
+      };
+      "OBJ_2059" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1142";
+      };
+      "OBJ_206" = {
+         isa = "PBXFileReference";
+         path = "Services.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2060" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1145";
+      };
+      "OBJ_2061" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1146";
+      };
+      "OBJ_2062" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1147";
+      };
+      "OBJ_2063" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_2064"
+         );
+      };
+      "OBJ_2064" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::BoringSSL::Product";
+      };
+      "OBJ_2065" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::BoringSSL";
+      };
+      "OBJ_2066" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_2067",
+            "OBJ_2068"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_2067" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
+               "$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/ClientTests_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "ClientTests";
+         };
+         name = "Debug";
+      };
+      "OBJ_2068" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
+               "$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/ClientTests_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "ClientTests";
+         };
+         name = "Release";
+      };
+      "OBJ_2069" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_2070",
+            "OBJ_2071",
+            "OBJ_2072",
+            "OBJ_2073",
+            "OBJ_2074",
+            "OBJ_2075",
+            "OBJ_2076"
+         );
+      };
+      "OBJ_207" = {
+         isa = "PBXFileReference";
+         path = "ShopClient.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2070" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_213";
+      };
+      "OBJ_2071" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_214";
+      };
+      "OBJ_2072" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_215";
+      };
+      "OBJ_2073" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_216";
+      };
+      "OBJ_2074" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_217";
+      };
+      "OBJ_2075" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_218";
+      };
+      "OBJ_2076" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_219";
+      };
+      "OBJ_2077" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_2078",
+            "OBJ_2079",
+            "OBJ_2080",
+            "OBJ_2081",
+            "OBJ_2082",
+            "OBJ_2083",
+            "OBJ_2084"
+         );
+      };
+      "OBJ_2078" = {
+         isa = "PBXBuildFile";
+         fileRef = "Bloombox::Bloombox::Product";
+      };
+      "OBJ_2079" = {
+         isa = "PBXBuildFile";
+         fileRef = "Bloombox::BloomboxServices::Product";
+      };
+      "OBJ_208" = {
+         isa = "PBXFileReference";
+         path = "TelemetryClient.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2080" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::SwiftGRPC::Product";
+      };
+      "OBJ_2081" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::CgRPC::Product";
+      };
+      "OBJ_2082" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::BoringSSL::Product";
+      };
+      "OBJ_2083" = {
+         isa = "PBXBuildFile";
+         fileRef = "Bloombox::OpenCannabis::Product";
+      };
+      "OBJ_2084" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftProtobuf::SwiftProtobuf::Product";
+      };
+      "OBJ_2085" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::Bloombox";
+      };
+      "OBJ_2086" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::BloomboxServices";
+      };
+      "OBJ_2087" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::SwiftGRPC";
+      };
+      "OBJ_2088" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::CgRPC";
+      };
+      "OBJ_2089" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::BoringSSL";
+      };
+      "OBJ_209" = {
+         isa = "PBXFileReference";
+         path = "TelemetryService+Generic.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2090" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::OpenCannabis";
+      };
+      "OBJ_2091" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftProtobuf::SwiftProtobuf";
+      };
+      "OBJ_2092" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_2093",
+            "OBJ_2094"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_2093" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/OpenCannabis_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "OpenCannabis";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "OpenCannabis";
+         };
+         name = "Debug";
+      };
+      "OBJ_2094" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/OpenCannabis_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "OpenCannabis";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "OpenCannabis";
+         };
+         name = "Release";
+      };
+      "OBJ_2095" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_2096",
+            "OBJ_2097",
+            "OBJ_2098",
+            "OBJ_2099",
+            "OBJ_2100",
+            "OBJ_2101",
+            "OBJ_2102",
+            "OBJ_2103",
+            "OBJ_2104",
+            "OBJ_2105",
+            "OBJ_2106",
+            "OBJ_2107",
+            "OBJ_2108",
+            "OBJ_2109",
+            "OBJ_2110",
+            "OBJ_2111",
+            "OBJ_2112",
+            "OBJ_2113",
+            "OBJ_2114",
+            "OBJ_2115",
+            "OBJ_2116",
+            "OBJ_2117",
+            "OBJ_2118",
+            "OBJ_2119",
+            "OBJ_2120",
+            "OBJ_2121",
+            "OBJ_2122",
+            "OBJ_2123",
+            "OBJ_2124",
+            "OBJ_2125",
+            "OBJ_2126",
+            "OBJ_2127",
+            "OBJ_2128",
+            "OBJ_2129",
+            "OBJ_2130",
+            "OBJ_2131",
+            "OBJ_2132",
+            "OBJ_2133",
+            "OBJ_2134",
+            "OBJ_2135",
+            "OBJ_2136",
+            "OBJ_2137",
+            "OBJ_2138",
+            "OBJ_2139",
+            "OBJ_2140",
+            "OBJ_2141",
+            "OBJ_2142",
+            "OBJ_2143",
+            "OBJ_2144",
+            "OBJ_2145",
+            "OBJ_2146",
+            "OBJ_2147",
+            "OBJ_2148",
+            "OBJ_2149",
+            "OBJ_2150",
+            "OBJ_2151",
+            "OBJ_2152",
+            "OBJ_2153",
+            "OBJ_2154",
+            "OBJ_2155",
+            "OBJ_2156",
+            "OBJ_2157",
+            "OBJ_2158",
+            "OBJ_2159",
+            "OBJ_2160",
+            "OBJ_2161",
+            "OBJ_2162",
+            "OBJ_2163",
+            "OBJ_2164",
+            "OBJ_2165",
+            "OBJ_2166",
+            "OBJ_2167",
+            "OBJ_2168",
+            "OBJ_2169",
+            "OBJ_2170",
+            "OBJ_2171",
+            "OBJ_2172",
+            "OBJ_2173",
+            "OBJ_2174",
+            "OBJ_2175",
+            "OBJ_2176",
+            "OBJ_2177",
+            "OBJ_2178",
+            "OBJ_2179",
+            "OBJ_2180",
+            "OBJ_2181",
+            "OBJ_2182",
+            "OBJ_2183",
+            "OBJ_2184",
+            "OBJ_2185",
+            "OBJ_2186",
+            "OBJ_2187",
+            "OBJ_2188",
+            "OBJ_2189",
+            "OBJ_2190",
+            "OBJ_2191",
+            "OBJ_2192",
+            "OBJ_2193",
+            "OBJ_2194",
+            "OBJ_2195",
+            "OBJ_2196",
+            "OBJ_2197",
+            "OBJ_2198",
+            "OBJ_2199",
+            "OBJ_2200",
+            "OBJ_2201",
+            "OBJ_2202",
+            "OBJ_2203",
+            "OBJ_2204",
+            "OBJ_2205",
+            "OBJ_2206",
+            "OBJ_2207",
+            "OBJ_2208",
+            "OBJ_2209",
+            "OBJ_2210",
+            "OBJ_2211",
+            "OBJ_2212",
+            "OBJ_2213",
+            "OBJ_2214",
+            "OBJ_2215",
+            "OBJ_2216",
+            "OBJ_2217",
+            "OBJ_2218",
+            "OBJ_2219",
+            "OBJ_2220",
+            "OBJ_2221",
+            "OBJ_2222",
+            "OBJ_2223",
+            "OBJ_2224",
+            "OBJ_2225",
+            "OBJ_2226",
+            "OBJ_2227",
+            "OBJ_2228",
+            "OBJ_2229",
+            "OBJ_2230",
+            "OBJ_2231",
+            "OBJ_2232",
+            "OBJ_2233",
+            "OBJ_2234",
+            "OBJ_2235",
+            "OBJ_2236",
+            "OBJ_2237",
+            "OBJ_2238",
+            "OBJ_2239",
+            "OBJ_2240",
+            "OBJ_2241",
+            "OBJ_2242",
+            "OBJ_2243",
+            "OBJ_2244",
+            "OBJ_2245",
+            "OBJ_2246",
+            "OBJ_2247",
+            "OBJ_2248",
+            "OBJ_2249",
+            "OBJ_2250",
+            "OBJ_2251",
+            "OBJ_2252",
+            "OBJ_2253",
+            "OBJ_2254",
+            "OBJ_2255",
+            "OBJ_2256",
+            "OBJ_2257",
+            "OBJ_2258",
+            "OBJ_2259",
+            "OBJ_2260",
+            "OBJ_2261",
+            "OBJ_2262",
+            "OBJ_2263",
+            "OBJ_2264",
+            "OBJ_2265"
+         );
+      };
+      "OBJ_2096" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_9";
+      };
+      "OBJ_2097" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_10";
+      };
+      "OBJ_2098" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_11";
+      };
+      "OBJ_2099" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_12";
+      };
+      "OBJ_21" = {
+         isa = "PBXFileReference";
+         path = "analytics_context_NativeDevice.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_210" = {
+         isa = "PBXFileReference";
+         path = "Transport.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2100" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_13";
+      };
+      "OBJ_2101" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_14";
+      };
+      "OBJ_2102" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_15";
+      };
+      "OBJ_2103" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_16";
+      };
+      "OBJ_2104" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_17";
+      };
+      "OBJ_2105" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_18";
+      };
+      "OBJ_2106" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_19";
+      };
+      "OBJ_2107" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_20";
+      };
+      "OBJ_2108" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_21";
+      };
+      "OBJ_2109" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_22";
+      };
+      "OBJ_211" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_212",
+            "OBJ_220"
+         );
+         name = "Tests";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2110" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_23";
+      };
+      "OBJ_2111" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_24";
+      };
+      "OBJ_2112" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_25";
+      };
+      "OBJ_2113" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_26";
+      };
+      "OBJ_2114" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_27";
+      };
+      "OBJ_2115" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_28";
+      };
+      "OBJ_2116" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_29";
+      };
+      "OBJ_2117" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_30";
+      };
+      "OBJ_2118" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_31";
+      };
+      "OBJ_2119" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_32";
+      };
+      "OBJ_212" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_213",
+            "OBJ_214",
+            "OBJ_215",
+            "OBJ_216",
+            "OBJ_217",
+            "OBJ_218",
+            "OBJ_219"
+         );
+         name = "ClientTests";
+         path = "Tests/ClientTests";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2120" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_33";
+      };
+      "OBJ_2121" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_34";
+      };
+      "OBJ_2122" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_35";
+      };
+      "OBJ_2123" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_36";
+      };
+      "OBJ_2124" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_37";
+      };
+      "OBJ_2125" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_38";
+      };
+      "OBJ_2126" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_39";
+      };
+      "OBJ_2127" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_40";
+      };
+      "OBJ_2128" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_41";
+      };
+      "OBJ_2129" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_42";
+      };
+      "OBJ_213" = {
+         isa = "PBXFileReference";
+         path = "AuthClientTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2130" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_43";
+      };
+      "OBJ_2131" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_44";
+      };
+      "OBJ_2132" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_45";
+      };
+      "OBJ_2133" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_46";
+      };
+      "OBJ_2134" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_47";
+      };
+      "OBJ_2135" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_48";
+      };
+      "OBJ_2136" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_49";
+      };
+      "OBJ_2137" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_50";
+      };
+      "OBJ_2138" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_51";
+      };
+      "OBJ_2139" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_52";
+      };
+      "OBJ_214" = {
+         isa = "PBXFileReference";
+         path = "ClientTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2140" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_53";
+      };
+      "OBJ_2141" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_54";
+      };
+      "OBJ_2142" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_55";
+      };
+      "OBJ_2143" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_56";
+      };
+      "OBJ_2144" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_57";
+      };
+      "OBJ_2145" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_58";
+      };
+      "OBJ_2146" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_59";
+      };
+      "OBJ_2147" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_60";
+      };
+      "OBJ_2148" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_61";
+      };
+      "OBJ_2149" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_62";
+      };
+      "OBJ_215" = {
+         isa = "PBXFileReference";
+         path = "DeviceClientTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2150" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_63";
+      };
+      "OBJ_2151" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_64";
+      };
+      "OBJ_2152" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_65";
+      };
+      "OBJ_2153" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_66";
+      };
+      "OBJ_2154" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_67";
+      };
+      "OBJ_2155" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_68";
+      };
+      "OBJ_2156" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_69";
+      };
+      "OBJ_2157" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_70";
+      };
+      "OBJ_2158" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_71";
+      };
+      "OBJ_2159" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_72";
+      };
+      "OBJ_216" = {
+         isa = "PBXFileReference";
+         path = "MenuClientTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2160" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_73";
+      };
+      "OBJ_2161" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_74";
+      };
+      "OBJ_2162" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_75";
+      };
+      "OBJ_2163" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_76";
+      };
+      "OBJ_2164" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_77";
+      };
+      "OBJ_2165" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_78";
+      };
+      "OBJ_2166" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_79";
+      };
+      "OBJ_2167" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_80";
+      };
+      "OBJ_2168" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_81";
+      };
+      "OBJ_2169" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_82";
+      };
+      "OBJ_217" = {
+         isa = "PBXFileReference";
+         path = "PlatformClientTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2170" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_83";
+      };
+      "OBJ_2171" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_84";
+      };
+      "OBJ_2172" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_85";
+      };
+      "OBJ_2173" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_86";
+      };
+      "OBJ_2174" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_87";
+      };
+      "OBJ_2175" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_88";
+      };
+      "OBJ_2176" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_89";
+      };
+      "OBJ_2177" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_90";
+      };
+      "OBJ_2178" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_91";
+      };
+      "OBJ_2179" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_92";
+      };
+      "OBJ_218" = {
+         isa = "PBXFileReference";
+         path = "ShopClientTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2180" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_93";
+      };
+      "OBJ_2181" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_94";
+      };
+      "OBJ_2182" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_95";
+      };
+      "OBJ_2183" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_96";
+      };
+      "OBJ_2184" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_97";
+      };
+      "OBJ_2185" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_98";
+      };
+      "OBJ_2186" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_99";
+      };
+      "OBJ_2187" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_100";
+      };
+      "OBJ_2188" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_101";
+      };
+      "OBJ_2189" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_102";
+      };
+      "OBJ_219" = {
+         isa = "PBXFileReference";
+         path = "TelemetryClientTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2190" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_103";
+      };
+      "OBJ_2191" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_104";
+      };
+      "OBJ_2192" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_105";
+      };
+      "OBJ_2193" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_106";
+      };
+      "OBJ_2194" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_107";
+      };
+      "OBJ_2195" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_108";
+      };
+      "OBJ_2196" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_109";
+      };
+      "OBJ_2197" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_110";
+      };
+      "OBJ_2198" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_111";
+      };
+      "OBJ_2199" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_112";
+      };
+      "OBJ_22" = {
+         isa = "PBXFileReference";
+         path = "analytics_context_OS.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_220" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_221",
+            "OBJ_222",
+            "OBJ_223"
+         );
+         name = "SchemaTests";
+         path = "Tests/SchemaTests";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2200" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_113";
+      };
+      "OBJ_2201" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_114";
+      };
+      "OBJ_2202" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_115";
+      };
+      "OBJ_2203" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_116";
+      };
+      "OBJ_2204" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_117";
+      };
+      "OBJ_2205" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_118";
+      };
+      "OBJ_2206" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_119";
+      };
+      "OBJ_2207" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_120";
+      };
+      "OBJ_2208" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_121";
+      };
+      "OBJ_2209" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_122";
+      };
+      "OBJ_221" = {
+         isa = "PBXFileReference";
+         path = "ModelTool.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2210" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_123";
+      };
+      "OBJ_2211" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_124";
+      };
+      "OBJ_2212" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_125";
+      };
+      "OBJ_2213" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_126";
+      };
+      "OBJ_2214" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_127";
+      };
+      "OBJ_2215" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_128";
+      };
+      "OBJ_2216" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_129";
+      };
+      "OBJ_2217" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_130";
+      };
+      "OBJ_2218" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_131";
+      };
+      "OBJ_2219" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_132";
+      };
+      "OBJ_222" = {
+         isa = "PBXFileReference";
+         path = "SchemaTests+Codec.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2220" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_133";
+      };
+      "OBJ_2221" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_134";
+      };
+      "OBJ_2222" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_135";
+      };
+      "OBJ_2223" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_136";
+      };
+      "OBJ_2224" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_137";
+      };
+      "OBJ_2225" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_138";
+      };
+      "OBJ_2226" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_139";
+      };
+      "OBJ_2227" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_140";
+      };
+      "OBJ_2228" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_141";
+      };
+      "OBJ_2229" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_142";
+      };
+      "OBJ_223" = {
+         isa = "PBXFileReference";
+         path = "SchemaTests.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_2230" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_143";
+      };
+      "OBJ_2231" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_144";
+      };
+      "OBJ_2232" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_145";
+      };
+      "OBJ_2233" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_146";
+      };
+      "OBJ_2234" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_147";
+      };
+      "OBJ_2235" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_148";
+      };
+      "OBJ_2236" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_149";
+      };
+      "OBJ_2237" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_150";
+      };
+      "OBJ_2238" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_151";
+      };
+      "OBJ_2239" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_152";
+      };
+      "OBJ_224" = {
+         isa = "PBXFileReference";
+         path = "Example";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2240" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_153";
+      };
+      "OBJ_2241" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_154";
+      };
+      "OBJ_2242" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_155";
+      };
+      "OBJ_2243" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_156";
+      };
+      "OBJ_2244" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_157";
+      };
+      "OBJ_2245" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_158";
+      };
+      "OBJ_2246" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_159";
+      };
+      "OBJ_2247" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_160";
+      };
+      "OBJ_2248" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_161";
+      };
+      "OBJ_2249" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_162";
+      };
+      "OBJ_225" = {
+         isa = "PBXFileReference";
+         path = "docs";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2250" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_163";
+      };
+      "OBJ_2251" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_164";
+      };
+      "OBJ_2252" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_165";
+      };
+      "OBJ_2253" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_166";
+      };
+      "OBJ_2254" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_167";
+      };
+      "OBJ_2255" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_168";
+      };
+      "OBJ_2256" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_169";
+      };
+      "OBJ_2257" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_170";
+      };
+      "OBJ_2258" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_171";
+      };
+      "OBJ_2259" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_172";
+      };
+      "OBJ_226" = {
+         isa = "PBXFileReference";
+         path = "Schema";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2260" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_173";
+      };
+      "OBJ_2261" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_174";
+      };
+      "OBJ_2262" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_175";
+      };
+      "OBJ_2263" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_176";
+      };
+      "OBJ_2264" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_177";
+      };
+      "OBJ_2265" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_178";
+      };
+      "OBJ_2266" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_2267"
+         );
+      };
+      "OBJ_2267" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftProtobuf::SwiftProtobuf::Product";
+      };
+      "OBJ_2268" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftProtobuf::SwiftProtobuf";
+      };
+      "OBJ_2269" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_2270",
+            "OBJ_2271"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_227" = {
+         isa = "PBXFileReference";
+         path = "fastlane";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2270" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
+               "$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/SchemaTests_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "SchemaTests";
+         };
+         name = "Debug";
+      };
+      "OBJ_2271" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_MODULES = "YES";
+            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
+               "$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/SchemaTests_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "@loader_path/../Frameworks",
+               "@loader_path/Frameworks"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "SchemaTests";
+         };
+         name = "Release";
+      };
+      "OBJ_2272" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_2273",
+            "OBJ_2274",
+            "OBJ_2275"
+         );
+      };
+      "OBJ_2273" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_221";
+      };
+      "OBJ_2274" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_222";
+      };
+      "OBJ_2275" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_223";
+      };
+      "OBJ_2276" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_2277",
+            "OBJ_2278",
+            "OBJ_2279",
+            "OBJ_2280",
+            "OBJ_2281",
+            "OBJ_2282",
+            "OBJ_2283"
+         );
+      };
+      "OBJ_2277" = {
+         isa = "PBXBuildFile";
+         fileRef = "Bloombox::Bloombox::Product";
+      };
+      "OBJ_2278" = {
+         isa = "PBXBuildFile";
+         fileRef = "Bloombox::BloomboxServices::Product";
+      };
+      "OBJ_2279" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::SwiftGRPC::Product";
+      };
+      "OBJ_228" = {
+         isa = "PBXFileReference";
+         path = "SwiftGRPC";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2280" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::CgRPC::Product";
+      };
+      "OBJ_2281" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::BoringSSL::Product";
+      };
+      "OBJ_2282" = {
+         isa = "PBXBuildFile";
+         fileRef = "Bloombox::OpenCannabis::Product";
+      };
+      "OBJ_2283" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftProtobuf::SwiftProtobuf::Product";
+      };
+      "OBJ_2284" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::Bloombox";
+      };
+      "OBJ_2285" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::BloomboxServices";
+      };
+      "OBJ_2286" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::SwiftGRPC";
+      };
+      "OBJ_2287" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::CgRPC";
+      };
+      "OBJ_2288" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::BoringSSL";
+      };
+      "OBJ_2289" = {
+         isa = "PBXTargetDependency";
+         target = "Bloombox::OpenCannabis";
+      };
+      "OBJ_229" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_230",
+            "OBJ_1211"
+         );
+         name = "Dependencies";
+         path = "";
+         sourceTree = "<group>";
+      };
+      "OBJ_2290" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftProtobuf::SwiftProtobuf";
+      };
+      "OBJ_2291" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_2292",
+            "OBJ_2293"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_2292" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
+               "$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/SwiftGRPC_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SwiftGRPC";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "SwiftGRPC";
+         };
+         name = "Debug";
+      };
+      "OBJ_2293" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include",
+               "$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL/include",
+               "$(SRCROOT)/.build/checkouts/swift-nio-zlib-support.git--6802803625406282736",
+               "$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/SwiftGRPC_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)",
+               "-lz"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/.build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC/include/module.modulemap",
+               "-Xcc",
+               "-fmodule-map-file=$(SRCROOT)/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SwiftGRPC";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "SwiftGRPC";
+         };
+         name = "Release";
+      };
+      "OBJ_2294" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_2295",
+            "OBJ_2296",
+            "OBJ_2297",
+            "OBJ_2298",
+            "OBJ_2299",
+            "OBJ_2300",
+            "OBJ_2301",
+            "OBJ_2302",
+            "OBJ_2303",
+            "OBJ_2304",
+            "OBJ_2305",
+            "OBJ_2306",
+            "OBJ_2307",
+            "OBJ_2308",
+            "OBJ_2309",
+            "OBJ_2310",
+            "OBJ_2311",
+            "OBJ_2312",
+            "OBJ_2313",
+            "OBJ_2314",
+            "OBJ_2315",
+            "OBJ_2316",
+            "OBJ_2317",
+            "OBJ_2318",
+            "OBJ_2319",
+            "OBJ_2320",
+            "OBJ_2321",
+            "OBJ_2322",
+            "OBJ_2323",
+            "OBJ_2324",
+            "OBJ_2325",
+            "OBJ_2326"
+         );
+      };
+      "OBJ_2295" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_678";
+      };
+      "OBJ_2296" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_679";
+      };
+      "OBJ_2297" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_680";
+      };
+      "OBJ_2298" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_681";
+      };
+      "OBJ_2299" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_682";
+      };
+      "OBJ_23" = {
+         isa = "PBXFileReference";
+         path = "analytics_generic_Event.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_230" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_231",
+            "OBJ_675",
+            "OBJ_676",
+            "OBJ_711",
+            "OBJ_1207",
+            "OBJ_1208",
+            "OBJ_1209",
+            "OBJ_1210"
+         );
+         name = "SwiftGRPC";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2300" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_683";
+      };
+      "OBJ_2301" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_684";
+      };
+      "OBJ_2302" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_685";
+      };
+      "OBJ_2303" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_686";
+      };
+      "OBJ_2304" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_687";
+      };
+      "OBJ_2305" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_688";
+      };
+      "OBJ_2306" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_689";
+      };
+      "OBJ_2307" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_690";
+      };
+      "OBJ_2308" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_691";
+      };
+      "OBJ_2309" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_692";
+      };
+      "OBJ_231" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_232",
+            "OBJ_558",
+            "OBJ_559",
+            "OBJ_596",
+            "OBJ_599"
+         );
+         name = "BoringSSL";
+         path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/BoringSSL";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_2310" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_693";
+      };
+      "OBJ_2311" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_695";
+      };
+      "OBJ_2312" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_696";
+      };
+      "OBJ_2313" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_697";
+      };
+      "OBJ_2314" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_698";
+      };
+      "OBJ_2315" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_699";
+      };
+      "OBJ_2316" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_700";
+      };
+      "OBJ_2317" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_701";
+      };
+      "OBJ_2318" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_702";
+      };
+      "OBJ_2319" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_703";
+      };
+      "OBJ_232" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_233",
+            "OBJ_264",
+            "OBJ_266",
+            "OBJ_277",
+            "OBJ_280",
+            "OBJ_282",
+            "OBJ_287",
+            "OBJ_289",
+            "OBJ_301",
+            "OBJ_303",
+            "OBJ_305",
+            "OBJ_306",
+            "OBJ_307",
+            "OBJ_308",
+            "OBJ_309",
+            "OBJ_310",
+            "OBJ_311",
+            "OBJ_314",
+            "OBJ_319",
+            "OBJ_321",
+            "OBJ_324",
+            "OBJ_326",
+            "OBJ_328",
+            "OBJ_330",
+            "OBJ_332",
+            "OBJ_335",
+            "OBJ_351",
+            "OBJ_352",
+            "OBJ_427",
+            "OBJ_429",
+            "OBJ_431",
+            "OBJ_432",
+            "OBJ_435",
+            "OBJ_444",
+            "OBJ_447",
+            "OBJ_451",
+            "OBJ_455",
+            "OBJ_457",
+            "OBJ_463",
+            "OBJ_465",
+            "OBJ_466",
+            "OBJ_467",
+            "OBJ_469",
+            "OBJ_471",
+            "OBJ_472",
+            "OBJ_473",
+            "OBJ_474",
+            "OBJ_475",
+            "OBJ_525"
+         );
+         name = "crypto";
+         path = "crypto";
+         sourceTree = "<group>";
+      };
+      "OBJ_2320" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_704";
+      };
+      "OBJ_2321" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_705";
+      };
+      "OBJ_2322" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_706";
+      };
+      "OBJ_2323" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_707";
+      };
+      "OBJ_2324" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_708";
+      };
+      "OBJ_2325" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_709";
+      };
+      "OBJ_2326" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_710";
+      };
+      "OBJ_2327" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_2328",
+            "OBJ_2329",
+            "OBJ_2330"
+         );
+      };
+      "OBJ_2328" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftProtobuf::SwiftProtobuf::Product";
+      };
+      "OBJ_2329" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::CgRPC::Product";
+      };
+      "OBJ_233" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_234",
+            "OBJ_235",
+            "OBJ_236",
+            "OBJ_237",
+            "OBJ_238",
+            "OBJ_239",
+            "OBJ_240",
+            "OBJ_241",
+            "OBJ_242",
+            "OBJ_243",
+            "OBJ_244",
+            "OBJ_245",
+            "OBJ_246",
+            "OBJ_247",
+            "OBJ_248",
+            "OBJ_249",
+            "OBJ_250",
+            "OBJ_251",
+            "OBJ_252",
+            "OBJ_253",
+            "OBJ_254",
+            "OBJ_255",
+            "OBJ_256",
+            "OBJ_257",
+            "OBJ_258",
+            "OBJ_259",
+            "OBJ_260",
+            "OBJ_261",
+            "OBJ_262",
+            "OBJ_263"
+         );
+         name = "asn1";
+         path = "asn1";
+         sourceTree = "<group>";
+      };
+      "OBJ_2330" = {
+         isa = "PBXBuildFile";
+         fileRef = "SwiftGRPC::BoringSSL::Product";
+      };
+      "OBJ_2331" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftProtobuf::SwiftProtobuf";
+      };
+      "OBJ_2332" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::CgRPC";
+      };
+      "OBJ_2333" = {
+         isa = "PBXTargetDependency";
+         target = "SwiftGRPC::BoringSSL";
+      };
+      "OBJ_2335" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_2336",
+            "OBJ_2337"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_2336" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
+            );
+            SWIFT_VERSION = "4.0";
+         };
+         name = "Debug";
+      };
+      "OBJ_2337" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
+            );
+            SWIFT_VERSION = "4.0";
+         };
+         name = "Release";
+      };
+      "OBJ_2338" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_2339"
+         );
+      };
+      "OBJ_2339" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1210";
+      };
+      "OBJ_234" = {
+         isa = "PBXFileReference";
+         path = "a_bitstr.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_2340" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_2341",
+            "OBJ_2342"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_2341" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/SwiftProtobuf_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SwiftProtobuf";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.2";
+            TARGET_NAME = "SwiftProtobuf";
+         };
+         name = "Debug";
+      };
+      "OBJ_2342" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "Bloombox.xcodeproj/SwiftProtobuf_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "SwiftProtobuf";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.2";
+            TARGET_NAME = "SwiftProtobuf";
+         };
+         name = "Release";
+      };
+      "OBJ_2343" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_2344",
+            "OBJ_2345",
+            "OBJ_2346",
+            "OBJ_2347",
+            "OBJ_2348",
+            "OBJ_2349",
+            "OBJ_2350",
+            "OBJ_2351",
+            "OBJ_2352",
+            "OBJ_2353",
+            "OBJ_2354",
+            "OBJ_2355",
+            "OBJ_2356",
+            "OBJ_2357",
+            "OBJ_2358",
+            "OBJ_2359",
+            "OBJ_2360",
+            "OBJ_2361",
+            "OBJ_2362",
+            "OBJ_2363",
+            "OBJ_2364",
+            "OBJ_2365",
+            "OBJ_2366",
+            "OBJ_2367",
+            "OBJ_2368",
+            "OBJ_2369",
+            "OBJ_2370",
+            "OBJ_2371",
+            "OBJ_2372",
+            "OBJ_2373",
+            "OBJ_2374",
+            "OBJ_2375",
+            "OBJ_2376",
+            "OBJ_2377",
+            "OBJ_2378",
+            "OBJ_2379",
+            "OBJ_2380",
+            "OBJ_2381",
+            "OBJ_2382",
+            "OBJ_2383",
+            "OBJ_2384",
+            "OBJ_2385",
+            "OBJ_2386",
+            "OBJ_2387",
+            "OBJ_2388",
+            "OBJ_2389",
+            "OBJ_2390",
+            "OBJ_2391",
+            "OBJ_2392",
+            "OBJ_2393",
+            "OBJ_2394",
+            "OBJ_2395",
+            "OBJ_2396",
+            "OBJ_2397",
+            "OBJ_2398",
+            "OBJ_2399",
+            "OBJ_2400",
+            "OBJ_2401",
+            "OBJ_2402",
+            "OBJ_2403",
+            "OBJ_2404",
+            "OBJ_2405",
+            "OBJ_2406",
+            "OBJ_2407",
+            "OBJ_2408",
+            "OBJ_2409",
+            "OBJ_2410",
+            "OBJ_2411",
+            "OBJ_2412",
+            "OBJ_2413",
+            "OBJ_2414",
+            "OBJ_2415",
+            "OBJ_2416",
+            "OBJ_2417",
+            "OBJ_2418",
+            "OBJ_2419"
+         );
+      };
+      "OBJ_2344" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1214";
+      };
+      "OBJ_2345" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1215";
+      };
+      "OBJ_2346" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1216";
+      };
+      "OBJ_2347" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1217";
+      };
+      "OBJ_2348" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1218";
+      };
+      "OBJ_2349" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1219";
+      };
+      "OBJ_235" = {
+         isa = "PBXFileReference";
+         path = "a_bool.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_2350" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1220";
+      };
+      "OBJ_2351" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1221";
+      };
+      "OBJ_2352" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1222";
+      };
+      "OBJ_2353" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1223";
+      };
+      "OBJ_2354" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1224";
+      };
+      "OBJ_2355" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1225";
+      };
+      "OBJ_2356" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1226";
+      };
+      "OBJ_2357" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1227";
+      };
+      "OBJ_2358" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1228";
+      };
+      "OBJ_2359" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1229";
+      };
+      "OBJ_236" = {
+         isa = "PBXFileReference";
+         path = "a_d2i_fp.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_2360" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1230";
+      };
+      "OBJ_2361" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1231";
+      };
+      "OBJ_2362" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1232";
+      };
+      "OBJ_2363" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1233";
+      };
+      "OBJ_2364" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1234";
+      };
+      "OBJ_2365" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1235";
+      };
+      "OBJ_2366" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1236";
+      };
+      "OBJ_2367" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1237";
+      };
+      "OBJ_2368" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1238";
+      };
+      "OBJ_2369" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1239";
+      };
+      "OBJ_237" = {
+         isa = "PBXFileReference";
+         path = "a_dup.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_2370" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1240";
+      };
+      "OBJ_2371" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1241";
+      };
+      "OBJ_2372" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1242";
+      };
+      "OBJ_2373" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1243";
+      };
+      "OBJ_2374" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1244";
+      };
+      "OBJ_2375" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1245";
+      };
+      "OBJ_2376" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1246";
+      };
+      "OBJ_2377" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1247";
+      };
+      "OBJ_2378" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1248";
+      };
+      "OBJ_2379" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1249";
+      };
+      "OBJ_238" = {
+         isa = "PBXFileReference";
+         path = "a_enum.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_2380" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1250";
+      };
+      "OBJ_2381" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1251";
+      };
+      "OBJ_2382" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1252";
+      };
+      "OBJ_2383" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1253";
+      };
+      "OBJ_2384" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1254";
+      };
+      "OBJ_2385" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1255";
+      };
+      "OBJ_2386" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1256";
+      };
+      "OBJ_2387" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1257";
+      };
+      "OBJ_2388" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1258";
+      };
+      "OBJ_2389" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1259";
+      };
+      "OBJ_239" = {
+         isa = "PBXFileReference";
+         path = "a_gentm.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_2390" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1260";
+      };
+      "OBJ_2391" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1261";
+      };
+      "OBJ_2392" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1262";
+      };
+      "OBJ_2393" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1263";
+      };
+      "OBJ_2394" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1264";
+      };
+      "OBJ_2395" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1265";
+      };
+      "OBJ_2396" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1266";
+      };
+      "OBJ_2397" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1267";
+      };
+      "OBJ_2398" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1268";
+      };
+      "OBJ_2399" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1269";
+      };
+      "OBJ_24" = {
+         isa = "PBXFileReference";
+         path = "analytics_generic_Exception.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_240" = {
+         isa = "PBXFileReference";
+         path = "a_i2d_fp.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_2400" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1270";
+      };
+      "OBJ_2401" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1271";
+      };
+      "OBJ_2402" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1272";
+      };
+      "OBJ_2403" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1273";
+      };
+      "OBJ_2404" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1274";
+      };
+      "OBJ_2405" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1275";
+      };
+      "OBJ_2406" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1276";
+      };
+      "OBJ_2407" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1277";
+      };
+      "OBJ_2408" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1278";
+      };
+      "OBJ_2409" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1279";
+      };
+      "OBJ_241" = {
+         isa = "PBXFileReference";
+         path = "a_int.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_2410" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1280";
+      };
+      "OBJ_2411" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1281";
+      };
+      "OBJ_2412" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1282";
+      };
+      "OBJ_2413" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1283";
+      };
+      "OBJ_2414" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1284";
+      };
+      "OBJ_2415" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1285";
+      };
+      "OBJ_2416" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1286";
+      };
+      "OBJ_2417" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1287";
+      };
+      "OBJ_2418" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1288";
+      };
+      "OBJ_2419" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1289";
+      };
+      "OBJ_242" = {
+         isa = "PBXFileReference";
+         path = "a_mbstr.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_2420" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+         );
+      };
+      "OBJ_2422" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_2423",
+            "OBJ_2424"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_2423" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4.2",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
+            );
+            SWIFT_VERSION = "4.2";
+         };
+         name = "Debug";
+      };
+      "OBJ_2424" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            LD = "/usr/bin/true";
+            OTHER_SWIFT_FLAGS = (
+               "-swift-version",
+               "4.2",
+               "-I",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
+               "-target",
+               "x86_64-apple-macosx10.10",
+               "-sdk",
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
+            );
+            SWIFT_VERSION = "4.2";
+         };
+         name = "Release";
+      };
+      "OBJ_2425" = {
+         isa = "PBXSourcesBuildPhase";
+         files = (
+            "OBJ_2426"
+         );
+      };
+      "OBJ_2426" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_1292";
+      };
+      "OBJ_243" = {
+         isa = "PBXFileReference";
+         path = "a_object.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_244" = {
+         isa = "PBXFileReference";
+         path = "a_octet.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_245" = {
+         isa = "PBXFileReference";
+         path = "a_print.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_246" = {
+         isa = "PBXFileReference";
+         path = "a_strnid.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_247" = {
+         isa = "PBXFileReference";
+         path = "a_time.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_248" = {
+         isa = "PBXFileReference";
+         path = "a_type.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_249" = {
+         isa = "PBXFileReference";
+         path = "a_utctm.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_25" = {
+         isa = "PBXFileReference";
+         path = "analytics_identity_UserAnalytics.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_250" = {
+         isa = "PBXFileReference";
+         path = "a_utf8.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_251" = {
+         isa = "PBXFileReference";
+         path = "asn1_lib.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_252" = {
+         isa = "PBXFileReference";
+         path = "asn1_par.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_253" = {
+         isa = "PBXFileReference";
+         path = "asn_pack.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_254" = {
+         isa = "PBXFileReference";
+         path = "f_enum.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_255" = {
+         isa = "PBXFileReference";
+         path = "f_int.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_256" = {
+         isa = "PBXFileReference";
+         path = "f_string.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_257" = {
+         isa = "PBXFileReference";
+         path = "tasn_dec.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_258" = {
+         isa = "PBXFileReference";
+         path = "tasn_enc.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_259" = {
+         isa = "PBXFileReference";
+         path = "tasn_fre.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_26" = {
+         isa = "PBXFileReference";
+         path = "analytics_search_SearchProperty.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_260" = {
+         isa = "PBXFileReference";
+         path = "tasn_new.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_261" = {
+         isa = "PBXFileReference";
+         path = "tasn_typ.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_262" = {
+         isa = "PBXFileReference";
+         path = "tasn_utl.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_263" = {
+         isa = "PBXFileReference";
+         path = "time_support.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_264" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_265"
+         );
+         name = "base64";
+         path = "base64";
+         sourceTree = "<group>";
+      };
+      "OBJ_265" = {
+         isa = "PBXFileReference";
+         path = "base64.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_266" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_267",
+            "OBJ_268",
+            "OBJ_269",
+            "OBJ_270",
+            "OBJ_271",
+            "OBJ_272",
+            "OBJ_273",
+            "OBJ_274",
+            "OBJ_275",
+            "OBJ_276"
+         );
+         name = "bio";
+         path = "bio";
+         sourceTree = "<group>";
+      };
+      "OBJ_267" = {
+         isa = "PBXFileReference";
+         path = "bio.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_268" = {
+         isa = "PBXFileReference";
+         path = "bio_mem.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_269" = {
+         isa = "PBXFileReference";
+         path = "connect.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_27" = {
+         isa = "PBXFileReference";
+         path = "analytics_stats_OrderStats.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_270" = {
+         isa = "PBXFileReference";
+         path = "fd.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_271" = {
+         isa = "PBXFileReference";
+         path = "file.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_272" = {
+         isa = "PBXFileReference";
+         path = "hexdump.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_273" = {
+         isa = "PBXFileReference";
+         path = "pair.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_274" = {
+         isa = "PBXFileReference";
+         path = "printf.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_275" = {
+         isa = "PBXFileReference";
+         path = "socket.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_276" = {
+         isa = "PBXFileReference";
+         path = "socket_helper.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_277" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_278",
+            "OBJ_279"
+         );
+         name = "bn_extra";
+         path = "bn_extra";
+         sourceTree = "<group>";
+      };
+      "OBJ_278" = {
+         isa = "PBXFileReference";
+         path = "bn_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_279" = {
+         isa = "PBXFileReference";
+         path = "convert.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_28" = {
+         isa = "PBXFileReference";
+         path = "analytics_stats_SessionStats.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_280" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_281"
+         );
+         name = "buf";
+         path = "buf";
+         sourceTree = "<group>";
+      };
+      "OBJ_281" = {
+         isa = "PBXFileReference";
+         path = "buf.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_282" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_283",
+            "OBJ_284",
+            "OBJ_285",
+            "OBJ_286"
+         );
+         name = "bytestring";
+         path = "bytestring";
+         sourceTree = "<group>";
+      };
+      "OBJ_283" = {
+         isa = "PBXFileReference";
+         path = "asn1_compat.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_284" = {
+         isa = "PBXFileReference";
+         path = "ber.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_285" = {
+         isa = "PBXFileReference";
+         path = "cbb.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_286" = {
+         isa = "PBXFileReference";
+         path = "cbs.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_287" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_288"
+         );
+         name = "chacha";
+         path = "chacha";
+         sourceTree = "<group>";
+      };
+      "OBJ_288" = {
+         isa = "PBXFileReference";
+         path = "chacha.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_289" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_290",
+            "OBJ_291",
+            "OBJ_292",
+            "OBJ_293",
+            "OBJ_294",
+            "OBJ_295",
+            "OBJ_296",
+            "OBJ_297",
+            "OBJ_298",
+            "OBJ_299",
+            "OBJ_300"
+         );
+         name = "cipher_extra";
+         path = "cipher_extra";
+         sourceTree = "<group>";
+      };
+      "OBJ_29" = {
+         isa = "PBXFileReference";
+         path = "analytics_stream_Filter.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_290" = {
+         isa = "PBXFileReference";
+         path = "cipher_extra.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_291" = {
+         isa = "PBXFileReference";
+         path = "derive_key.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_292" = {
+         isa = "PBXFileReference";
+         path = "e_aesctrhmac.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_293" = {
+         isa = "PBXFileReference";
+         path = "e_aesgcmsiv.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_294" = {
+         isa = "PBXFileReference";
+         path = "e_chacha20poly1305.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_295" = {
+         isa = "PBXFileReference";
+         path = "e_null.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_296" = {
+         isa = "PBXFileReference";
+         path = "e_rc2.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_297" = {
+         isa = "PBXFileReference";
+         path = "e_rc4.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_298" = {
+         isa = "PBXFileReference";
+         path = "e_ssl3.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_299" = {
+         isa = "PBXFileReference";
+         path = "e_tls.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_3" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_OBJC_ARC = "YES";
+            COMBINE_HIDPI_IMAGES = "YES";
+            COPY_PHASE_STRIP = "NO";
+            DEBUG_INFORMATION_FORMAT = "dwarf";
+            DYLIB_INSTALL_NAME_BASE = "@rpath";
+            ENABLE_NS_ASSERTIONS = "YES";
+            GCC_OPTIMIZATION_LEVEL = "0";
+            GCC_PREPROCESSOR_DEFINITIONS = (
+               "DEBUG=1",
+               "$(inherited)"
+            );
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            ONLY_ACTIVE_ARCH = "YES";
+            OTHER_SWIFT_FLAGS = (
+               "-DXcode"
+            );
+            PRODUCT_NAME = "$(TARGET_NAME)";
+            SDKROOT = "macosx";
+            SUPPORTED_PLATFORMS = (
+               "macosx",
+               "iphoneos",
+               "iphonesimulator",
+               "appletvos",
+               "appletvsimulator",
+               "watchos",
+               "watchsimulator"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "SWIFT_PACKAGE",
+               "DEBUG"
+            );
+            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+            USE_HEADERMAP = "NO";
+         };
+         name = "Debug";
+      };
+      "OBJ_30" = {
+         isa = "PBXFileReference";
+         path = "auth_v1beta1_AuthService_Beta1.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_300" = {
+         isa = "PBXFileReference";
+         path = "tls_cbc.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_301" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_302"
+         );
+         name = "cmac";
+         path = "cmac";
+         sourceTree = "<group>";
+      };
+      "OBJ_302" = {
+         isa = "PBXFileReference";
+         path = "cmac.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_303" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_304"
+         );
+         name = "conf";
+         path = "conf";
+         sourceTree = "<group>";
+      };
+      "OBJ_304" = {
+         isa = "PBXFileReference";
+         path = "conf.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_305" = {
+         isa = "PBXFileReference";
+         path = "cpu-aarch64-linux.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_306" = {
+         isa = "PBXFileReference";
+         path = "cpu-arm-linux.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_307" = {
+         isa = "PBXFileReference";
+         path = "cpu-arm.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_308" = {
+         isa = "PBXFileReference";
+         path = "cpu-intel.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_309" = {
+         isa = "PBXFileReference";
+         path = "cpu-ppc64le.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_31" = {
+         isa = "PBXFileReference";
+         path = "base_Compression.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_310" = {
+         isa = "PBXFileReference";
+         path = "crypto.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_311" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_312",
+            "OBJ_313"
+         );
+         name = "curve25519";
+         path = "curve25519";
+         sourceTree = "<group>";
+      };
+      "OBJ_312" = {
+         isa = "PBXFileReference";
+         path = "spake25519.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_313" = {
+         isa = "PBXFileReference";
+         path = "x25519-x86_64.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_314" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_315",
+            "OBJ_316",
+            "OBJ_317",
+            "OBJ_318"
+         );
+         name = "dh";
+         path = "dh";
+         sourceTree = "<group>";
+      };
+      "OBJ_315" = {
+         isa = "PBXFileReference";
+         path = "check.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_316" = {
+         isa = "PBXFileReference";
+         path = "dh.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_317" = {
+         isa = "PBXFileReference";
+         path = "dh_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_318" = {
+         isa = "PBXFileReference";
+         path = "params.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_319" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_320"
+         );
+         name = "digest_extra";
+         path = "digest_extra";
+         sourceTree = "<group>";
+      };
+      "OBJ_32" = {
+         isa = "PBXFileReference";
+         path = "base_Language.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_320" = {
+         isa = "PBXFileReference";
+         path = "digest_extra.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_321" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_322",
+            "OBJ_323"
+         );
+         name = "dsa";
+         path = "dsa";
+         sourceTree = "<group>";
+      };
+      "OBJ_322" = {
+         isa = "PBXFileReference";
+         path = "dsa.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_323" = {
+         isa = "PBXFileReference";
+         path = "dsa_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_324" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_325"
+         );
+         name = "ec_extra";
+         path = "ec_extra";
+         sourceTree = "<group>";
+      };
+      "OBJ_325" = {
+         isa = "PBXFileReference";
+         path = "ec_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_326" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_327"
+         );
+         name = "ecdh";
+         path = "ecdh";
+         sourceTree = "<group>";
+      };
+      "OBJ_327" = {
+         isa = "PBXFileReference";
+         path = "ecdh.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_328" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_329"
+         );
+         name = "ecdsa_extra";
+         path = "ecdsa_extra";
+         sourceTree = "<group>";
+      };
+      "OBJ_329" = {
+         isa = "PBXFileReference";
+         path = "ecdsa_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_33" = {
+         isa = "PBXFileReference";
+         path = "base_ProductKey.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_330" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_331"
+         );
+         name = "engine";
+         path = "engine";
+         sourceTree = "<group>";
+      };
+      "OBJ_331" = {
+         isa = "PBXFileReference";
+         path = "engine.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_332" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_333",
+            "OBJ_334"
+         );
+         name = "err";
+         path = "err";
+         sourceTree = "<group>";
+      };
+      "OBJ_333" = {
+         isa = "PBXFileReference";
+         path = "err.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_334" = {
+         isa = "PBXFileReference";
+         path = "err_data.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_335" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_336",
+            "OBJ_337",
+            "OBJ_338",
+            "OBJ_339",
+            "OBJ_340",
+            "OBJ_341",
+            "OBJ_342",
+            "OBJ_343",
+            "OBJ_344",
+            "OBJ_345",
+            "OBJ_346",
+            "OBJ_347",
+            "OBJ_348",
+            "OBJ_349",
+            "OBJ_350"
+         );
+         name = "evp";
+         path = "evp";
+         sourceTree = "<group>";
+      };
+      "OBJ_336" = {
+         isa = "PBXFileReference";
+         path = "digestsign.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_337" = {
+         isa = "PBXFileReference";
+         path = "evp.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_338" = {
+         isa = "PBXFileReference";
+         path = "evp_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_339" = {
+         isa = "PBXFileReference";
+         path = "evp_ctx.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_34" = {
+         isa = "PBXFileReference";
+         path = "base_ProductKind.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_340" = {
+         isa = "PBXFileReference";
+         path = "p_dsa_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_341" = {
+         isa = "PBXFileReference";
+         path = "p_ec.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_342" = {
+         isa = "PBXFileReference";
+         path = "p_ec_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_343" = {
+         isa = "PBXFileReference";
+         path = "p_ed25519.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_344" = {
+         isa = "PBXFileReference";
+         path = "p_ed25519_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_345" = {
+         isa = "PBXFileReference";
+         path = "p_rsa.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_346" = {
+         isa = "PBXFileReference";
+         path = "p_rsa_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_347" = {
+         isa = "PBXFileReference";
+         path = "pbkdf.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_348" = {
+         isa = "PBXFileReference";
+         path = "print.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_349" = {
+         isa = "PBXFileReference";
+         path = "scrypt.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_35" = {
+         isa = "PBXFileReference";
+         path = "commerce_Currency.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_350" = {
+         isa = "PBXFileReference";
+         path = "sign.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_351" = {
+         isa = "PBXFileReference";
+         path = "ex_data.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_352" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_353",
+            "OBJ_357",
+            "OBJ_376",
+            "OBJ_381",
+            "OBJ_383",
+            "OBJ_386",
+            "OBJ_397",
+            "OBJ_399",
+            "OBJ_401",
+            "OBJ_402",
+            "OBJ_404",
+            "OBJ_406",
+            "OBJ_413",
+            "OBJ_417",
+            "OBJ_422"
+         );
+         name = "fipsmodule";
+         path = "fipsmodule";
+         sourceTree = "<group>";
+      };
+      "OBJ_353" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_354",
+            "OBJ_355",
+            "OBJ_356"
+         );
+         name = "aes";
+         path = "aes";
+         sourceTree = "<group>";
+      };
+      "OBJ_354" = {
+         isa = "PBXFileReference";
+         path = "aes.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_355" = {
+         isa = "PBXFileReference";
+         path = "key_wrap.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_356" = {
+         isa = "PBXFileReference";
+         path = "mode_wrappers.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_357" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_358",
+            "OBJ_359",
+            "OBJ_360",
+            "OBJ_361",
+            "OBJ_362",
+            "OBJ_363",
+            "OBJ_364",
+            "OBJ_365",
+            "OBJ_366",
+            "OBJ_367",
+            "OBJ_368",
+            "OBJ_369",
+            "OBJ_370",
+            "OBJ_371",
+            "OBJ_372",
+            "OBJ_373",
+            "OBJ_374",
+            "OBJ_375"
+         );
+         name = "bn";
+         path = "bn";
+         sourceTree = "<group>";
+      };
+      "OBJ_358" = {
+         isa = "PBXFileReference";
+         path = "add.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_359" = {
+         isa = "PBXFileReference";
+         path = "bn.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_36" = {
+         isa = "PBXFileReference";
+         path = "commerce_Customer.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_360" = {
+         isa = "PBXFileReference";
+         path = "bytes.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_361" = {
+         isa = "PBXFileReference";
+         path = "cmp.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_362" = {
+         isa = "PBXFileReference";
+         path = "ctx.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_363" = {
+         isa = "PBXFileReference";
+         path = "div.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_364" = {
+         isa = "PBXFileReference";
+         path = "exponentiation.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_365" = {
+         isa = "PBXFileReference";
+         path = "gcd.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_366" = {
+         isa = "PBXFileReference";
+         path = "generic.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_367" = {
+         isa = "PBXFileReference";
+         path = "jacobi.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_368" = {
+         isa = "PBXFileReference";
+         path = "montgomery.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_369" = {
+         isa = "PBXFileReference";
+         path = "montgomery_inv.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_37" = {
+         isa = "PBXFileReference";
+         path = "commerce_Delivery.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_370" = {
+         isa = "PBXFileReference";
+         path = "mul.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_371" = {
+         isa = "PBXFileReference";
+         path = "prime.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_372" = {
+         isa = "PBXFileReference";
+         path = "random.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_373" = {
+         isa = "PBXFileReference";
+         path = "rsaz_exp.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_374" = {
+         isa = "PBXFileReference";
+         path = "shift.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_375" = {
+         isa = "PBXFileReference";
+         path = "sqrt.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_376" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_377",
+            "OBJ_378",
+            "OBJ_379",
+            "OBJ_380"
+         );
+         name = "cipher";
+         path = "cipher";
+         sourceTree = "<group>";
+      };
+      "OBJ_377" = {
+         isa = "PBXFileReference";
+         path = "aead.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_378" = {
+         isa = "PBXFileReference";
+         path = "cipher.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_379" = {
+         isa = "PBXFileReference";
+         path = "e_aes.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_38" = {
+         isa = "PBXFileReference";
+         path = "commerce_Discounts.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_380" = {
+         isa = "PBXFileReference";
+         path = "e_des.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_381" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_382"
+         );
+         name = "des";
+         path = "des";
+         sourceTree = "<group>";
+      };
+      "OBJ_382" = {
+         isa = "PBXFileReference";
+         path = "des.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_383" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_384",
+            "OBJ_385"
+         );
+         name = "digest";
+         path = "digest";
+         sourceTree = "<group>";
+      };
+      "OBJ_384" = {
+         isa = "PBXFileReference";
+         path = "digest.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_385" = {
+         isa = "PBXFileReference";
+         path = "digests.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_386" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_387",
+            "OBJ_388",
+            "OBJ_389",
+            "OBJ_390",
+            "OBJ_391",
+            "OBJ_392",
+            "OBJ_393",
+            "OBJ_394",
+            "OBJ_395",
+            "OBJ_396"
+         );
+         name = "ec";
+         path = "ec";
+         sourceTree = "<group>";
+      };
+      "OBJ_387" = {
+         isa = "PBXFileReference";
+         path = "ec.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_388" = {
+         isa = "PBXFileReference";
+         path = "ec_key.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_389" = {
+         isa = "PBXFileReference";
+         path = "ec_montgomery.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_39" = {
+         isa = "PBXFileReference";
+         path = "commerce_Item.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_390" = {
+         isa = "PBXFileReference";
+         path = "oct.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_391" = {
+         isa = "PBXFileReference";
+         path = "p224-64.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_392" = {
+         isa = "PBXFileReference";
+         path = "p256-64.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_393" = {
+         isa = "PBXFileReference";
+         path = "p256-x86_64.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_394" = {
+         isa = "PBXFileReference";
+         path = "simple.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_395" = {
+         isa = "PBXFileReference";
+         path = "util-64.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_396" = {
+         isa = "PBXFileReference";
+         path = "wnaf.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_397" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_398"
+         );
+         name = "ecdsa";
+         path = "ecdsa";
+         sourceTree = "<group>";
+      };
+      "OBJ_398" = {
+         isa = "PBXFileReference";
+         path = "ecdsa.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_399" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_400"
+         );
+         name = "hmac";
+         path = "hmac";
+         sourceTree = "<group>";
+      };
+      "OBJ_4" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            CLANG_ENABLE_OBJC_ARC = "YES";
+            COMBINE_HIDPI_IMAGES = "YES";
+            COPY_PHASE_STRIP = "YES";
+            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+            DYLIB_INSTALL_NAME_BASE = "@rpath";
+            GCC_OPTIMIZATION_LEVEL = "s";
+            MACOSX_DEPLOYMENT_TARGET = "10.10";
+            OTHER_SWIFT_FLAGS = (
+               "-DXcode"
+            );
+            PRODUCT_NAME = "$(TARGET_NAME)";
+            SDKROOT = "macosx";
+            SUPPORTED_PLATFORMS = (
+               "macosx",
+               "iphoneos",
+               "iphonesimulator",
+               "appletvos",
+               "appletvsimulator",
+               "watchos",
+               "watchsimulator"
+            );
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "SWIFT_PACKAGE"
+            );
+            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+            USE_HEADERMAP = "NO";
+         };
+         name = "Release";
+      };
+      "OBJ_40" = {
+         isa = "PBXFileReference";
+         path = "commerce_Order.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_400" = {
+         isa = "PBXFileReference";
+         path = "hmac.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_401" = {
+         isa = "PBXFileReference";
+         path = "is_fips.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_402" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_403"
+         );
+         name = "md4";
+         path = "md4";
+         sourceTree = "<group>";
+      };
+      "OBJ_403" = {
+         isa = "PBXFileReference";
+         path = "md4.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_404" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_405"
+         );
+         name = "md5";
+         path = "md5";
+         sourceTree = "<group>";
+      };
+      "OBJ_405" = {
+         isa = "PBXFileReference";
+         path = "md5.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_406" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_407",
+            "OBJ_408",
+            "OBJ_409",
+            "OBJ_410",
+            "OBJ_411",
+            "OBJ_412"
+         );
+         name = "modes";
+         path = "modes";
+         sourceTree = "<group>";
+      };
+      "OBJ_407" = {
+         isa = "PBXFileReference";
+         path = "cbc.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_408" = {
+         isa = "PBXFileReference";
+         path = "cfb.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_409" = {
+         isa = "PBXFileReference";
+         path = "ctr.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_41" = {
+         isa = "PBXFileReference";
+         path = "commerce_Purchase.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_410" = {
+         isa = "PBXFileReference";
+         path = "gcm.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_411" = {
+         isa = "PBXFileReference";
+         path = "ofb.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_412" = {
+         isa = "PBXFileReference";
+         path = "polyval.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_413" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_414",
+            "OBJ_415",
+            "OBJ_416"
+         );
+         name = "rand";
+         path = "rand";
+         sourceTree = "<group>";
+      };
+      "OBJ_414" = {
+         isa = "PBXFileReference";
+         path = "ctrdrbg.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_415" = {
+         isa = "PBXFileReference";
+         path = "rand.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_416" = {
+         isa = "PBXFileReference";
+         path = "urandom.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_417" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_418",
+            "OBJ_419",
+            "OBJ_420",
+            "OBJ_421"
+         );
+         name = "rsa";
+         path = "rsa";
+         sourceTree = "<group>";
+      };
+      "OBJ_418" = {
+         isa = "PBXFileReference";
+         path = "blinding.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_419" = {
+         isa = "PBXFileReference";
+         path = "padding.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_42" = {
+         isa = "PBXFileReference";
+         path = "commerce_payments_Payment.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_420" = {
+         isa = "PBXFileReference";
+         path = "rsa.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_421" = {
+         isa = "PBXFileReference";
+         path = "rsa_impl.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_422" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_423",
+            "OBJ_424",
+            "OBJ_425",
+            "OBJ_426"
+         );
+         name = "sha";
+         path = "sha";
+         sourceTree = "<group>";
+      };
+      "OBJ_423" = {
+         isa = "PBXFileReference";
+         path = "sha1-altivec.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_424" = {
+         isa = "PBXFileReference";
+         path = "sha1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_425" = {
+         isa = "PBXFileReference";
+         path = "sha256.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_426" = {
+         isa = "PBXFileReference";
+         path = "sha512.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_427" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_428"
+         );
+         name = "hkdf";
+         path = "hkdf";
+         sourceTree = "<group>";
+      };
+      "OBJ_428" = {
+         isa = "PBXFileReference";
+         path = "hkdf.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_429" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_430"
+         );
+         name = "lhash";
+         path = "lhash";
+         sourceTree = "<group>";
+      };
+      "OBJ_43" = {
+         isa = "PBXFileReference";
+         path = "comms_Comms.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_430" = {
+         isa = "PBXFileReference";
+         path = "lhash.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_431" = {
+         isa = "PBXFileReference";
+         path = "mem.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_432" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_433",
+            "OBJ_434"
+         );
+         name = "obj";
+         path = "obj";
+         sourceTree = "<group>";
+      };
+      "OBJ_433" = {
+         isa = "PBXFileReference";
+         path = "obj.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_434" = {
+         isa = "PBXFileReference";
+         path = "obj_xref.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_435" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_436",
+            "OBJ_437",
+            "OBJ_438",
+            "OBJ_439",
+            "OBJ_440",
+            "OBJ_441",
+            "OBJ_442",
+            "OBJ_443"
+         );
+         name = "pem";
+         path = "pem";
+         sourceTree = "<group>";
+      };
+      "OBJ_436" = {
+         isa = "PBXFileReference";
+         path = "pem_all.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_437" = {
+         isa = "PBXFileReference";
+         path = "pem_info.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_438" = {
+         isa = "PBXFileReference";
+         path = "pem_lib.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_439" = {
+         isa = "PBXFileReference";
+         path = "pem_oth.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_44" = {
+         isa = "PBXFileReference";
+         path = "comms_CommsTask.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_440" = {
+         isa = "PBXFileReference";
+         path = "pem_pk8.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_441" = {
+         isa = "PBXFileReference";
+         path = "pem_pkey.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_442" = {
+         isa = "PBXFileReference";
+         path = "pem_x509.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_443" = {
+         isa = "PBXFileReference";
+         path = "pem_xaux.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_444" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_445",
+            "OBJ_446"
+         );
+         name = "pkcs7";
+         path = "pkcs7";
+         sourceTree = "<group>";
+      };
+      "OBJ_445" = {
+         isa = "PBXFileReference";
+         path = "pkcs7.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_446" = {
+         isa = "PBXFileReference";
+         path = "pkcs7_x509.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_447" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_448",
+            "OBJ_449",
+            "OBJ_450"
+         );
+         name = "pkcs8";
+         path = "pkcs8";
+         sourceTree = "<group>";
+      };
+      "OBJ_448" = {
+         isa = "PBXFileReference";
+         path = "p5_pbev2.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_449" = {
+         isa = "PBXFileReference";
+         path = "pkcs8.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_45" = {
+         isa = "PBXFileReference";
+         path = "comms_Email.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_450" = {
+         isa = "PBXFileReference";
+         path = "pkcs8_x509.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_451" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_452",
+            "OBJ_453",
+            "OBJ_454"
+         );
+         name = "poly1305";
+         path = "poly1305";
+         sourceTree = "<group>";
+      };
+      "OBJ_452" = {
+         isa = "PBXFileReference";
+         path = "poly1305.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_453" = {
+         isa = "PBXFileReference";
+         path = "poly1305_arm.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_454" = {
+         isa = "PBXFileReference";
+         path = "poly1305_vec.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_455" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_456"
+         );
+         name = "pool";
+         path = "pool";
+         sourceTree = "<group>";
+      };
+      "OBJ_456" = {
+         isa = "PBXFileReference";
+         path = "pool.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_457" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_458",
+            "OBJ_459",
+            "OBJ_460",
+            "OBJ_461",
+            "OBJ_462"
+         );
+         name = "rand_extra";
+         path = "rand_extra";
+         sourceTree = "<group>";
+      };
+      "OBJ_458" = {
+         isa = "PBXFileReference";
+         path = "deterministic.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_459" = {
+         isa = "PBXFileReference";
+         path = "forkunsafe.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_46" = {
+         isa = "PBXFileReference";
+         path = "comms_SMS.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_460" = {
+         isa = "PBXFileReference";
+         path = "fuchsia.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_461" = {
+         isa = "PBXFileReference";
+         path = "rand_extra.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_462" = {
+         isa = "PBXFileReference";
+         path = "windows.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_463" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_464"
+         );
+         name = "rc4";
+         path = "rc4";
+         sourceTree = "<group>";
+      };
+      "OBJ_464" = {
+         isa = "PBXFileReference";
+         path = "rc4.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_465" = {
+         isa = "PBXFileReference";
+         path = "refcount_c11.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_466" = {
+         isa = "PBXFileReference";
+         path = "refcount_lock.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_467" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_468"
+         );
+         name = "rsa_extra";
+         path = "rsa_extra";
+         sourceTree = "<group>";
+      };
+      "OBJ_468" = {
+         isa = "PBXFileReference";
+         path = "rsa_asn1.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_469" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_470"
+         );
+         name = "stack";
+         path = "stack";
+         sourceTree = "<group>";
+      };
+      "OBJ_47" = {
+         isa = "PBXFileReference";
+         path = "contact_ContactInfo.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_470" = {
+         isa = "PBXFileReference";
+         path = "stack.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_471" = {
+         isa = "PBXFileReference";
+         path = "thread.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_472" = {
+         isa = "PBXFileReference";
+         path = "thread_none.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_473" = {
+         isa = "PBXFileReference";
+         path = "thread_pthread.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_474" = {
+         isa = "PBXFileReference";
+         path = "thread_win.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_475" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_476",
+            "OBJ_477",
+            "OBJ_478",
+            "OBJ_479",
+            "OBJ_480",
+            "OBJ_481",
+            "OBJ_482",
+            "OBJ_483",
+            "OBJ_484",
+            "OBJ_485",
+            "OBJ_486",
+            "OBJ_487",
+            "OBJ_488",
+            "OBJ_489",
+            "OBJ_490",
+            "OBJ_491",
+            "OBJ_492",
+            "OBJ_493",
+            "OBJ_494",
+            "OBJ_495",
+            "OBJ_496",
+            "OBJ_497",
+            "OBJ_498",
+            "OBJ_499",
+            "OBJ_500",
+            "OBJ_501",
+            "OBJ_502",
+            "OBJ_503",
+            "OBJ_504",
+            "OBJ_505",
+            "OBJ_506",
+            "OBJ_507",
+            "OBJ_508",
+            "OBJ_509",
+            "OBJ_510",
+            "OBJ_511",
+            "OBJ_512",
+            "OBJ_513",
+            "OBJ_514",
+            "OBJ_515",
+            "OBJ_516",
+            "OBJ_517",
+            "OBJ_518",
+            "OBJ_519",
+            "OBJ_520",
+            "OBJ_521",
+            "OBJ_522",
+            "OBJ_523",
+            "OBJ_524"
+         );
+         name = "x509";
+         path = "x509";
+         sourceTree = "<group>";
+      };
+      "OBJ_476" = {
+         isa = "PBXFileReference";
+         path = "a_digest.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_477" = {
+         isa = "PBXFileReference";
+         path = "a_sign.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_478" = {
+         isa = "PBXFileReference";
+         path = "a_strex.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_479" = {
+         isa = "PBXFileReference";
+         path = "a_verify.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_48" = {
+         isa = "PBXFileReference";
+         path = "contact_EmailAddress.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_480" = {
+         isa = "PBXFileReference";
+         path = "algorithm.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_481" = {
+         isa = "PBXFileReference";
+         path = "asn1_gen.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_482" = {
+         isa = "PBXFileReference";
+         path = "by_dir.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_483" = {
+         isa = "PBXFileReference";
+         path = "by_file.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_484" = {
+         isa = "PBXFileReference";
+         path = "i2d_pr.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_485" = {
+         isa = "PBXFileReference";
+         path = "rsa_pss.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_486" = {
+         isa = "PBXFileReference";
+         path = "t_crl.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_487" = {
+         isa = "PBXFileReference";
+         path = "t_req.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_488" = {
+         isa = "PBXFileReference";
+         path = "t_x509.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_489" = {
+         isa = "PBXFileReference";
+         path = "t_x509a.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_49" = {
+         isa = "PBXFileReference";
+         path = "contact_PhoneNumber.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_490" = {
+         isa = "PBXFileReference";
+         path = "x509.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_491" = {
+         isa = "PBXFileReference";
+         path = "x509_att.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_492" = {
+         isa = "PBXFileReference";
+         path = "x509_cmp.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_493" = {
+         isa = "PBXFileReference";
+         path = "x509_d2.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_494" = {
+         isa = "PBXFileReference";
+         path = "x509_def.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_495" = {
+         isa = "PBXFileReference";
+         path = "x509_ext.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_496" = {
+         isa = "PBXFileReference";
+         path = "x509_lu.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_497" = {
+         isa = "PBXFileReference";
+         path = "x509_obj.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_498" = {
+         isa = "PBXFileReference";
+         path = "x509_r2x.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_499" = {
+         isa = "PBXFileReference";
+         path = "x509_req.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_5" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_6",
+            "OBJ_7",
+            "OBJ_211",
+            "OBJ_224",
+            "OBJ_225",
+            "OBJ_226",
+            "OBJ_227",
+            "OBJ_228",
+            "OBJ_229",
+            "OBJ_1293"
+         );
+         path = "";
+         sourceTree = "<group>";
+      };
+      "OBJ_50" = {
+         isa = "PBXFileReference";
+         path = "contact_Website.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_500" = {
+         isa = "PBXFileReference";
+         path = "x509_set.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_501" = {
+         isa = "PBXFileReference";
+         path = "x509_trs.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_502" = {
+         isa = "PBXFileReference";
+         path = "x509_txt.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_503" = {
+         isa = "PBXFileReference";
+         path = "x509_v3.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_504" = {
+         isa = "PBXFileReference";
+         path = "x509_vfy.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_505" = {
+         isa = "PBXFileReference";
+         path = "x509_vpm.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_506" = {
+         isa = "PBXFileReference";
+         path = "x509cset.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_507" = {
+         isa = "PBXFileReference";
+         path = "x509name.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_508" = {
+         isa = "PBXFileReference";
+         path = "x509rset.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_509" = {
+         isa = "PBXFileReference";
+         path = "x509spki.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_51" = {
+         isa = "PBXFileReference";
+         path = "content_Brand.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_510" = {
+         isa = "PBXFileReference";
+         path = "x_algor.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_511" = {
+         isa = "PBXFileReference";
+         path = "x_all.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_512" = {
+         isa = "PBXFileReference";
+         path = "x_attrib.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_513" = {
+         isa = "PBXFileReference";
+         path = "x_crl.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_514" = {
+         isa = "PBXFileReference";
+         path = "x_exten.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_515" = {
+         isa = "PBXFileReference";
+         path = "x_info.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_516" = {
+         isa = "PBXFileReference";
+         path = "x_name.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_517" = {
+         isa = "PBXFileReference";
+         path = "x_pkey.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_518" = {
+         isa = "PBXFileReference";
+         path = "x_pubkey.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_519" = {
+         isa = "PBXFileReference";
+         path = "x_req.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_52" = {
+         isa = "PBXFileReference";
+         path = "content_Colors.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_520" = {
+         isa = "PBXFileReference";
+         path = "x_sig.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_521" = {
+         isa = "PBXFileReference";
+         path = "x_spki.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_522" = {
+         isa = "PBXFileReference";
+         path = "x_val.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_523" = {
+         isa = "PBXFileReference";
+         path = "x_x509.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_524" = {
+         isa = "PBXFileReference";
+         path = "x_x509a.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_525" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_526",
+            "OBJ_527",
+            "OBJ_528",
+            "OBJ_529",
+            "OBJ_530",
+            "OBJ_531",
+            "OBJ_532",
+            "OBJ_533",
+            "OBJ_534",
+            "OBJ_535",
+            "OBJ_536",
+            "OBJ_537",
+            "OBJ_538",
+            "OBJ_539",
+            "OBJ_540",
+            "OBJ_541",
+            "OBJ_542",
+            "OBJ_543",
+            "OBJ_544",
+            "OBJ_545",
+            "OBJ_546",
+            "OBJ_547",
+            "OBJ_548",
+            "OBJ_549",
+            "OBJ_550",
+            "OBJ_551",
+            "OBJ_552",
+            "OBJ_553",
+            "OBJ_554",
+            "OBJ_555",
+            "OBJ_556",
+            "OBJ_557"
+         );
+         name = "x509v3";
+         path = "x509v3";
+         sourceTree = "<group>";
+      };
+      "OBJ_526" = {
+         isa = "PBXFileReference";
+         path = "pcy_cache.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_527" = {
+         isa = "PBXFileReference";
+         path = "pcy_data.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_528" = {
+         isa = "PBXFileReference";
+         path = "pcy_lib.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_529" = {
+         isa = "PBXFileReference";
+         path = "pcy_map.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_53" = {
+         isa = "PBXFileReference";
+         path = "content_Content.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_530" = {
+         isa = "PBXFileReference";
+         path = "pcy_node.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_531" = {
+         isa = "PBXFileReference";
+         path = "pcy_tree.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_532" = {
+         isa = "PBXFileReference";
+         path = "v3_akey.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_533" = {
+         isa = "PBXFileReference";
+         path = "v3_akeya.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_534" = {
+         isa = "PBXFileReference";
+         path = "v3_alt.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_535" = {
+         isa = "PBXFileReference";
+         path = "v3_bcons.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_536" = {
+         isa = "PBXFileReference";
+         path = "v3_bitst.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_537" = {
+         isa = "PBXFileReference";
+         path = "v3_conf.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_538" = {
+         isa = "PBXFileReference";
+         path = "v3_cpols.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_539" = {
+         isa = "PBXFileReference";
+         path = "v3_crld.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_54" = {
+         isa = "PBXFileReference";
+         path = "content_MaterialsData.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_540" = {
+         isa = "PBXFileReference";
+         path = "v3_enum.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_541" = {
+         isa = "PBXFileReference";
+         path = "v3_extku.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_542" = {
+         isa = "PBXFileReference";
+         path = "v3_genn.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_543" = {
+         isa = "PBXFileReference";
+         path = "v3_ia5.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_544" = {
+         isa = "PBXFileReference";
+         path = "v3_info.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_545" = {
+         isa = "PBXFileReference";
+         path = "v3_int.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_546" = {
+         isa = "PBXFileReference";
+         path = "v3_lib.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_547" = {
+         isa = "PBXFileReference";
+         path = "v3_ncons.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_548" = {
+         isa = "PBXFileReference";
+         path = "v3_pci.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_549" = {
+         isa = "PBXFileReference";
+         path = "v3_pcia.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_55" = {
+         isa = "PBXFileReference";
+         path = "content_Name.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_550" = {
+         isa = "PBXFileReference";
+         path = "v3_pcons.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_551" = {
+         isa = "PBXFileReference";
+         path = "v3_pku.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_552" = {
+         isa = "PBXFileReference";
+         path = "v3_pmaps.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_553" = {
+         isa = "PBXFileReference";
+         path = "v3_prn.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_554" = {
+         isa = "PBXFileReference";
+         path = "v3_purp.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_555" = {
+         isa = "PBXFileReference";
+         path = "v3_skey.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_556" = {
+         isa = "PBXFileReference";
+         path = "v3_sxnet.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_557" = {
+         isa = "PBXFileReference";
+         path = "v3_utl.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_558" = {
+         isa = "PBXFileReference";
+         path = "err_data.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_559" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_560",
+            "OBJ_561",
+            "OBJ_562",
+            "OBJ_563",
+            "OBJ_564",
+            "OBJ_565",
+            "OBJ_566",
+            "OBJ_567",
+            "OBJ_568",
+            "OBJ_569",
+            "OBJ_570",
+            "OBJ_571",
+            "OBJ_572",
+            "OBJ_573",
+            "OBJ_574",
+            "OBJ_575",
+            "OBJ_576",
+            "OBJ_577",
+            "OBJ_578",
+            "OBJ_579",
+            "OBJ_580",
+            "OBJ_581",
+            "OBJ_582",
+            "OBJ_583",
+            "OBJ_584",
+            "OBJ_585",
+            "OBJ_586",
+            "OBJ_587",
+            "OBJ_588",
+            "OBJ_589",
+            "OBJ_590",
+            "OBJ_591",
+            "OBJ_592",
+            "OBJ_593",
+            "OBJ_594",
+            "OBJ_595"
+         );
+         name = "ssl";
+         path = "ssl";
+         sourceTree = "<group>";
+      };
+      "OBJ_56" = {
+         isa = "PBXFileReference";
+         path = "content_ProductContent.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_560" = {
+         isa = "PBXFileReference";
+         path = "bio_ssl.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_561" = {
+         isa = "PBXFileReference";
+         path = "custom_extensions.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_562" = {
+         isa = "PBXFileReference";
+         path = "d1_both.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_563" = {
+         isa = "PBXFileReference";
+         path = "d1_lib.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_564" = {
+         isa = "PBXFileReference";
+         path = "d1_pkt.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_565" = {
+         isa = "PBXFileReference";
+         path = "d1_srtp.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_566" = {
+         isa = "PBXFileReference";
+         path = "dtls_method.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_567" = {
+         isa = "PBXFileReference";
+         path = "dtls_record.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_568" = {
+         isa = "PBXFileReference";
+         path = "handshake.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_569" = {
+         isa = "PBXFileReference";
+         path = "handshake_client.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_57" = {
+         isa = "PBXFileReference";
+         path = "core_Datamodel.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_570" = {
+         isa = "PBXFileReference";
+         path = "handshake_server.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_571" = {
+         isa = "PBXFileReference";
+         path = "s3_both.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_572" = {
+         isa = "PBXFileReference";
+         path = "s3_lib.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_573" = {
+         isa = "PBXFileReference";
+         path = "s3_pkt.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_574" = {
+         isa = "PBXFileReference";
+         path = "ssl_aead_ctx.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_575" = {
+         isa = "PBXFileReference";
+         path = "ssl_asn1.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_576" = {
+         isa = "PBXFileReference";
+         path = "ssl_buffer.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_577" = {
+         isa = "PBXFileReference";
+         path = "ssl_cert.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_578" = {
+         isa = "PBXFileReference";
+         path = "ssl_cipher.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_579" = {
+         isa = "PBXFileReference";
+         path = "ssl_file.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_58" = {
+         isa = "PBXFileReference";
+         path = "crypto_Container.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_580" = {
+         isa = "PBXFileReference";
+         path = "ssl_key_share.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_581" = {
+         isa = "PBXFileReference";
+         path = "ssl_lib.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_582" = {
+         isa = "PBXFileReference";
+         path = "ssl_privkey.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_583" = {
+         isa = "PBXFileReference";
+         path = "ssl_session.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_584" = {
+         isa = "PBXFileReference";
+         path = "ssl_stat.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_585" = {
+         isa = "PBXFileReference";
+         path = "ssl_transcript.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_586" = {
+         isa = "PBXFileReference";
+         path = "ssl_versions.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_587" = {
+         isa = "PBXFileReference";
+         path = "ssl_x509.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_588" = {
+         isa = "PBXFileReference";
+         path = "t1_enc.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_589" = {
+         isa = "PBXFileReference";
+         path = "t1_lib.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_59" = {
+         isa = "PBXFileReference";
+         path = "crypto_Signature.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_590" = {
+         isa = "PBXFileReference";
+         path = "tls13_both.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_591" = {
+         isa = "PBXFileReference";
+         path = "tls13_client.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_592" = {
+         isa = "PBXFileReference";
+         path = "tls13_enc.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_593" = {
+         isa = "PBXFileReference";
+         path = "tls13_server.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_594" = {
+         isa = "PBXFileReference";
+         path = "tls_method.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_595" = {
+         isa = "PBXFileReference";
+         path = "tls_record.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_596" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_597"
+         );
+         name = "third_party";
+         path = "third_party";
+         sourceTree = "<group>";
+      };
+      "OBJ_597" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_598"
+         );
+         name = "fiat";
+         path = "fiat";
+         sourceTree = "<group>";
+      };
+      "OBJ_598" = {
+         isa = "PBXFileReference";
+         path = "curve25519.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_599" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_600",
+            "OBJ_674"
+         );
+         name = "include";
+         path = "include";
+         sourceTree = "<group>";
+      };
+      "OBJ_6" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         path = "Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_60" = {
+         isa = "PBXFileReference";
+         path = "crypto_primitives_Integrity.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_600" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_601",
+            "OBJ_602",
+            "OBJ_603",
+            "OBJ_604",
+            "OBJ_605",
+            "OBJ_606",
+            "OBJ_607",
+            "OBJ_608",
+            "OBJ_609",
+            "OBJ_610",
+            "OBJ_611",
+            "OBJ_612",
+            "OBJ_613",
+            "OBJ_614",
+            "OBJ_615",
+            "OBJ_616",
+            "OBJ_617",
+            "OBJ_618",
+            "OBJ_619",
+            "OBJ_620",
+            "OBJ_621",
+            "OBJ_622",
+            "OBJ_623",
+            "OBJ_624",
+            "OBJ_625",
+            "OBJ_626",
+            "OBJ_627",
+            "OBJ_628",
+            "OBJ_629",
+            "OBJ_630",
+            "OBJ_631",
+            "OBJ_632",
+            "OBJ_633",
+            "OBJ_634",
+            "OBJ_635",
+            "OBJ_636",
+            "OBJ_637",
+            "OBJ_638",
+            "OBJ_639",
+            "OBJ_640",
+            "OBJ_641",
+            "OBJ_642",
+            "OBJ_643",
+            "OBJ_644",
+            "OBJ_645",
+            "OBJ_646",
+            "OBJ_647",
+            "OBJ_648",
+            "OBJ_649",
+            "OBJ_650",
+            "OBJ_651",
+            "OBJ_652",
+            "OBJ_653",
+            "OBJ_654",
+            "OBJ_655",
+            "OBJ_656",
+            "OBJ_657",
+            "OBJ_658",
+            "OBJ_659",
+            "OBJ_660",
+            "OBJ_661",
+            "OBJ_662",
+            "OBJ_663",
+            "OBJ_664",
+            "OBJ_665",
+            "OBJ_666",
+            "OBJ_667",
+            "OBJ_668",
+            "OBJ_669",
+            "OBJ_670",
+            "OBJ_671",
+            "OBJ_672",
+            "OBJ_673"
+         );
+         name = "openssl";
+         path = "openssl";
+         sourceTree = "<group>";
+      };
+      "OBJ_601" = {
+         isa = "PBXFileReference";
+         path = "pem.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_602" = {
+         isa = "PBXFileReference";
+         path = "nid.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_603" = {
+         isa = "PBXFileReference";
+         path = "ssl3.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_604" = {
+         isa = "PBXFileReference";
+         path = "ossl_typ.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_605" = {
+         isa = "PBXFileReference";
+         path = "dtls1.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_606" = {
+         isa = "PBXFileReference";
+         path = "err.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_607" = {
+         isa = "PBXFileReference";
+         path = "bn.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_608" = {
+         isa = "PBXFileReference";
+         path = "blowfish.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_609" = {
+         isa = "PBXFileReference";
+         path = "engine.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_61" = {
+         isa = "PBXFileReference";
+         path = "crypto_primitives_Keys.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_610" = {
+         isa = "PBXFileReference";
+         path = "bytestring.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_611" = {
+         isa = "PBXFileReference";
+         path = "x509.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_612" = {
+         isa = "PBXFileReference";
+         path = "asn1_mac.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_613" = {
+         isa = "PBXFileReference";
+         path = "pool.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_614" = {
+         isa = "PBXFileReference";
+         path = "ec_key.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_615" = {
+         isa = "PBXFileReference";
+         path = "base64.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_616" = {
+         isa = "PBXFileReference";
+         path = "is_boringssl.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_617" = {
+         isa = "PBXFileReference";
+         path = "sha.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_618" = {
+         isa = "PBXFileReference";
+         path = "asn1.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_619" = {
+         isa = "PBXFileReference";
+         path = "chacha.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_62" = {
+         isa = "PBXFileReference";
+         path = "device_Device.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_620" = {
+         isa = "PBXFileReference";
+         path = "opensslconf.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_621" = {
+         isa = "PBXFileReference";
+         path = "arm_arch.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_622" = {
+         isa = "PBXFileReference";
+         path = "bio.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_623" = {
+         isa = "PBXFileReference";
+         path = "dh.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_624" = {
+         isa = "PBXFileReference";
+         path = "digest.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_625" = {
+         isa = "PBXFileReference";
+         path = "x509v3.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_626" = {
+         isa = "PBXFileReference";
+         path = "conf.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_627" = {
+         isa = "PBXFileReference";
+         path = "poly1305.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_628" = {
+         isa = "PBXFileReference";
+         path = "hkdf.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_629" = {
+         isa = "PBXFileReference";
+         path = "type_check.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_63" = {
+         isa = "PBXFileReference";
+         path = "devices_v1beta1_DevicesService_Beta1.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_630" = {
+         isa = "PBXFileReference";
+         path = "md5.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_631" = {
+         isa = "PBXFileReference";
+         path = "x509_vfy.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_632" = {
+         isa = "PBXFileReference";
+         path = "pkcs8.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_633" = {
+         isa = "PBXFileReference";
+         path = "safestack.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_634" = {
+         isa = "PBXFileReference";
+         path = "buf.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_635" = {
+         isa = "PBXFileReference";
+         path = "obj.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_636" = {
+         isa = "PBXFileReference";
+         path = "ecdsa.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_637" = {
+         isa = "PBXFileReference";
+         path = "cipher.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_638" = {
+         isa = "PBXFileReference";
+         path = "objects.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_639" = {
+         isa = "PBXFileReference";
+         path = "pkcs12.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_64" = {
+         isa = "PBXFileReference";
+         path = "geo_Address.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_640" = {
+         isa = "PBXFileReference";
+         path = "crypto.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_641" = {
+         isa = "PBXFileReference";
+         path = "opensslv.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_642" = {
+         isa = "PBXFileReference";
+         path = "pkcs7.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_643" = {
+         isa = "PBXFileReference";
+         path = "obj_mac.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_644" = {
+         isa = "PBXFileReference";
+         path = "buffer.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_645" = {
+         isa = "PBXFileReference";
+         path = "ssl.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_646" = {
+         isa = "PBXFileReference";
+         path = "thread.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_647" = {
+         isa = "PBXFileReference";
+         path = "evp.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_648" = {
+         isa = "PBXFileReference";
+         path = "md4.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_649" = {
+         isa = "PBXFileReference";
+         path = "hmac.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_65" = {
+         isa = "PBXFileReference";
+         path = "geo_Country.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_650" = {
+         isa = "PBXFileReference";
+         path = "aes.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_651" = {
+         isa = "PBXFileReference";
+         path = "cast.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_652" = {
+         isa = "PBXFileReference";
+         path = "rc4.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_653" = {
+         isa = "PBXFileReference";
+         path = "cpu.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_654" = {
+         isa = "PBXFileReference";
+         path = "stack.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_655" = {
+         isa = "PBXFileReference";
+         path = "des.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_656" = {
+         isa = "PBXFileReference";
+         path = "ec.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_657" = {
+         isa = "PBXFileReference";
+         path = "ecdh.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_658" = {
+         isa = "PBXFileReference";
+         path = "rand.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_659" = {
+         isa = "PBXFileReference";
+         path = "aead.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_66" = {
+         isa = "PBXFileReference";
+         path = "geo_Distance.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_660" = {
+         isa = "PBXFileReference";
+         path = "lhash_macros.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_661" = {
+         isa = "PBXFileReference";
+         path = "span.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_662" = {
+         isa = "PBXFileReference";
+         path = "rsa.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_663" = {
+         isa = "PBXFileReference";
+         path = "mem.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_664" = {
+         isa = "PBXFileReference";
+         path = "ripemd.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_665" = {
+         isa = "PBXFileReference";
+         path = "curve25519.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_666" = {
+         isa = "PBXFileReference";
+         path = "tls1.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_667" = {
+         isa = "PBXFileReference";
+         path = "dsa.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_668" = {
+         isa = "PBXFileReference";
+         path = "srtp.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_669" = {
+         isa = "PBXFileReference";
+         path = "asn1t.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_67" = {
+         isa = "PBXFileReference";
+         path = "geo_Geohash.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_670" = {
+         isa = "PBXFileReference";
+         path = "cmac.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_671" = {
+         isa = "PBXFileReference";
+         path = "lhash.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_672" = {
+         isa = "PBXFileReference";
+         path = "ex_data.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_673" = {
+         isa = "PBXFileReference";
+         path = "base.h";
+         sourceTree = "<group>";
+      };
+      "OBJ_674" = {
+         isa = "PBXFileReference";
+         name = "module.modulemap";
+         path = "/Volumes/PITBULL/Vault/Bloombox/Client/Swift/Bloombox.xcodeproj/GeneratedModuleMap/BoringSSL/module.modulemap";
+         sourceTree = "<group>";
+      };
+      "OBJ_675" = {
+         isa = "PBXGroup";
+         children = (
+         );
+         name = "RootsEncoder";
+         path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/RootsEncoder";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_676" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_677",
+            "OBJ_694"
+         );
+         name = "SwiftGRPC";
+         path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/SwiftGRPC";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_677" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_678",
+            "OBJ_679",
+            "OBJ_680",
+            "OBJ_681",
+            "OBJ_682",
+            "OBJ_683",
+            "OBJ_684",
+            "OBJ_685",
+            "OBJ_686",
+            "OBJ_687",
+            "OBJ_688",
+            "OBJ_689",
+            "OBJ_690",
+            "OBJ_691",
+            "OBJ_692",
+            "OBJ_693"
+         );
+         name = "Core";
+         path = "Core";
+         sourceTree = "<group>";
+      };
+      "OBJ_678" = {
+         isa = "PBXFileReference";
+         path = "ByteBuffer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_679" = {
+         isa = "PBXFileReference";
+         path = "Call.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_68" = {
+         isa = "PBXFileReference";
+         path = "geo_Location.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_680" = {
+         isa = "PBXFileReference";
+         path = "CallError.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_681" = {
+         isa = "PBXFileReference";
+         path = "CallResult.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_682" = {
+         isa = "PBXFileReference";
+         path = "Channel.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_683" = {
+         isa = "PBXFileReference";
+         path = "ChannelArgument.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_684" = {
+         isa = "PBXFileReference";
+         path = "CompletionQueue.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_685" = {
+         isa = "PBXFileReference";
+         path = "Handler.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_686" = {
+         isa = "PBXFileReference";
+         path = "Metadata.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_687" = {
+         isa = "PBXFileReference";
+         path = "Mutex.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_688" = {
+         isa = "PBXFileReference";
+         path = "Operation.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_689" = {
+         isa = "PBXFileReference";
+         path = "OperationGroup.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_69" = {
+         isa = "PBXFileReference";
+         path = "geo_Point.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_690" = {
+         isa = "PBXFileReference";
+         path = "Roots.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_691" = {
+         isa = "PBXFileReference";
+         path = "Server.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_692" = {
+         isa = "PBXFileReference";
+         path = "ServerStatus.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_693" = {
+         isa = "PBXFileReference";
+         path = "gRPC.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_694" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_695",
+            "OBJ_696",
+            "OBJ_697",
+            "OBJ_698",
+            "OBJ_699",
+            "OBJ_700",
+            "OBJ_701",
+            "OBJ_702",
+            "OBJ_703",
+            "OBJ_704",
+            "OBJ_705",
+            "OBJ_706",
+            "OBJ_707",
+            "OBJ_708",
+            "OBJ_709",
+            "OBJ_710"
+         );
+         name = "Runtime";
+         path = "Runtime";
+         sourceTree = "<group>";
+      };
+      "OBJ_695" = {
+         isa = "PBXFileReference";
+         path = "ClientCall.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_696" = {
+         isa = "PBXFileReference";
+         path = "ClientCallBidirectionalStreaming.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_697" = {
+         isa = "PBXFileReference";
+         path = "ClientCallClientStreaming.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_698" = {
+         isa = "PBXFileReference";
+         path = "ClientCallServerStreaming.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_699" = {
+         isa = "PBXFileReference";
+         path = "ClientCallUnary.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_7" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_8",
+            "OBJ_179",
+            "OBJ_190"
+         );
+         name = "Sources";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_70" = {
+         isa = "PBXFileReference";
+         path = "geo_Province.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_700" = {
+         isa = "PBXFileReference";
+         path = "RPCError.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_701" = {
+         isa = "PBXFileReference";
+         path = "ServerSession.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_702" = {
+         isa = "PBXFileReference";
+         path = "ServerSessionBidirectionalStreaming.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_703" = {
+         isa = "PBXFileReference";
+         path = "ServerSessionClientStreaming.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_704" = {
+         isa = "PBXFileReference";
+         path = "ServerSessionServerStreaming.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_705" = {
+         isa = "PBXFileReference";
+         path = "ServerSessionUnary.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_706" = {
+         isa = "PBXFileReference";
+         path = "ServiceClient.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_707" = {
+         isa = "PBXFileReference";
+         path = "ServiceProvider.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_708" = {
+         isa = "PBXFileReference";
+         path = "ServiceServer.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_709" = {
+         isa = "PBXFileReference";
+         path = "StreamReceiving.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_71" = {
+         isa = "PBXFileReference";
+         path = "geo_USState.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_710" = {
+         isa = "PBXFileReference";
+         path = "StreamSending.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_711" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_712",
+            "OBJ_725",
+            "OBJ_1143",
+            "OBJ_1148"
+         );
+         name = "CgRPC";
+         path = ".build/checkouts/grpc-swift.git--2568890431933451096/Sources/CgRPC";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_712" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_713",
+            "OBJ_714",
+            "OBJ_715",
+            "OBJ_716",
+            "OBJ_717",
+            "OBJ_718",
+            "OBJ_719",
+            "OBJ_720",
+            "OBJ_721",
+            "OBJ_722",
+            "OBJ_723",
+            "OBJ_724"
+         );
+         name = "shim";
+         path = "shim";
+         sourceTree = "<group>";
+      };
+      "OBJ_713" = {
+         isa = "PBXFileReference";
+         path = "byte_buffer.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_714" = {
+         isa = "PBXFileReference";
+         path = "call.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_715" = {
+         isa = "PBXFileReference";
+         path = "channel.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_716" = {
+         isa = "PBXFileReference";
+         path = "completion_queue.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_717" = {
+         isa = "PBXFileReference";
+         path = "event.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_718" = {
+         isa = "PBXFileReference";
+         path = "handler.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_719" = {
+         isa = "PBXFileReference";
+         path = "internal.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_72" = {
+         isa = "PBXFileReference";
+         path = "geo_usa_ca_CACounty.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_720" = {
+         isa = "PBXFileReference";
+         path = "metadata.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_721" = {
+         isa = "PBXFileReference";
+         path = "mutex.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_722" = {
+         isa = "PBXFileReference";
+         path = "observers.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_723" = {
+         isa = "PBXFileReference";
+         path = "operations.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_724" = {
+         isa = "PBXFileReference";
+         path = "server.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_725" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_726"
+         );
+         name = "src";
+         path = "src";
+         sourceTree = "<group>";
+      };
+      "OBJ_726" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_727",
+            "OBJ_848",
+            "OBJ_1100",
+            "OBJ_1102"
+         );
+         name = "core";
+         path = "core";
+         sourceTree = "<group>";
+      };
+      "OBJ_727" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_728",
+            "OBJ_730",
+            "OBJ_803"
+         );
+         name = "ext";
+         path = "ext";
+         sourceTree = "<group>";
+      };
+      "OBJ_728" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_729"
+         );
+         name = "census";
+         path = "census";
+         sourceTree = "<group>";
+      };
+      "OBJ_729" = {
+         isa = "PBXFileReference";
+         path = "grpc_context.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_73" = {
+         isa = "PBXFileReference";
+         path = "google_api_annotations.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_730" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_731",
+            "OBJ_782",
+            "OBJ_784",
+            "OBJ_793",
+            "OBJ_796",
+            "OBJ_798",
+            "OBJ_800"
+         );
+         name = "filters";
+         path = "filters";
+         sourceTree = "<group>";
+      };
+      "OBJ_731" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_732",
+            "OBJ_733",
+            "OBJ_734",
+            "OBJ_735",
+            "OBJ_736",
+            "OBJ_737",
+            "OBJ_738",
+            "OBJ_739",
+            "OBJ_740",
+            "OBJ_741",
+            "OBJ_757",
+            "OBJ_758",
+            "OBJ_759",
+            "OBJ_760",
+            "OBJ_761",
+            "OBJ_762",
+            "OBJ_763",
+            "OBJ_764",
+            "OBJ_777",
+            "OBJ_778",
+            "OBJ_779",
+            "OBJ_780",
+            "OBJ_781"
+         );
+         name = "client_channel";
+         path = "client_channel";
+         sourceTree = "<group>";
+      };
+      "OBJ_732" = {
+         isa = "PBXFileReference";
+         path = "backup_poller.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_733" = {
+         isa = "PBXFileReference";
+         path = "channel_connectivity.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_734" = {
+         isa = "PBXFileReference";
+         path = "client_channel.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_735" = {
+         isa = "PBXFileReference";
+         path = "client_channel_factory.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_736" = {
+         isa = "PBXFileReference";
+         path = "client_channel_plugin.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_737" = {
+         isa = "PBXFileReference";
+         path = "connector.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_738" = {
+         isa = "PBXFileReference";
+         path = "http_connect_handshaker.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_739" = {
+         isa = "PBXFileReference";
+         path = "http_proxy.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_74" = {
+         isa = "PBXFileReference";
+         path = "google_api_http.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_740" = {
+         isa = "PBXFileReference";
+         path = "lb_policy.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_741" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_742",
+            "OBJ_753",
+            "OBJ_755"
+         );
+         name = "lb_policy";
+         path = "lb_policy";
+         sourceTree = "<group>";
+      };
+      "OBJ_742" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_743",
+            "OBJ_744",
+            "OBJ_745",
+            "OBJ_746",
+            "OBJ_747",
+            "OBJ_748"
+         );
+         name = "grpclb";
+         path = "grpclb";
+         sourceTree = "<group>";
+      };
+      "OBJ_743" = {
+         isa = "PBXFileReference";
+         path = "client_load_reporting_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_744" = {
+         isa = "PBXFileReference";
+         path = "grpclb.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_745" = {
+         isa = "PBXFileReference";
+         path = "grpclb_channel_secure.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_746" = {
+         isa = "PBXFileReference";
+         path = "grpclb_client_stats.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_747" = {
+         isa = "PBXFileReference";
+         path = "load_balancer_api.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_748" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_749"
+         );
+         name = "proto";
+         path = "proto";
+         sourceTree = "<group>";
+      };
+      "OBJ_749" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_750"
+         );
+         name = "grpc";
+         path = "grpc";
+         sourceTree = "<group>";
+      };
+      "OBJ_75" = {
+         isa = "PBXFileReference";
+         path = "google_protobuf_descriptor.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_750" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_751"
+         );
+         name = "lb";
+         path = "lb";
+         sourceTree = "<group>";
+      };
+      "OBJ_751" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_752"
+         );
+         name = "v1";
+         path = "v1";
+         sourceTree = "<group>";
+      };
+      "OBJ_752" = {
+         isa = "PBXFileReference";
+         path = "load_balancer.pb.c";
+         sourceTree = "<group>";
+      };
+      "OBJ_753" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_754"
+         );
+         name = "pick_first";
+         path = "pick_first";
+         sourceTree = "<group>";
+      };
+      "OBJ_754" = {
+         isa = "PBXFileReference";
+         path = "pick_first.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_755" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_756"
+         );
+         name = "round_robin";
+         path = "round_robin";
+         sourceTree = "<group>";
+      };
+      "OBJ_756" = {
+         isa = "PBXFileReference";
+         path = "round_robin.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_757" = {
+         isa = "PBXFileReference";
+         path = "lb_policy_factory.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_758" = {
+         isa = "PBXFileReference";
+         path = "lb_policy_registry.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_759" = {
+         isa = "PBXFileReference";
+         path = "method_params.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_76" = {
+         isa = "PBXFileReference";
+         path = "identity_ID.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_760" = {
+         isa = "PBXFileReference";
+         path = "parse_address.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_761" = {
+         isa = "PBXFileReference";
+         path = "proxy_mapper.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_762" = {
+         isa = "PBXFileReference";
+         path = "proxy_mapper_registry.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_763" = {
+         isa = "PBXFileReference";
+         path = "resolver.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_764" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_765",
+            "OBJ_773",
+            "OBJ_775"
+         );
+         name = "resolver";
+         path = "resolver";
+         sourceTree = "<group>";
+      };
+      "OBJ_765" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_766",
+            "OBJ_771"
+         );
+         name = "dns";
+         path = "dns";
+         sourceTree = "<group>";
+      };
+      "OBJ_766" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_767",
+            "OBJ_768",
+            "OBJ_769",
+            "OBJ_770"
+         );
+         name = "c_ares";
+         path = "c_ares";
+         sourceTree = "<group>";
+      };
+      "OBJ_767" = {
+         isa = "PBXFileReference";
+         path = "dns_resolver_ares.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_768" = {
+         isa = "PBXFileReference";
+         path = "grpc_ares_ev_driver_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_769" = {
+         isa = "PBXFileReference";
+         path = "grpc_ares_wrapper.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_77" = {
+         isa = "PBXFileReference";
+         path = "identity_IDMedia.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_770" = {
+         isa = "PBXFileReference";
+         path = "grpc_ares_wrapper_fallback.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_771" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_772"
+         );
+         name = "native";
+         path = "native";
+         sourceTree = "<group>";
+      };
+      "OBJ_772" = {
+         isa = "PBXFileReference";
+         path = "dns_resolver.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_773" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_774"
+         );
+         name = "fake";
+         path = "fake";
+         sourceTree = "<group>";
+      };
+      "OBJ_774" = {
+         isa = "PBXFileReference";
+         path = "fake_resolver.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_775" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_776"
+         );
+         name = "sockaddr";
+         path = "sockaddr";
+         sourceTree = "<group>";
+      };
+      "OBJ_776" = {
+         isa = "PBXFileReference";
+         path = "sockaddr_resolver.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_777" = {
+         isa = "PBXFileReference";
+         path = "resolver_registry.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_778" = {
+         isa = "PBXFileReference";
+         path = "retry_throttle.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_779" = {
+         isa = "PBXFileReference";
+         path = "subchannel.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_78" = {
+         isa = "PBXFileReference";
+         path = "identity_Membership.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_780" = {
+         isa = "PBXFileReference";
+         path = "subchannel_index.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_781" = {
+         isa = "PBXFileReference";
+         path = "uri_parser.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_782" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_783"
+         );
+         name = "deadline";
+         path = "deadline";
+         sourceTree = "<group>";
+      };
+      "OBJ_783" = {
+         isa = "PBXFileReference";
+         path = "deadline_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_784" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_785",
+            "OBJ_787",
+            "OBJ_788",
+            "OBJ_789",
+            "OBJ_791"
+         );
+         name = "http";
+         path = "http";
+         sourceTree = "<group>";
+      };
+      "OBJ_785" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_786"
+         );
+         name = "client";
+         path = "client";
+         sourceTree = "<group>";
+      };
+      "OBJ_786" = {
+         isa = "PBXFileReference";
+         path = "http_client_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_787" = {
+         isa = "PBXFileReference";
+         path = "client_authority_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_788" = {
+         isa = "PBXFileReference";
+         path = "http_filters_plugin.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_789" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_790"
+         );
+         name = "message_compress";
+         path = "message_compress";
+         sourceTree = "<group>";
+      };
+      "OBJ_79" = {
+         isa = "PBXFileReference";
+         path = "identity_MembershipKey.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_790" = {
+         isa = "PBXFileReference";
+         path = "message_compress_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_791" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_792"
+         );
+         name = "server";
+         path = "server";
+         sourceTree = "<group>";
+      };
+      "OBJ_792" = {
+         isa = "PBXFileReference";
+         path = "http_server_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_793" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_794",
+            "OBJ_795"
+         );
+         name = "load_reporting";
+         path = "load_reporting";
+         sourceTree = "<group>";
+      };
+      "OBJ_794" = {
+         isa = "PBXFileReference";
+         path = "server_load_reporting_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_795" = {
+         isa = "PBXFileReference";
+         path = "server_load_reporting_plugin.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_796" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_797"
+         );
+         name = "max_age";
+         path = "max_age";
+         sourceTree = "<group>";
+      };
+      "OBJ_797" = {
+         isa = "PBXFileReference";
+         path = "max_age_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_798" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_799"
+         );
+         name = "message_size";
+         path = "message_size";
+         sourceTree = "<group>";
+      };
+      "OBJ_799" = {
+         isa = "PBXFileReference";
+         path = "message_size_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_8" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_9",
+            "OBJ_10",
+            "OBJ_11",
+            "OBJ_12",
+            "OBJ_13",
+            "OBJ_14",
+            "OBJ_15",
+            "OBJ_16",
+            "OBJ_17",
+            "OBJ_18",
+            "OBJ_19",
+            "OBJ_20",
+            "OBJ_21",
+            "OBJ_22",
+            "OBJ_23",
+            "OBJ_24",
+            "OBJ_25",
+            "OBJ_26",
+            "OBJ_27",
+            "OBJ_28",
+            "OBJ_29",
+            "OBJ_30",
+            "OBJ_31",
+            "OBJ_32",
+            "OBJ_33",
+            "OBJ_34",
+            "OBJ_35",
+            "OBJ_36",
+            "OBJ_37",
+            "OBJ_38",
+            "OBJ_39",
+            "OBJ_40",
+            "OBJ_41",
+            "OBJ_42",
+            "OBJ_43",
+            "OBJ_44",
+            "OBJ_45",
+            "OBJ_46",
+            "OBJ_47",
+            "OBJ_48",
+            "OBJ_49",
+            "OBJ_50",
+            "OBJ_51",
+            "OBJ_52",
+            "OBJ_53",
+            "OBJ_54",
+            "OBJ_55",
+            "OBJ_56",
+            "OBJ_57",
+            "OBJ_58",
+            "OBJ_59",
+            "OBJ_60",
+            "OBJ_61",
+            "OBJ_62",
+            "OBJ_63",
+            "OBJ_64",
+            "OBJ_65",
+            "OBJ_66",
+            "OBJ_67",
+            "OBJ_68",
+            "OBJ_69",
+            "OBJ_70",
+            "OBJ_71",
+            "OBJ_72",
+            "OBJ_73",
+            "OBJ_74",
+            "OBJ_75",
+            "OBJ_76",
+            "OBJ_77",
+            "OBJ_78",
+            "OBJ_79",
+            "OBJ_80",
+            "OBJ_81",
+            "OBJ_82",
+            "OBJ_83",
+            "OBJ_84",
+            "OBJ_85",
+            "OBJ_86",
+            "OBJ_87",
+            "OBJ_88",
+            "OBJ_89",
+            "OBJ_90",
+            "OBJ_91",
+            "OBJ_92",
+            "OBJ_93",
+            "OBJ_94",
+            "OBJ_95",
+            "OBJ_96",
+            "OBJ_97",
+            "OBJ_98",
+            "OBJ_99",
+            "OBJ_100",
+            "OBJ_101",
+            "OBJ_102",
+            "OBJ_103",
+            "OBJ_104",
+            "OBJ_105",
+            "OBJ_106",
+            "OBJ_107",
+            "OBJ_108",
+            "OBJ_109",
+            "OBJ_110",
+            "OBJ_111",
+            "OBJ_112",
+            "OBJ_113",
+            "OBJ_114",
+            "OBJ_115",
+            "OBJ_116",
+            "OBJ_117",
+            "OBJ_118",
+            "OBJ_119",
+            "OBJ_120",
+            "OBJ_121",
+            "OBJ_122",
+            "OBJ_123",
+            "OBJ_124",
+            "OBJ_125",
+            "OBJ_126",
+            "OBJ_127",
+            "OBJ_128",
+            "OBJ_129",
+            "OBJ_130",
+            "OBJ_131",
+            "OBJ_132",
+            "OBJ_133",
+            "OBJ_134",
+            "OBJ_135",
+            "OBJ_136",
+            "OBJ_137",
+            "OBJ_138",
+            "OBJ_139",
+            "OBJ_140",
+            "OBJ_141",
+            "OBJ_142",
+            "OBJ_143",
+            "OBJ_144",
+            "OBJ_145",
+            "OBJ_146",
+            "OBJ_147",
+            "OBJ_148",
+            "OBJ_149",
+            "OBJ_150",
+            "OBJ_151",
+            "OBJ_152",
+            "OBJ_153",
+            "OBJ_154",
+            "OBJ_155",
+            "OBJ_156",
+            "OBJ_157",
+            "OBJ_158",
+            "OBJ_159",
+            "OBJ_160",
+            "OBJ_161",
+            "OBJ_162",
+            "OBJ_163",
+            "OBJ_164",
+            "OBJ_165",
+            "OBJ_166",
+            "OBJ_167",
+            "OBJ_168",
+            "OBJ_169",
+            "OBJ_170",
+            "OBJ_171",
+            "OBJ_172",
+            "OBJ_173",
+            "OBJ_174",
+            "OBJ_175",
+            "OBJ_176",
+            "OBJ_177",
+            "OBJ_178"
+         );
+         name = "OpenCannabis";
+         path = "Sources/Schema";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_80" = {
+         isa = "PBXFileReference";
+         path = "identity_StaffUser.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_800" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_801",
+            "OBJ_802"
+         );
+         name = "workarounds";
+         path = "workarounds";
+         sourceTree = "<group>";
+      };
+      "OBJ_801" = {
+         isa = "PBXFileReference";
+         path = "workaround_cronet_compression_filter.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_802" = {
+         isa = "PBXFileReference";
+         path = "workaround_utils.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_803" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_804",
+            "OBJ_845"
+         );
+         name = "transport";
+         path = "transport";
+         sourceTree = "<group>";
+      };
+      "OBJ_804" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_805",
+            "OBJ_807",
+            "OBJ_815",
+            "OBJ_822"
+         );
+         name = "chttp2";
+         path = "chttp2";
+         sourceTree = "<group>";
+      };
+      "OBJ_805" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_806"
+         );
+         name = "alpn";
+         path = "alpn";
+         sourceTree = "<group>";
+      };
+      "OBJ_806" = {
+         isa = "PBXFileReference";
+         path = "alpn.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_807" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_808",
+            "OBJ_809",
+            "OBJ_810",
+            "OBJ_813"
+         );
+         name = "client";
+         path = "client";
+         sourceTree = "<group>";
+      };
+      "OBJ_808" = {
+         isa = "PBXFileReference";
+         path = "authority.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_809" = {
+         isa = "PBXFileReference";
+         path = "chttp2_connector.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_81" = {
+         isa = "PBXFileReference";
+         path = "identity_User.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_810" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_811",
+            "OBJ_812"
+         );
+         name = "insecure";
+         path = "insecure";
+         sourceTree = "<group>";
+      };
+      "OBJ_811" = {
+         isa = "PBXFileReference";
+         path = "channel_create.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_812" = {
+         isa = "PBXFileReference";
+         path = "channel_create_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_813" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_814"
+         );
+         name = "secure";
+         path = "secure";
+         sourceTree = "<group>";
+      };
+      "OBJ_814" = {
+         isa = "PBXFileReference";
+         path = "secure_channel_create.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_815" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_816",
+            "OBJ_817",
+            "OBJ_820"
+         );
+         name = "server";
+         path = "server";
+         sourceTree = "<group>";
+      };
+      "OBJ_816" = {
+         isa = "PBXFileReference";
+         path = "chttp2_server.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_817" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_818",
+            "OBJ_819"
+         );
+         name = "insecure";
+         path = "insecure";
+         sourceTree = "<group>";
+      };
+      "OBJ_818" = {
+         isa = "PBXFileReference";
+         path = "server_chttp2.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_819" = {
+         isa = "PBXFileReference";
+         path = "server_chttp2_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_82" = {
+         isa = "PBXFileReference";
+         path = "identity_UserKey.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_820" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_821"
+         );
+         name = "secure";
+         path = "secure";
+         sourceTree = "<group>";
+      };
+      "OBJ_821" = {
+         isa = "PBXFileReference";
+         path = "server_secure_chttp2.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_822" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_823",
+            "OBJ_824",
+            "OBJ_825",
+            "OBJ_826",
+            "OBJ_827",
+            "OBJ_828",
+            "OBJ_829",
+            "OBJ_830",
+            "OBJ_831",
+            "OBJ_832",
+            "OBJ_833",
+            "OBJ_834",
+            "OBJ_835",
+            "OBJ_836",
+            "OBJ_837",
+            "OBJ_838",
+            "OBJ_839",
+            "OBJ_840",
+            "OBJ_841",
+            "OBJ_842",
+            "OBJ_843",
+            "OBJ_844"
+         );
+         name = "transport";
+         path = "transport";
+         sourceTree = "<group>";
+      };
+      "OBJ_823" = {
+         isa = "PBXFileReference";
+         path = "bin_decoder.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_824" = {
+         isa = "PBXFileReference";
+         path = "bin_encoder.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_825" = {
+         isa = "PBXFileReference";
+         path = "chttp2_plugin.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_826" = {
+         isa = "PBXFileReference";
+         path = "chttp2_transport.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_827" = {
+         isa = "PBXFileReference";
+         path = "flow_control.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_828" = {
+         isa = "PBXFileReference";
+         path = "frame_data.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_829" = {
+         isa = "PBXFileReference";
+         path = "frame_goaway.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_83" = {
+         isa = "PBXFileReference";
+         path = "identity_bioprint_Affinities.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_830" = {
+         isa = "PBXFileReference";
+         path = "frame_ping.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_831" = {
+         isa = "PBXFileReference";
+         path = "frame_rst_stream.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_832" = {
+         isa = "PBXFileReference";
+         path = "frame_settings.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_833" = {
+         isa = "PBXFileReference";
+         path = "frame_window_update.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_834" = {
+         isa = "PBXFileReference";
+         path = "hpack_encoder.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_835" = {
+         isa = "PBXFileReference";
+         path = "hpack_parser.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_836" = {
+         isa = "PBXFileReference";
+         path = "hpack_table.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_837" = {
+         isa = "PBXFileReference";
+         path = "http2_settings.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_838" = {
+         isa = "PBXFileReference";
+         path = "huffsyms.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_839" = {
+         isa = "PBXFileReference";
+         path = "incoming_metadata.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_84" = {
+         isa = "PBXFileReference";
+         path = "identity_bioprint_Aspects.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_840" = {
+         isa = "PBXFileReference";
+         path = "parsing.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_841" = {
+         isa = "PBXFileReference";
+         path = "stream_lists.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_842" = {
+         isa = "PBXFileReference";
+         path = "stream_map.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_843" = {
+         isa = "PBXFileReference";
+         path = "varint.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_844" = {
+         isa = "PBXFileReference";
+         path = "writing.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_845" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_846",
+            "OBJ_847"
+         );
+         name = "inproc";
+         path = "inproc";
+         sourceTree = "<group>";
+      };
+      "OBJ_846" = {
+         isa = "PBXFileReference";
+         path = "inproc_plugin.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_847" = {
+         isa = "PBXFileReference";
+         path = "inproc_transport.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_848" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_849",
+            "OBJ_851",
+            "OBJ_853",
+            "OBJ_864",
+            "OBJ_871",
+            "OBJ_875",
+            "OBJ_911",
+            "OBJ_914",
+            "OBJ_919",
+            "OBJ_1003",
+            "OBJ_1008",
+            "OBJ_1011",
+            "OBJ_1057",
+            "OBJ_1064",
+            "OBJ_1085"
+         );
+         name = "lib";
+         path = "lib";
+         sourceTree = "<group>";
+      };
+      "OBJ_849" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_850"
+         );
+         name = "avl";
+         path = "avl";
+         sourceTree = "<group>";
+      };
+      "OBJ_85" = {
+         isa = "PBXFileReference";
+         path = "identity_bioprint_Bioprint.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_850" = {
+         isa = "PBXFileReference";
+         path = "avl.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_851" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_852"
+         );
+         name = "backoff";
+         path = "backoff";
+         sourceTree = "<group>";
+      };
+      "OBJ_852" = {
+         isa = "PBXFileReference";
+         path = "backoff.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_853" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_854",
+            "OBJ_855",
+            "OBJ_856",
+            "OBJ_857",
+            "OBJ_858",
+            "OBJ_859",
+            "OBJ_860",
+            "OBJ_861",
+            "OBJ_862",
+            "OBJ_863"
+         );
+         name = "channel";
+         path = "channel";
+         sourceTree = "<group>";
+      };
+      "OBJ_854" = {
+         isa = "PBXFileReference";
+         path = "channel_args.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_855" = {
+         isa = "PBXFileReference";
+         path = "channel_stack.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_856" = {
+         isa = "PBXFileReference";
+         path = "channel_stack_builder.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_857" = {
+         isa = "PBXFileReference";
+         path = "channel_trace.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_858" = {
+         isa = "PBXFileReference";
+         path = "channel_trace_registry.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_859" = {
+         isa = "PBXFileReference";
+         path = "connected_channel.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_86" = {
+         isa = "PBXFileReference";
+         path = "identity_bioprint_Weights.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_860" = {
+         isa = "PBXFileReference";
+         path = "handshaker.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_861" = {
+         isa = "PBXFileReference";
+         path = "handshaker_factory.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_862" = {
+         isa = "PBXFileReference";
+         path = "handshaker_registry.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_863" = {
+         isa = "PBXFileReference";
+         path = "status_util.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_864" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_865",
+            "OBJ_866",
+            "OBJ_867",
+            "OBJ_868",
+            "OBJ_869",
+            "OBJ_870"
+         );
+         name = "compression";
+         path = "compression";
+         sourceTree = "<group>";
+      };
+      "OBJ_865" = {
+         isa = "PBXFileReference";
+         path = "compression.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_866" = {
+         isa = "PBXFileReference";
+         path = "compression_internal.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_867" = {
+         isa = "PBXFileReference";
+         path = "message_compress.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_868" = {
+         isa = "PBXFileReference";
+         path = "stream_compression.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_869" = {
+         isa = "PBXFileReference";
+         path = "stream_compression_gzip.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_87" = {
+         isa = "PBXFileReference";
+         path = "identity_ids_Passport.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_870" = {
+         isa = "PBXFileReference";
+         path = "stream_compression_identity.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_871" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_872",
+            "OBJ_873",
+            "OBJ_874"
+         );
+         name = "debug";
+         path = "debug";
+         sourceTree = "<group>";
+      };
+      "OBJ_872" = {
+         isa = "PBXFileReference";
+         path = "stats.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_873" = {
+         isa = "PBXFileReference";
+         path = "stats_data.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_874" = {
+         isa = "PBXFileReference";
+         path = "trace.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_875" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_876",
+            "OBJ_877",
+            "OBJ_878",
+            "OBJ_879",
+            "OBJ_880",
+            "OBJ_881",
+            "OBJ_882",
+            "OBJ_883",
+            "OBJ_884",
+            "OBJ_885",
+            "OBJ_886",
+            "OBJ_887",
+            "OBJ_888",
+            "OBJ_889",
+            "OBJ_890",
+            "OBJ_891",
+            "OBJ_892",
+            "OBJ_893",
+            "OBJ_894",
+            "OBJ_895",
+            "OBJ_896",
+            "OBJ_897",
+            "OBJ_898",
+            "OBJ_899",
+            "OBJ_900",
+            "OBJ_901",
+            "OBJ_902",
+            "OBJ_903",
+            "OBJ_904",
+            "OBJ_905",
+            "OBJ_906",
+            "OBJ_907",
+            "OBJ_908",
+            "OBJ_909",
+            "OBJ_910"
+         );
+         name = "gpr";
+         path = "gpr";
+         sourceTree = "<group>";
+      };
+      "OBJ_876" = {
+         isa = "PBXFileReference";
+         path = "alloc.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_877" = {
+         isa = "PBXFileReference";
+         path = "arena.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_878" = {
+         isa = "PBXFileReference";
+         path = "atm.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_879" = {
+         isa = "PBXFileReference";
+         path = "cpu_iphone.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_88" = {
+         isa = "PBXFileReference";
+         path = "identity_ids_USDL.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_880" = {
+         isa = "PBXFileReference";
+         path = "cpu_linux.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_881" = {
+         isa = "PBXFileReference";
+         path = "cpu_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_882" = {
+         isa = "PBXFileReference";
+         path = "cpu_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_883" = {
+         isa = "PBXFileReference";
+         path = "env_linux.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_884" = {
+         isa = "PBXFileReference";
+         path = "env_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_885" = {
+         isa = "PBXFileReference";
+         path = "env_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_886" = {
+         isa = "PBXFileReference";
+         path = "fork.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_887" = {
+         isa = "PBXFileReference";
+         path = "host_port.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_888" = {
+         isa = "PBXFileReference";
+         path = "log.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_889" = {
+         isa = "PBXFileReference";
+         path = "log_android.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_89" = {
+         isa = "PBXFileReference";
+         path = "identity_ids_UserDoctorRec.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_890" = {
+         isa = "PBXFileReference";
+         path = "log_linux.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_891" = {
+         isa = "PBXFileReference";
+         path = "log_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_892" = {
+         isa = "PBXFileReference";
+         path = "log_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_893" = {
+         isa = "PBXFileReference";
+         path = "mpscq.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_894" = {
+         isa = "PBXFileReference";
+         path = "murmur_hash.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_895" = {
+         isa = "PBXFileReference";
+         path = "string.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_896" = {
+         isa = "PBXFileReference";
+         path = "string_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_897" = {
+         isa = "PBXFileReference";
+         path = "string_util_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_898" = {
+         isa = "PBXFileReference";
+         path = "string_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_899" = {
+         isa = "PBXFileReference";
+         path = "sync.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_9" = {
+         isa = "PBXFileReference";
+         path = "accounting_Taxes.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_90" = {
+         isa = "PBXFileReference";
+         path = "identity_industry_DashboardStaffSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_900" = {
+         isa = "PBXFileReference";
+         path = "sync_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_901" = {
+         isa = "PBXFileReference";
+         path = "sync_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_902" = {
+         isa = "PBXFileReference";
+         path = "time.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_903" = {
+         isa = "PBXFileReference";
+         path = "time_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_904" = {
+         isa = "PBXFileReference";
+         path = "time_precise.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_905" = {
+         isa = "PBXFileReference";
+         path = "time_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_906" = {
+         isa = "PBXFileReference";
+         path = "tls_pthread.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_907" = {
+         isa = "PBXFileReference";
+         path = "tmpfile_msys.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_908" = {
+         isa = "PBXFileReference";
+         path = "tmpfile_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_909" = {
+         isa = "PBXFileReference";
+         path = "tmpfile_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_91" = {
+         isa = "PBXFileReference";
+         path = "identity_industry_POSStaffSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_910" = {
+         isa = "PBXFileReference";
+         path = "wrap_memcpy.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_911" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_912",
+            "OBJ_913"
+         );
+         name = "gprpp";
+         path = "gprpp";
+         sourceTree = "<group>";
+      };
+      "OBJ_912" = {
+         isa = "PBXFileReference";
+         path = "thd_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_913" = {
+         isa = "PBXFileReference";
+         path = "thd_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_914" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_915",
+            "OBJ_916",
+            "OBJ_917",
+            "OBJ_918"
+         );
+         name = "http";
+         path = "http";
+         sourceTree = "<group>";
+      };
+      "OBJ_915" = {
+         isa = "PBXFileReference";
+         path = "format_request.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_916" = {
+         isa = "PBXFileReference";
+         path = "httpcli.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_917" = {
+         isa = "PBXFileReference";
+         path = "httpcli_security_connector.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_918" = {
+         isa = "PBXFileReference";
+         path = "parser.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_919" = {
+         isa = "PBXGroup";
+         children = (
+            "OBJ_920",
+            "OBJ_921",
+            "OBJ_922",
+            "OBJ_923",
+            "OBJ_924",
+            "OBJ_925",
+            "OBJ_926",
+            "OBJ_927",
+            "OBJ_928",
+            "OBJ_929",
+            "OBJ_930",
+            "OBJ_931",
+            "OBJ_932",
+            "OBJ_933",
+            "OBJ_934",
+            "OBJ_935",
+            "OBJ_936",
+            "OBJ_937",
+            "OBJ_938",
+            "OBJ_939",
+            "OBJ_940",
+            "OBJ_941",
+            "OBJ_942",
+            "OBJ_943",
+            "OBJ_944",
+            "OBJ_945",
+            "OBJ_946",
+            "OBJ_947",
+            "OBJ_948",
+            "OBJ_949",
+            "OBJ_950",
+            "OBJ_951",
+            "OBJ_952",
+            "OBJ_953",
+            "OBJ_954",
+            "OBJ_955",
+            "OBJ_956",
+            "OBJ_957",
+            "OBJ_958",
+            "OBJ_959",
+            "OBJ_960",
+            "OBJ_961",
+            "OBJ_962",
+            "OBJ_963",
+            "OBJ_964",
+            "OBJ_965",
+            "OBJ_966",
+            "OBJ_967",
+            "OBJ_968",
+            "OBJ_969",
+            "OBJ_970",
+            "OBJ_971",
+            "OBJ_972",
+            "OBJ_973",
+            "OBJ_974",
+            "OBJ_975",
+            "OBJ_976",
+            "OBJ_977",
+            "OBJ_978",
+            "OBJ_979",
+            "OBJ_980",
+            "OBJ_981",
+            "OBJ_982",
+            "OBJ_983",
+            "OBJ_984",
+            "OBJ_985",
+            "OBJ_986",
+            "OBJ_987",
+            "OBJ_988",
+            "OBJ_989",
+            "OBJ_990",
+            "OBJ_991",
+            "OBJ_992",
+            "OBJ_993",
+            "OBJ_994",
+            "OBJ_995",
+            "OBJ_996",
+            "OBJ_997",
+            "OBJ_998",
+            "OBJ_999",
+            "OBJ_1000",
+            "OBJ_1001",
+            "OBJ_1002"
+         );
+         name = "iomgr";
+         path = "iomgr";
+         sourceTree = "<group>";
+      };
+      "OBJ_92" = {
+         isa = "PBXFileReference";
+         path = "identity_industry_StaffSettings.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_920" = {
+         isa = "PBXFileReference";
+         path = "call_combiner.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_921" = {
+         isa = "PBXFileReference";
+         path = "combiner.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_922" = {
+         isa = "PBXFileReference";
+         path = "endpoint.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_923" = {
+         isa = "PBXFileReference";
+         path = "endpoint_pair_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_924" = {
+         isa = "PBXFileReference";
+         path = "endpoint_pair_uv.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_925" = {
+         isa = "PBXFileReference";
+         path = "endpoint_pair_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_926" = {
+         isa = "PBXFileReference";
+         path = "error.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_927" = {
+         isa = "PBXFileReference";
+         path = "ev_epoll1_linux.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_928" = {
+         isa = "PBXFileReference";
+         path = "ev_epollex_linux.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_929" = {
+         isa = "PBXFileReference";
+         path = "ev_epollsig_linux.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_93" = {
+         isa = "PBXFileReference";
+         path = "identity_pass_Pass.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_930" = {
+         isa = "PBXFileReference";
+         path = "ev_poll_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_931" = {
+         isa = "PBXFileReference";
+         path = "ev_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_932" = {
+         isa = "PBXFileReference";
+         path = "ev_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_933" = {
+         isa = "PBXFileReference";
+         path = "exec_ctx.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_934" = {
+         isa = "PBXFileReference";
+         path = "executor.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_935" = {
+         isa = "PBXFileReference";
+         path = "fork_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_936" = {
+         isa = "PBXFileReference";
+         path = "fork_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_937" = {
+         isa = "PBXFileReference";
+         path = "gethostname_fallback.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_938" = {
+         isa = "PBXFileReference";
+         path = "gethostname_host_name_max.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_939" = {
+         isa = "PBXFileReference";
+         path = "gethostname_sysconf.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_94" = {
+         isa = "PBXFileReference";
+         path = "identity_pass_PassKey.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_940" = {
+         isa = "PBXFileReference";
+         path = "iocp_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_941" = {
+         isa = "PBXFileReference";
+         path = "iomgr.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_942" = {
+         isa = "PBXFileReference";
+         path = "iomgr_custom.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_943" = {
+         isa = "PBXFileReference";
+         path = "iomgr_internal.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_944" = {
+         isa = "PBXFileReference";
+         path = "iomgr_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_945" = {
+         isa = "PBXFileReference";
+         path = "iomgr_uv.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_946" = {
+         isa = "PBXFileReference";
+         path = "iomgr_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_947" = {
+         isa = "PBXFileReference";
+         path = "is_epollexclusive_available.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_948" = {
+         isa = "PBXFileReference";
+         path = "load_file.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_949" = {
+         isa = "PBXFileReference";
+         path = "lockfree_event.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_95" = {
+         isa = "PBXFileReference";
+         path = "identity_v1beta1_IdentityService_Beta1.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_950" = {
+         isa = "PBXFileReference";
+         path = "network_status_tracker.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_951" = {
+         isa = "PBXFileReference";
+         path = "polling_entity.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_952" = {
+         isa = "PBXFileReference";
+         path = "pollset.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_953" = {
+         isa = "PBXFileReference";
+         path = "pollset_custom.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_954" = {
+         isa = "PBXFileReference";
+         path = "pollset_set.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_955" = {
+         isa = "PBXFileReference";
+         path = "pollset_set_custom.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_956" = {
+         isa = "PBXFileReference";
+         path = "pollset_set_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_957" = {
+         isa = "PBXFileReference";
+         path = "pollset_uv.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_958" = {
+         isa = "PBXFileReference";
+         path = "pollset_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_959" = {
+         isa = "PBXFileReference";
+         path = "resolve_address.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_96" = {
+         isa = "PBXFileReference";
+         path = "inventory_InventoryLocation.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_960" = {
+         isa = "PBXFileReference";
+         path = "resolve_address_custom.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_961" = {
+         isa = "PBXFileReference";
+         path = "resolve_address_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_962" = {
+         isa = "PBXFileReference";
+         path = "resolve_address_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_963" = {
+         isa = "PBXFileReference";
+         path = "resource_quota.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_964" = {
+         isa = "PBXFileReference";
+         path = "sockaddr_utils.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_965" = {
+         isa = "PBXFileReference";
+         path = "socket_factory_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_966" = {
+         isa = "PBXFileReference";
+         path = "socket_mutator.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_967" = {
+         isa = "PBXFileReference";
+         path = "socket_utils_common_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_968" = {
+         isa = "PBXFileReference";
+         path = "socket_utils_linux.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_969" = {
+         isa = "PBXFileReference";
+         path = "socket_utils_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_97" = {
+         isa = "PBXFileReference";
+         path = "inventory_InventoryProduct.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_970" = {
+         isa = "PBXFileReference";
+         path = "socket_utils_uv.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_971" = {
+         isa = "PBXFileReference";
+         path = "socket_utils_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_972" = {
+         isa = "PBXFileReference";
+         path = "socket_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_973" = {
+         isa = "PBXFileReference";
+         path = "tcp_client.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_974" = {
+         isa = "PBXFileReference";
+         path = "tcp_client_custom.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_975" = {
+         isa = "PBXFileReference";
+         path = "tcp_client_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_976" = {
+         isa = "PBXFileReference";
+         path = "tcp_client_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_977" = {
+         isa = "PBXFileReference";
+         path = "tcp_custom.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_978" = {
+         isa = "PBXFileReference";
+         path = "tcp_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_979" = {
+         isa = "PBXFileReference";
+         path = "tcp_server.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_98" = {
+         isa = "PBXFileReference";
+         path = "ledger_Account.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_980" = {
+         isa = "PBXFileReference";
+         path = "tcp_server_custom.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_981" = {
+         isa = "PBXFileReference";
+         path = "tcp_server_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_982" = {
+         isa = "PBXFileReference";
+         path = "tcp_server_utils_posix_common.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_983" = {
+         isa = "PBXFileReference";
+         path = "tcp_server_utils_posix_ifaddrs.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_984" = {
+         isa = "PBXFileReference";
+         path = "tcp_server_utils_posix_noifaddrs.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_985" = {
+         isa = "PBXFileReference";
+         path = "tcp_server_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_986" = {
+         isa = "PBXFileReference";
+         path = "tcp_uv.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_987" = {
+         isa = "PBXFileReference";
+         path = "tcp_windows.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_988" = {
+         isa = "PBXFileReference";
+         path = "time_averaged_stats.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_989" = {
+         isa = "PBXFileReference";
+         path = "timer.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_99" = {
+         isa = "PBXFileReference";
+         path = "ledger_Asset.pb.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_990" = {
+         isa = "PBXFileReference";
+         path = "timer_custom.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_991" = {
+         isa = "PBXFileReference";
+         path = "timer_generic.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_992" = {
+         isa = "PBXFileReference";
+         path = "timer_heap.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_993" = {
+         isa = "PBXFileReference";
+         path = "timer_manager.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_994" = {
+         isa = "PBXFileReference";
+         path = "timer_uv.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_995" = {
+         isa = "PBXFileReference";
+         path = "udp_server.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_996" = {
+         isa = "PBXFileReference";
+         path = "unix_sockets_posix.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_997" = {
+         isa = "PBXFileReference";
+         path = "unix_sockets_posix_noop.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_998" = {
+         isa = "PBXFileReference";
+         path = "wakeup_fd_cv.cc";
+         sourceTree = "<group>";
+      };
+      "OBJ_999" = {
+         isa = "PBXFileReference";
+         path = "wakeup_fd_eventfd.cc";
+         sourceTree = "<group>";
+      };
+      "SwiftGRPC::BoringSSL" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1386";
+         buildPhases = (
+            "OBJ_1389",
+            "OBJ_1704"
+         );
+         dependencies = (
+         );
+         name = "BoringSSL";
+         productName = "BoringSSL";
+         productReference = "SwiftGRPC::BoringSSL::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftGRPC::BoringSSL::Product" = {
+         isa = "PBXFileReference";
+         path = "BoringSSL.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SwiftGRPC::CgRPC" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_1705";
+         buildPhases = (
+            "OBJ_1708",
+            "OBJ_2063"
+         );
+         dependencies = (
+            "OBJ_2065"
+         );
+         name = "CgRPC";
+         productName = "CgRPC";
+         productReference = "SwiftGRPC::CgRPC::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftGRPC::CgRPC::Product" = {
+         isa = "PBXFileReference";
+         path = "CgRPC.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SwiftGRPC::SwiftGRPC" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_2291";
+         buildPhases = (
+            "OBJ_2294",
+            "OBJ_2327"
+         );
+         dependencies = (
+            "OBJ_2331",
+            "OBJ_2332",
+            "OBJ_2333"
+         );
+         name = "SwiftGRPC";
+         productName = "SwiftGRPC";
+         productReference = "SwiftGRPC::SwiftGRPC::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftGRPC::SwiftGRPC::Product" = {
+         isa = "PBXFileReference";
+         path = "SwiftGRPC.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+      "SwiftGRPC::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_2335";
+         buildPhases = (
+            "OBJ_2338"
+         );
+         dependencies = (
+         );
+         name = "SwiftGRPCPackageDescription";
+         productName = "SwiftGRPCPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftProtobuf::SwiftPMPackageDescription" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_2422";
+         buildPhases = (
+            "OBJ_2425"
+         );
+         dependencies = (
+         );
+         name = "SwiftProtobufPackageDescription";
+         productName = "SwiftProtobufPackageDescription";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftProtobuf::SwiftProtobuf" = {
+         isa = "PBXNativeTarget";
+         buildConfigurationList = "OBJ_2340";
+         buildPhases = (
+            "OBJ_2343",
+            "OBJ_2420"
+         );
+         dependencies = (
+         );
+         name = "SwiftProtobuf";
+         productName = "SwiftProtobuf";
+         productReference = "SwiftProtobuf::SwiftProtobuf::Product";
+         productType = "com.apple.product-type.framework";
+      };
+      "SwiftProtobuf::SwiftProtobuf::Product" = {
+         isa = "PBXFileReference";
+         path = "SwiftProtobuf.framework";
+         sourceTree = "BUILT_PRODUCTS_DIR";
+      };
+   };
+   rootObject = "OBJ_1";
 }

--- a/Bloombox.xcodeproj/xcshareddata/xcschemes/Bloombox-Package.xcscheme
+++ b/Bloombox.xcodeproj/xcshareddata/xcschemes/Bloombox-Package.xcscheme
@@ -14,20 +14,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Bloombox::Bloombox"
-               BuildableName = "Bloombox.framework"
-               BlueprintName = "Bloombox"
-               ReferencedContainer = "container:Bloombox.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "Bloombox::OpenCannabis"
                BuildableName = "OpenCannabis.framework"
                BlueprintName = "OpenCannabis"
@@ -48,6 +34,20 @@
                ReferencedContainer = "container:Bloombox.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Bloombox::Bloombox"
+               BuildableName = "Bloombox.framework"
+               BlueprintName = "Bloombox"
+               ReferencedContainer = "container:Bloombox.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -60,9 +60,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Bloombox::ClientTests"
-               BuildableName = "ClientTests.xctest"
-               BlueprintName = "ClientTests"
+               BlueprintIdentifier = "Bloombox::SchemaTests"
+               BuildableName = "SchemaTests.xctest"
+               BlueprintName = "SchemaTests"
                ReferencedContainer = "container:Bloombox.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -70,9 +70,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Bloombox::SchemaTests"
-               BuildableName = "SchemaTests.xctest"
-               BlueprintName = "SchemaTests"
+               BlueprintIdentifier = "Bloombox::ClientTests"
+               BuildableName = "ClientTests.xctest"
+               BlueprintName = "ClientTests"
                ReferencedContainer = "container:Bloombox.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -93,9 +93,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "Bloombox::Bloombox"
-            BuildableName = "Bloombox.framework"
-            BlueprintName = "Bloombox"
+            BlueprintIdentifier = "Bloombox::OpenCannabis"
+            BuildableName = "OpenCannabis.framework"
+            BlueprintName = "OpenCannabis"
             ReferencedContainer = "container:Bloombox.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/BloomboxServices.podspec
+++ b/BloomboxServices.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "BloomboxServices"
   s.swift_version = "4.2"
-  s.version       = "0.1.10"
+  s.version       = "0.2.0"
   s.summary       = "Service definitions for Bloombox Cloud APIs"
   s.description   = <<-DESC
 Compiled low-level service definitions for Bloombox Cloud APIs. Usually usable with
@@ -31,7 +31,7 @@ the Bloombox client library for Swift.
   s.source_files = 'Sources/Services/*.swift'
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.dependency 'OpenCannabis', '~> 0.1.10'
+  s.dependency 'OpenCannabis', '~> 0.2.0'
   s.dependency 'SwiftProtobuf'
   s.dependency 'SwiftGRPC'
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 
 SCHEMA ?= Schema/
-VERSION ?= 0.1.10
+VERSION ?= 0.2.0
 SCHEMA_BRANCH ?= master
 SWIFT_GRPC ?= SwiftGRPC
 

--- a/OpenCannabis.podspec
+++ b/OpenCannabis.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "OpenCannabis"
   s.swift_version = "4.2"
-  s.version       = "0.1.10"
+  s.version       = "0.2.0"
   s.summary       = "OpenCannabis for Swift"
   s.description   = <<-DESC
 Native Swift codegen and bindings for OpenCannabis

--- a/Sources/Client/Transport.swift
+++ b/Sources/Client/Transport.swift
@@ -130,12 +130,17 @@ internal enum TransportEnvironment {
   }
 }
 
+
+/// Global specifying the main API hostname.
+internal let apiHostname = "rpc.bloombox.cloud"
+
+
 /// Production identity service settings.
 internal struct ProductionIdentity: RPCServiceSettings {
     let secure = true
-    let host = "api.bloombox.cloud"
+    let host = apiHostname
     let port = 443
-    let hostname: String? = "api.bloombox.cloud"
+    let hostname: String? = apiHostname
     let chain: String? = authorityChain
     let cert: String? = nil
     let key: String? = nil
@@ -144,9 +149,9 @@ internal struct ProductionIdentity: RPCServiceSettings {
 /// Production devices service settings.
 internal struct ProductionDevices: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = apiHostname
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = apiHostname
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -155,9 +160,9 @@ internal struct ProductionDevices: RPCServiceSettings {
 /// Production shop settings.
 internal struct ProductionShop: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = apiHostname
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = apiHostname
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -166,9 +171,9 @@ internal struct ProductionShop: RPCServiceSettings {
 /// Production telemetry settings.
 internal struct ProductionTelemetry: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = apiHostname
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = apiHostname
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -177,9 +182,9 @@ internal struct ProductionTelemetry: RPCServiceSettings {
 /// Production media settings.
 internal struct ProductionMedia: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = apiHostname
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = apiHostname
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -188,9 +193,9 @@ internal struct ProductionMedia: RPCServiceSettings {
 /// Production menu settings.
 internal struct ProductionMenu: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = apiHostname
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = apiHostname
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -199,9 +204,9 @@ internal struct ProductionMenu: RPCServiceSettings {
 /// Production POS settings.
 internal struct ProductionPOS: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = apiHostname
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = apiHostname
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -210,9 +215,9 @@ internal struct ProductionPOS: RPCServiceSettings {
 /// Production auth settings.
 internal struct ProductionAuth: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = apiHostname
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = apiHostname
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -221,9 +226,9 @@ internal struct ProductionAuth: RPCServiceSettings {
 /// Production checkin settings.
 internal struct ProductionCheckin: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = apiHostname
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = apiHostname
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -232,9 +237,9 @@ internal struct ProductionCheckin: RPCServiceSettings {
 /// Production platform API settings.
 internal struct ProductionPlatform: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = apiHostname
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = apiHostname
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil

--- a/Tests/ClientTests/ClientTests.swift
+++ b/Tests/ClientTests/ClientTests.swift
@@ -8,8 +8,8 @@
 import XCTest
 @testable import Bloombox
 
-let testPartner = "caliva"
-let testLocation = "sjc"
+let testPartner = "abatin"
+let testLocation = "sacramento"
 let testAccount = "sam@bloombox.io"
 let testApiKey = "AIzaSyBC4ZQVM3JnnS4P-wu6MHKi5oc0NcEuWxE"
 let testOrigin = "abatin.menu:443"

--- a/Tests/ClientTests/ClientTests.swift
+++ b/Tests/ClientTests/ClientTests.swift
@@ -8,8 +8,8 @@
 import XCTest
 @testable import Bloombox
 
-let testPartner = "abatin"
-let testLocation = "sacramento"
+let testPartner = "caliva"
+let testLocation = "sjc"
 let testAccount = "sam@bloombox.io"
 let testApiKey = "AIzaSyBC4ZQVM3JnnS4P-wu6MHKi5oc0NcEuWxE"
 let testOrigin = "abatin.menu:443"

--- a/Tests/ClientTests/PlatformClientTests.swift
+++ b/Tests/ClientTests/PlatformClientTests.swift
@@ -76,8 +76,8 @@ internal final class PlatformClientTests: XCTestCase {
 
   func testResolveDomainKnownValid() throws {
     let manifest = try ClientTools.client.platform.resolve(domain: testOrigin)
-    XCTAssertEqual(manifest.partner, testPartner, "should be able to resolve known-good domain partner")
-    XCTAssertEqual(manifest.location, testLocation, "should be able to resolve known-good domain location")
+    XCTAssertEqual(manifest.partner, "abatin", "should be able to resolve known-good domain partner")
+    XCTAssertEqual(manifest.location, "sacramento", "should be able to resolve known-good domain location")
   }
 
   func testResolveDomainKnownValidAsync() throws {
@@ -85,8 +85,8 @@ internal final class PlatformClientTests: XCTestCase {
 
     try ClientTools.client.platform.resolve(domain: testOrigin) { (result, response) in
       XCTAssertNotNil(response, "should get response for valid domain resolve")
-      XCTAssertEqual(response?.partner, testPartner, "partner resolved for test origin should match")
-      XCTAssertEqual(response?.location, testLocation, "location resolved for test origin should match")
+      XCTAssertEqual(response?.partner, "abatin", "partner resolved for test origin should match")
+      XCTAssertEqual(response?.location, "sacramento", "location resolved for test origin should match")
       expectation.fulfill()
     }
 

--- a/Tests/ClientTests/PlatformClientTests.swift
+++ b/Tests/ClientTests/PlatformClientTests.swift
@@ -155,8 +155,12 @@ internal final class PlatformClientTests: XCTestCase {
   }
 
   func testDomainInfoKnownValid() throws {
-    let domains = try ClientTools.client.platform.domains()
-    XCTAssertNotNil(domains.menu)
+    do {
+      let domains = try ClientTools.client.platform.domains()
+      XCTAssertNotNil(domains.menu)
+    } catch {
+      XCTAssertTrue(false, "got error: \(error)")
+    }
   }
 
   func testDomainInfoKnownValidAsync() throws {

--- a/Tests/ClientTests/ShopClientTests.swift
+++ b/Tests/ClientTests/ShopClientTests.swift
@@ -194,7 +194,10 @@ internal final class ShopClientTests: XCTestCase {
     let expectation = XCTestExpectation(description: "Fetch member verification: known bad")
 
     try client.shop.verifyMember(email: "does-not-exist@nosuchdomain.com") { result, resp in
-      assert(!resp!.verified, "invalid customer should not verify")
+      assert(resp != nil, "should get a response no matter what")
+      if resp != nil {
+        assert(!resp!.verified, "invalid customer should not verify")
+      }
       expectation.fulfill()
     }
 
@@ -284,8 +287,8 @@ internal final class ShopClientTests: XCTestCase {
 
     try ClientTools.client.shop.getOrder(id: "abc123") { result, response in
       XCTAssertNotNil(response, "should get a response when fetching an order")
-      XCTAssertTrue(response!.success, "get-order for known order should be successful")
-      XCTAssertTrue(response!.hasOrder, "get-order should contain order data")
+      XCTAssertTrue(response?.success ?? false, "get-order for known order should be successful")
+      XCTAssertTrue(response?.hasOrder ?? false, "get-order should contain order data")
       expectation.fulfill()
     }
 

--- a/Tests/ClientTests/ShopClientTests.swift
+++ b/Tests/ClientTests/ShopClientTests.swift
@@ -248,14 +248,22 @@ internal final class ShopClientTests: XCTestCase {
   }
 
   func testZipcheckKnownEligible() throws {
-    let result = try ClientTools.client.shop.checkZipcode(zipcode: testZipcode)
+    let result = try ClientTools.client.shop.checkZipcode(
+      zipcode: testZipcode,
+      partner: "caliva",
+      location: "sjc",
+      apiKey: nil)
     XCTAssertTrue(result.supported, "known-eligible zipcode should report 'supported' as true")
   }
 
   func testZipcheckKnownEligibleAsync() throws {
     let expectation = XCTestExpectation(description: "Check known-eligible zipcode")
 
-    try ClientTools.client.shop.checkZipcode(zipcode: testZipcode) { result, response in
+    try ClientTools.client.shop.checkZipcode(
+      zipcode: testZipcode,
+      partner: "caliva",
+      location: "sjc",
+      apiKey: nil) { result, response in
       XCTAssertNotNil(response, "response should not be nil for supported zipcode")
       XCTAssertTrue(response?.supported ?? false, "known-eligible zipcode should report 'supported' as true")
       expectation.fulfill()
@@ -265,13 +273,21 @@ internal final class ShopClientTests: XCTestCase {
   }
 
   func testZipcheckKnownMinimum() throws {
-    let result = try ClientTools.client.shop.checkZipcode(zipcode: testZipcode)
+    let result = try ClientTools.client.shop.checkZipcode(
+      zipcode: testZipcode,
+      partner: "caliva",
+      location: "sjc",
+      apiKey: nil)
     XCTAssertTrue(result.supported, "known-eligible zipcode should report 'supported' as true")
     XCTAssertEqual(result.deliveryMinimum, 50.0, "known-delivery-minimum should match")
   }
 
   func testZipcheckKnownIneligible() throws {
-    let result = try ClientTools.client.shop.checkZipcode(zipcode: "12345")
+    let result = try ClientTools.client.shop.checkZipcode(
+      zipcode: "12345",
+      partner: "caliva",
+      location: "sjc",
+      apiKey: nil)
     XCTAssertFalse(result.supported, "should indicate unsupported zipcode is unsupported")
   }
 


### PR DESCRIPTION
This changeset introduces the new server framework to Bloombox for Swift. About 10% of tests don't yet pass against this new server.

Changes so far:
- [x] Update API endpoint to new value (`rpc.bloombox.cloud`)
- [x] Note failed tests
  - [x] File issues for failed tests
  - [x] Fix failed tests
    - [x] Domain info implementation
    - [x] Zipcheck issues (Bloombox/GOALPOST#12)
    - [x] Order retrieve issues (Bloombox/GOALPOST#13)
    - [x] Member verify issues (Bloombox/GOALPOST#11)