### PR TITLE
Feature: Swift 5 Support

### DIFF
--- a/Bloombox.podspec
+++ b/Bloombox.podspec
@@ -32,7 +32,7 @@ Native Swift client for accessing Bloombox Cloud APIs
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.dependency 'OpenCannabis', '= 0.5.0-beta1'
   s.dependency 'BloomboxServices', '= 0.5.0-beta1'
-  s.dependency 'SwiftProtobuf', '= 1.6.0'
+  s.dependency 'SwiftProtobuf', '~> 1.5.0'
   s.dependency 'SwiftGRPC', '= 0.9.1'
 
   # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/Bloombox.podspec
+++ b/Bloombox.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "Bloombox"
   s.swift_version = "5.0"
-  s.version       = "0.5.0-beta1"
+  s.version       = "0.5.0-beta2"
   s.summary       = "Client for Bloombox Cloud APIs"
   s.description   = <<-DESC
 Native Swift client for accessing Bloombox Cloud APIs
@@ -30,8 +30,8 @@ Native Swift client for accessing Bloombox Cloud APIs
   s.source_files = 'Sources/Client/*.swift'
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.dependency 'OpenCannabis', '= 0.5.0-beta1'
-  s.dependency 'BloomboxServices', '= 0.5.0-beta1'
+  s.dependency 'OpenCannabis', '= 0.5.0-beta2'
+  s.dependency 'BloomboxServices', '= 0.5.0-beta2'
   s.dependency 'SwiftProtobuf', '~> 1.5.0'
   s.dependency 'SwiftGRPC', '= 0.9.1'
 

--- a/Bloombox.podspec
+++ b/Bloombox.podspec
@@ -3,8 +3,8 @@ Pod::Spec.new do |s|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "Bloombox"
-  s.swift_version = "4.2"
-  s.version       = "0.4.0-beta1"
+  s.swift_version = "5.0"
+  s.version       = "0.5.0-beta1"
   s.summary       = "Client for Bloombox Cloud APIs"
   s.description   = <<-DESC
 Native Swift client for accessing Bloombox Cloud APIs
@@ -30,10 +30,10 @@ Native Swift client for accessing Bloombox Cloud APIs
   s.source_files = 'Sources/Client/*.swift'
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.dependency 'OpenCannabis', '= 0.4.0-beta1'
-  s.dependency 'BloomboxServices', '= 0.4.0-beta1'
-  s.dependency 'SwiftProtobuf', '~> 1.5.0'
-  s.dependency 'SwiftGRPC', '~> 0.9.0'
+  s.dependency 'OpenCannabis', '= 0.5.0-beta1'
+  s.dependency 'BloomboxServices', '= 0.5.0-beta1'
+  s.dependency 'SwiftProtobuf', '= 1.6.0'
+  s.dependency 'SwiftGRPC', '= 0.9.1'
 
   # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.frameworks  = "CoreLocation", "CoreBluetooth"

--- a/BloomboxServices.podspec
+++ b/BloomboxServices.podspec
@@ -32,7 +32,7 @@ the Bloombox client library for Swift.
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.dependency 'OpenCannabis', '= 0.5.0-beta1'
-  s.dependency 'SwiftProtobuf', '= 1.6.0'
+  s.dependency 'SwiftProtobuf', '~> 1.5.0'
   s.dependency 'SwiftGRPC', '= 0.9.1'
 
   # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/BloomboxServices.podspec
+++ b/BloomboxServices.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "BloomboxServices"
   s.swift_version = "5.0"
-  s.version       = "0.5.0-beta1"
+  s.version       = "0.5.0-beta2"
   s.summary       = "Service definitions for Bloombox Cloud APIs"
   s.description   = <<-DESC
 Compiled low-level service definitions for Bloombox Cloud APIs. Usually usable with
@@ -31,7 +31,7 @@ the Bloombox client library for Swift.
   s.source_files = 'Sources/Services/*.swift'
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.dependency 'OpenCannabis', '= 0.5.0-beta1'
+  s.dependency 'OpenCannabis', '= 0.5.0-beta2'
   s.dependency 'SwiftProtobuf', '~> 1.5.0'
   s.dependency 'SwiftGRPC', '= 0.9.1'
 

--- a/BloomboxServices.podspec
+++ b/BloomboxServices.podspec
@@ -3,8 +3,8 @@ Pod::Spec.new do |s|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "BloomboxServices"
-  s.swift_version = "4.2"
-  s.version       = "0.4.0-beta1"
+  s.swift_version = "5.0"
+  s.version       = "0.5.0-beta1"
   s.summary       = "Service definitions for Bloombox Cloud APIs"
   s.description   = <<-DESC
 Compiled low-level service definitions for Bloombox Cloud APIs. Usually usable with
@@ -31,9 +31,9 @@ the Bloombox client library for Swift.
   s.source_files = 'Sources/Services/*.swift'
 
   # ――― Dependencies ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  s.dependency 'OpenCannabis', '= 0.4.0-beta4'
-  s.dependency 'SwiftProtobuf', '~> 1.5.0'
-  s.dependency 'SwiftGRPC', '~> 0.9.0'
+  s.dependency 'OpenCannabis', '= 0.5.0-beta1'
+  s.dependency 'SwiftProtobuf', '= 1.6.0'
+  s.dependency 'SwiftGRPC', '= 0.9.1'
 
   # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.libraries   = "z"

--- a/OpenCannabis.podspec
+++ b/OpenCannabis.podspec
@@ -3,8 +3,8 @@ Pod::Spec.new do |s|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "OpenCannabis"
-  s.swift_version = "4.2"
-  s.version       = "0.4.0-beta1"
+  s.swift_version = "5.0"
+  s.version       = "0.5.0-beta1"
   s.summary       = "OpenCannabis for Swift"
   s.description   = <<-DESC
 Native Swift codegen and bindings for OpenCannabis
@@ -33,7 +33,7 @@ Native Swift codegen and bindings for OpenCannabis
   s.source_files = 'Sources/Schema/*.swift'
 
   # --- Dependencies -----------------―――――――――――――――――――――――――――――――――――――――――――- #
-  s.dependency 'SwiftProtobuf', '~> 1.5.0'
+  s.dependency 'SwiftProtobuf', '= 1.6.0'
 
   # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.libraries   = "z"

--- a/OpenCannabis.podspec
+++ b/OpenCannabis.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name          = "OpenCannabis"
   s.swift_version = "5.0"
-  s.version       = "0.5.0-beta1"
+  s.version       = "0.5.0-beta2"
   s.summary       = "OpenCannabis for Swift"
   s.description   = <<-DESC
 Native Swift codegen and bindings for OpenCannabis
@@ -33,7 +33,7 @@ Native Swift codegen and bindings for OpenCannabis
   s.source_files = 'Sources/Schema/*.swift'
 
   # --- Dependencies -----------------―――――――――――――――――――――――――――――――――――――――――――- #
-  s.dependency 'SwiftProtobuf', '= 1.6.0'
+  s.dependency 'SwiftProtobuf', '~> 1.5.0'
 
   # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.libraries   = "z"


### PR DESCRIPTION
This changeset introduces client library version `0.5.0-beta1`, which is the first release to support Swift 5 tooling.

Changes so far:
- [x] Update Swift version in Podspecs
- [x] Update Swift Protobuf/gRPC (we will see if this works)