### PR TITLE
Fix: RPC Target

### DIFF
--- a/Bloombox.podspec
+++ b/Bloombox.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "Bloombox"
   s.swift_version = "4.2"
-  s.version       = "0.2.0-beta2"
+  s.version       = "0.2.0-beta3"
   s.summary       = "Client for Bloombox Cloud APIs"
   s.description   = <<-DESC
 Native Swift client for accessing Bloombox Cloud APIs
@@ -30,8 +30,8 @@ Native Swift client for accessing Bloombox Cloud APIs
   s.source_files = 'Sources/Client/*.swift'
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.dependency 'OpenCannabis', '= 0.2.0-beta2'
-  s.dependency 'BloomboxServices', '= 0.2.0-beta2'
+  s.dependency 'OpenCannabis', '= 0.2.0-beta3'
+  s.dependency 'BloomboxServices', '= 0.2.0-beta3'
   s.dependency 'SwiftProtobuf', '~> 1.5.0'
   s.dependency 'SwiftGRPC', '~> 0.9.0'
 

--- a/BloomboxServices.podspec
+++ b/BloomboxServices.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "BloomboxServices"
   s.swift_version = "4.2"
-  s.version       = "0.2.0-beta2"
+  s.version       = "0.2.0-beta3"
   s.summary       = "Service definitions for Bloombox Cloud APIs"
   s.description   = <<-DESC
 Compiled low-level service definitions for Bloombox Cloud APIs. Usually usable with
@@ -31,7 +31,7 @@ the Bloombox client library for Swift.
   s.source_files = 'Sources/Services/*.swift'
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.dependency 'OpenCannabis', '= 0.2.0-beta2'
+  s.dependency 'OpenCannabis', '= 0.2.0-beta3'
   s.dependency 'SwiftProtobuf', '~> 1.5.0'
   s.dependency 'SwiftGRPC', '~> 0.9.0'
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 
 SCHEMA ?= Schema/
-VERSION ?= 0.2.0-beta2
+VERSION ?= 0.2.0-beta3
 SCHEMA_BRANCH ?= master
 SWIFT_GRPC ?= SwiftGRPC
 

--- a/OpenCannabis.podspec
+++ b/OpenCannabis.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "OpenCannabis"
   s.swift_version = "4.2"
-  s.version       = "0.2.0-beta2"
+  s.version       = "0.2.0-beta3"
   s.summary       = "OpenCannabis for Swift"
   s.description   = <<-DESC
 Native Swift codegen and bindings for OpenCannabis

--- a/Sources/Client/Transport.swift
+++ b/Sources/Client/Transport.swift
@@ -133,9 +133,9 @@ internal enum TransportEnvironment {
 /// Production identity service settings.
 internal struct ProductionIdentity: RPCServiceSettings {
     let secure = true
-    let host = "api.bloombox.cloud"
+    let host = "rpc.bloombox.cloud"
     let port = 443
-    let hostname: String? = "api.bloombox.cloud"
+    let hostname: String? = "rpc.bloombox.cloud"
     let chain: String? = authorityChain
     let cert: String? = nil
     let key: String? = nil
@@ -144,9 +144,9 @@ internal struct ProductionIdentity: RPCServiceSettings {
 /// Production devices service settings.
 internal struct ProductionDevices: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = "rpc.bloombox.cloud"
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = "rpc.bloombox.cloud"
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -155,9 +155,9 @@ internal struct ProductionDevices: RPCServiceSettings {
 /// Production shop settings.
 internal struct ProductionShop: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = "rpc.bloombox.cloud"
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = "rpc.bloombox.cloud"
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -166,9 +166,9 @@ internal struct ProductionShop: RPCServiceSettings {
 /// Production telemetry settings.
 internal struct ProductionTelemetry: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = "rpc.bloombox.cloud"
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = "rpc.bloombox.cloud"
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -177,9 +177,9 @@ internal struct ProductionTelemetry: RPCServiceSettings {
 /// Production media settings.
 internal struct ProductionMedia: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = "rpc.bloombox.cloud"
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = "rpc.bloombox.cloud"
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -188,9 +188,9 @@ internal struct ProductionMedia: RPCServiceSettings {
 /// Production menu settings.
 internal struct ProductionMenu: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = "rpc.bloombox.cloud"
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = "rpc.bloombox.cloud"
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -199,9 +199,9 @@ internal struct ProductionMenu: RPCServiceSettings {
 /// Production POS settings.
 internal struct ProductionPOS: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = "rpc.bloombox.cloud"
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = "rpc.bloombox.cloud"
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -210,9 +210,9 @@ internal struct ProductionPOS: RPCServiceSettings {
 /// Production auth settings.
 internal struct ProductionAuth: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = "rpc.bloombox.cloud"
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = "rpc.bloombox.cloud"
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -221,9 +221,9 @@ internal struct ProductionAuth: RPCServiceSettings {
 /// Production checkin settings.
 internal struct ProductionCheckin: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = "rpc.bloombox.cloud"
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = "rpc.bloombox.cloud"
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil
@@ -232,9 +232,9 @@ internal struct ProductionCheckin: RPCServiceSettings {
 /// Production platform API settings.
 internal struct ProductionPlatform: RPCServiceSettings {
   let secure = true
-  let host = "api.bloombox.cloud"
+  let host = "rpc.bloombox.cloud"
   let port = 443
-  let hostname: String? = "api.bloombox.cloud"
+  let hostname: String? = "rpc.bloombox.cloud"
   let chain: String? = authorityChain
   let cert: String? = nil
   let key: String? = nil


### PR DESCRIPTION
Switch over to the newer `rpc.bloombox.cloud` hostname for routing API calls.

Changes:
- [x] Switch to new endpoint
- [x] Version bump -> `0.2.0-beta3`